### PR TITLE
Fix #432: Definition of Model Variables (ModelVariables)

### DIFF
--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -877,7 +877,7 @@ there is no mechanism in the Modelica language to formulate connection restricti
 
 - if `causality = "input"` _[in order to provide new values for inputs]_,
 
-*fmi2SetXXX* can be called on any variable *for ModelExchange* *at an event instant* (after calling `fmi2EnterEventMode` and before `fmi2ExitEventMode` is called),
+*fmi2SetXXX* can be called on any variable *for ModelExchange* *at an event instant* (after calling `fmi2EnterEventMode` and before `fmi2EnterContinuousTimeMode` is called),
 and *for Co-Simulation at every communication point*,
 
 - if `causality = "parameter"` and `variability = "tunable"` _[in order to change the value of the tunable parameter at an event instant or at a communication point]_, or


### PR DESCRIPTION
Change "fmi2ExitEventMode" to "fmi2EnterContinuousTimeMode"