### PR TITLE
Description of gitflow branches

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,6 +11,17 @@ It's supported by https://fmi-standard.org/tools/[100+] tools and maintained as 
 - `headers` -- C header files
 - `schema` -- the XSD schema for the modelDescription.xml
 
+== Workflow and Branching
+
+We follow the gitflow workflow, see, e.g., https://datasift.github.io/gitflow/IntroducingGitFlow.html
+
+For the current work on the next planned releases of the FMI standard we use
+
+- https://github.com/modelica/fmi-standard[master] only for released versions, i.e., currently for FMI 2.0
+- https://github.com/modelica/fmi-standard/tree/release/2.0.1[release/2.0.1] for bugfixes, maintenance of the FMI 2.0 standard (no new features)
+- https://github.com/modelica/fmi-standard/tree/develop[develop] for the development of the FMI 3.0 standard, used for merging features
+- `feature/XXX` for the development of a new feature (when starting, branch for develop)
+
 == Building the specification document
 
 The FMI specification is written in http://asciidoc.org/[AsciiDoc], a plain-text mark-up format that can be converted to HTML, DocBook, PDF and other formats. To build the documentation locally


### PR DESCRIPTION
Open question: Shall we directly commit to `master` when fixing typos in the conversion from the release PDF version to the Asciidoc version for the standard or use a separate branch for that? 
I propose to directly commit to  master in that exceptional case.