### PR TITLE
Regularize state name and function name syntax

### DIFF
--- a/docs/0___preamble.adoc
+++ b/docs/0___preamble.adoc
@@ -186,4 +186,4 @@ used to define the sparseness structure of partial derivative matrices).
 ** In the implementation view, one-dimensional C arrays are used.
 In order to access an array element the C convention is used.
 For example,
-the first element of input argument `x` for function `setContinuousStates(..)` is `x[0]`.
+the first element of input argument `x` for function `setContinuousStates` is `x[0]`.

--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -164,7 +164,7 @@ An `fmi3ValueReference` references one such scalar.
 The coding of `fmi3ValueReference` is a "secret" of the environment that generated the FMU.
 The interface to the equations only provides access to variables via this handle.
 Extracting concrete information about a variable is specific to the used environment that reads the Model Description File in which the value handles are defined.
-If a function in the following sections is called with a wrong `fmi3ValueReference` value _[for example, setting a constant with a `fmi3SetReal(..)` function call]_, then the function has to return with an error ( `fmi3Status = fmi3Error`, see section 2.1.3).
+If a function in the following sections is called with a wrong `fmi3ValueReference` value _[for example, setting a constant with a `fmi3SetReal` function call]_, then the function has to return with an error ( `fmi3Status = fmi3Error`, see section 2.1.3).
 
 [source, C]
 ----
@@ -371,11 +371,11 @@ typedef struct {
 ----
 
 The struct contains pointers to functions provided by the environment to be used by the FMU.
-It is not allowed to change these functions between `fmi3Instantiate(..)` and `fmi3Terminate(..)` calls.
+It is not allowed to change these functions between `fmi3Instantiate` and `fmi3Terminate` calls.
 Additionally, a pointer to the environment is provided (componentEnvironment) that needs to be passed to all of the callback functions, in order that those functions can utilize data from the environment, such as mapping a `valueReference` to a string, or assigning memory to a certain FMU instance.
 In the unlikely case that `fmi3Component` is also needed in those functions, it has to be passed via argument `componentEnvironment`. Argument `componentEnvironment` may be a null pointer.
 
-The `componentEnvironment` pointer is also passed to the `stepFinished(..)` function in order that the environment can provide an efficient way to identify the slave that called `stepFinished(..)`.
+The `componentEnvironment` pointer is also passed to the `stepFinished` function in order that the environment can provide an efficient way to identify the slave that called `stepFinished`.
 
 In the default `fmi3FunctionTypes.h` file, typedefs for the function definitions are present to simplify the usage; this is non-normative.
 The functions have the following meaning:
@@ -421,7 +421,7 @@ If attribute `canNotUseMemoryManagementFunctions = "true"` in `<fmiModelDescript
 Function `stepFinished`::
 Optional call back function to signal if the computation of a communication step of a co- simulation slave is finished.
 A null pointer can be provided.
-In this case the master must use `fmi3GetStatus(..)` to query the status of `fmi3DoStep`.
+In this case the master must use `fmi3GetStatus` to query the status of `fmi3DoStep`.
 If a pointer to a function is provided, it must be called by the FMU after a completed communication step.
 
 [source, C]
@@ -502,7 +502,7 @@ fmi3Status fmi3Terminate(fmi3Component c);
 
 Informs the FMU that the simulation run is terminated.
 After calling this function,
-the final values of all variables can be inquired with the `fmi3GetXXX(..)` functions.
+the final values of all variables can be inquired with the `fmi3GetXXX` functions.
 It is not allowed to call this function after one of the functions returned with a status flag of `fmi3Error` or `fmi3Fatal`.
 
 [source, C]

--- a/docs/3_1_model_exchange_math.adoc
+++ b/docs/3_1_model_exchange_math.adoc
@@ -465,12 +465,12 @@ In order to determine a state event, the event indicators *z* have to be inquire
 Once the event indicators signal a change of their domain, an iteration over time is performed between the previous and the actual completed integrator step, in order to determine the time instant of the domain change up to a certain precision. +
 After an event is triggered, the FMU needs to be switched to Event Mode.
 In this mode, systems of equations over connected FMUs might be solved (similarily as in Continuous-Time Mode).
-Once convergence is reached, `fmi3NewDiscreteStates(..)` must be called to increment super dense time (and conceptually update the discrete-time states defined internally in the FMU by latexmath:[^{\bullet}\mathbf{x}_d := \mathbf{x}_d]).
+Once convergence is reached, `fmi3NewDiscreteStates` must be called to increment super dense time (and conceptually update the discrete-time states defined internally in the FMU by latexmath:[^{\bullet}\mathbf{x}_d := \mathbf{x}_d]).
 Depending on the discrete-time model, a new event iteration might be needed (for example, because the FMU describes internally a state machine
 and transitions are still able to fire, but new inputs shall be taken into account). +
 The function calls in the table above describe precisely which input arguments are needed to compute the desired output argument(s).
 There is no 1:1 mapping of these mathematical functions to C functions.
-Instead, all input arguments are set with `fmi3SetXXX(..)` C function calls, and then the result argument(s) can be determined with the C functions defined in the right column of the above table.
+Instead, all input arguments are set with `fmi3SetXXX` C function calls, and then the result argument(s) can be determined with the C functions defined in the right column of the above table.
 This technique is discussed in detail in section 3.2.1.
 _[In short:
 For efficiency reasons, all equations from the table above will usually be available in [underline]#one# (internal) C function.

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -58,7 +58,7 @@ to set the input arguments to the current model evaluation.
 fmi3Status fmi3EnterEventMode(fmi3Component c);
 ----
 
-The model enters Event Mode from the Continuous-Time Mode and discrete-time equations may become active (and relations are not "frozen").
+The model enters *Event Mode* from the *Continuous-Time Mode* and discrete-time equations may become active (and relations are not "frozen").
 
 [source, C]
 ----
@@ -74,7 +74,7 @@ typedef struct{
 } fmi3EventInfo;
 ----
 
-The FMU is in Event Mode and the super dense time is incremented by this call. +
+The FMU is in *Event Mode* and the super dense time is incremented by this call. +
 If the super dense time before a call to `fmi3NewDiscreteStates` was latexmath:[(t_R,t_I)], then the time instant after the call is latexmath:[(t_R,t_I)]. +
 If return argument `pass:[fmi3eventInfo->newDiscreteStatesNeeded]` = `fmi3True`, the FMU should stay in Event Mode, and the FMU requires to set new inputs to the FMU (`fmi3SetXXX` on inputs) to compute and get the outputs (`fmi3GetXXX` on outputs) and to call `fmi3NewDiscreteStates` again.
 Depending on the connection with other FMUs, the environment shall
@@ -83,7 +83,7 @@ Depending on the connection with other FMUs, the environment shall
 
 - call `fmi3EnterContinuousTimeMode` if all FMUs return `newDiscreteStatesNeeded` = `fmi3False`, and
 
-- stay in Event Mode otherwise.
+- stay in *Event Mode* otherwise.
 
 When the FMU is terminated, it is assumed that an appropriate message is printed by the logger function (see section 2.1.5) to explain the reason for the termination. +
 If `nominalsOfContinuousStatesChanged = fmi3True`, then the nominal values of the states have changed due to the function call and can be inquired with `fmi3GetNominalsOfContinuousStates`. +
@@ -92,15 +92,15 @@ The new values of the states can be inquired with `fmi3GetContinuousStates`.
 If no element of the continuous state vector has changed its value, `valuesOfContinuousStatesChanged` must return `fmi3False`.
 _[If `fmi3True` would be returned in this case, an infinite event loop may occur.]_ +
 If `nextEventTimeDefined = fmi3True`, then the simulation shall integrate at most until `time = nextEventTime`, and shall call `fmi3EnterEventMode` at this time instant.
-If integration is stopped before nextEventTime, for example, due to a state event, the definition of `nextEventTime` becomes obsolete.
+If integration is stopped before `nextEventTime`, for example, due to a state event, the definition of `nextEventTime` becomes obsolete.
 
 [source, C]
 ----
 fmi3Status fmi3EnterContinuousTimeMode(fmi3Component c);
 ----
 
-The model enters Continuous-Time Mode and all discrete-time equations become inactive and all relations are "frozen". +
-This function has to be called when changing from Event Mode (after the global event iteration in Event Mode over all involved FMUs and other models has converged) into Continuous-Time Mode. +
+The model enters *Continuous-Time Mode* and all discrete-time equations become inactive and all relations are "frozen". +
+This function has to be called when changing from *Event Mode* (after the global event iteration in *Event Mode* over all involved FMUs and other models has converged) into *Continuous-Time Mode*. +
 
 _[This function might be used for the following purposes:_
 
@@ -116,12 +116,12 @@ fmi3Status fmi3CompletedIntegratorStep(fmi3Component c,
                                  fmi3Boolean* terminateSimulation);
 ----
 
-This function must be called by the environment after every completed step of the integrator provided the capability flag completedIntegratorStepNotNeeded = false.
-Argument noSetFMUStatePriorToCurrentPoint is `fmi3True` if `fmi3SetFMUState` will no longer be called for time instants prior to current time in this simulation run [the FMU can use this flag to flush a result buffer]. +
-The function returns enterEventMode to signal to the environment if the FMU shall call `fmi3EnterEventMode`, and it returns terminateSimulation to signal if the simulation shall be terminated.
-If `enterEventMode` = `fmi3False` and `terminateSimulation` = `fmi3False` the FMU stays in Continuous-Time Mode without calling `fmi3EnterContinuousTimeMode` again.
+This function must be called by the environment after every completed step of the integrator provided the capability flag `completedIntegratorStepNotNeeded = false`.
+Argument `noSetFMUStatePriorToCurrentPoint` is `fmi3True` if `fmi3SetFMUState` will no longer be called for time instants prior to current time in this simulation run [the FMU can use this flag to flush a result buffer]. +
+The function returns `enterEventMode` to signal to the environment if the FMU shall call `fmi3EnterEventMode`, and it returns `terminateSimulation` to signal if the simulation shall be terminated.
+If `enterEventMode` = `fmi3False` and `terminateSimulation` = `fmi3False` the FMU stays in *Continuous-Time Mode* without calling `fmi3EnterContinuousTimeMode` again.
 When the integrator step is completed and the states are [underline]#modified# by the integrator [underline]#afterwards# (for example, correction by a BDF method),
-then `fmi3SetContinuousStates(..)` has to be called with the updated states [underline]#before# `fmi3CompletedIntegratorStep(..)` is called. +
+then `fmi3SetContinuousStates` has to be called with the updated states [underline]#before# `fmi3CompletedIntegratorStep` is called. +
 When the integrator step is completed and one or more event indicators change sign (with respect to the previously completed integrator step),
 then the integrator or the environment has to determine the time instant of the sign change that is closest to the previous completed step up to a certain precision (usually a small multiple of the machine epsilon).
 This is usually performed by an iteration where time is varied and state variables needed during the iteration are determined by interpolation.
@@ -138,11 +138,11 @@ _All variables that are used in a "delay(..)" operator are stored in an appropri
 . _Dynamic state selection: +
 It is checked whether the dynamically selected states are still numerically appropriate.
 If yes, the function returns with `enterEventMode` = `fmi3False`  otherwise with `enterEventMode` = `fmi3True`._
-_In the latter case, `fmi3EnterEventMode(..)` has to be called and the states are dynamically changed by a subsequent `fmi3NewDiscreteStates(..)`._
+_In the latter case, `fmi3EnterEventMode` has to be called and the states are dynamically changed by a subsequent `fmi3NewDiscreteStates`._
 
-_Note that this function is not used to detect time or state events, for example, by comparing event indicators of the previous with the current call of `fmi3CompletedIntegratorStep(..)`.
-These types of events are detected in the environment, and the environment has to call `fmi3EnterEventMode(..)` independently in these cases,
-whether the return argument `enterEventMode` of `fmi3CompletedIntegratorStep(..)` is `fmi3True` or `fmi3False`.]_
+_Note that this function is not used to detect time or state events, for example, by comparing event indicators of the previous with the current call of `fmi3CompletedIntegratorStep`.
+These types of events are detected in the environment, and the environment has to call `fmi3EnterEventMode` independently in these cases,
+whether the return argument `enterEventMode` of `fmi3CompletedIntegratorStep` is `fmi3True` or `fmi3False`.]_
 
 [source, C]
 ----
@@ -193,7 +193,7 @@ image::images/CallingSequenceME.png[width=100%]
 
 The objective of the start chart is to define the allowed calling sequences for functions of the FMI: Calling sequences not accepted by the state chart are not supported by the FMI.
 The behavior of an FMU is undefined for such a calling sequence.
-For example, the state chart indicates that when an FMU for Model Exchange is in state "Continuous-Time Mode", a call to `fmi3SetReal` for a discrete input is not supported.
+For example, the state chart indicates that when an FMU for Model Exchange is in state *Continuous-Time Mode*, a call to `fmi3SetReal` for a discrete input is not supported.
 The state chart is given here as UML 2.0 state machine.
 If a transition is labelled with one or more function names (for example, `fmi3GetReal`, `fmi3GetInteger`), this means that the transition is taken if any of these functions is successfully called.
 Note that the FMU can always determine in which state it is since every state is entered by a particular function call (such as `fmi3EnterEventMode`), or a particular return value (such as `fmi3Fatal`).
@@ -214,10 +214,10 @@ In this state, the continuous-time model equations are active and integrator ste
 The event time of a state event may be determined if a domain change of at least one event indicator is detected at the end of a completed integrator step.
 
 Event Mode::
-If an event is triggered in Continuous-Time Mode, then Event Mode is entered by calling `fmi3EnterEventMode`.
+If an event is triggered in *Continuous-Time Mode*, then *Event Mode* is entered by calling `fmi3EnterEventMode`.
 In this mode all continuous-time and discrete-time equations are active and the unknowns at an event can be computed and retrieved.
-After an event is completely processed, `fmi3NewDiscreteStates` must be called and depending on the return argument, `newDiscreteStatesNeeded`, the state chart stays in Event Mode or switches to Continuous-Time Mode.
-When the Initialization Mode is terminated with `fmi3ExitInitializationMode`, then Event Mode is directly entered, and the continuous-time and discrete-time variables at the initial time are computed based on the initial continuous-time states determined in the Initialization Mode.
+After an event is completely processed, `fmi3NewDiscreteStates` must be called and depending on the return argument, `newDiscreteStatesNeeded`, the state chart stays in *Event Mode* or switches to *Continuous-Time Mode*.
+When the *Initialization Mode* is terminated with `fmi3ExitInitializationMode`, then *Event Mode* is directly entered, and the continuous-time and discrete-time variables at the initial time are computed based on the initial continuous-time states determined in the *Initialization Mode*.
 
 terminated::
 In this state, the solution at the final time of a simulation can be retrieved.
@@ -225,7 +225,7 @@ In this state, the solution at the final time of a simulation can be retrieved.
 Note that simulation backward in time is only allowed over continuous time intervals.
 As soon as an event occurred (`fmi3EnterEventMode` was called), going back in time is forbidden, because `fmi3EnterEventMode` / `fmi3NewDiscreteStates` can only compute the next discrete state, not the previous one.
 
-Note that during Initialization, Event, and Continuous-Time Mode input variables can be set with `fmi3SetXXX` and output variables can be retrieved with `fmi3GetXXX` interchangeably according to the model structure defined under element `<ModelStructure>` in the XML file.
+Note that during *Initialization*, *Event*, and *Continuous-Time Mode* input variables can be set with `fmi3SetXXX` and output variables can be retrieved with `fmi3GetXXX` interchangeably according to the model structure defined under element `<ModelStructure>` in the XML file.
 _[For example, if one output `y1` depends on two inputs `u1`, `u2`, then these two inputs must be set, before `y1` can be retrieved.
 If additionally an output `y2` depends on an input `u3`, then `u3` can be set and `y2` can be retrieved afterwards.
 As a result, artificial or "real" algebraic loops over connected FMUs in any of these three modes can be handled by using appropriate numerical algorithms.]_

--- a/docs/3_3_model_exchange_schema.adoc
+++ b/docs/3_3_model_exchange_schema.adoc
@@ -52,7 +52,7 @@ That is, functions `fmi3GetFMUstate`, `fmi3SetFMUstate`, and `fmi3FreeFMUstate` 
 If this is the case, then flag `canGetAndSetFMUstate` must be true as well.
 
 |`providesDirectionalDerivative`
-|If `true`, the directional derivative of the equations can be computed with `fmi3GetDirectionalDerivative(..)`
+|If `true`, the directional derivative of the equations can be computed with `fmi3GetDirectionalDerivative`
 |====
 
 The flags have the following default values.

--- a/docs/4_2_co-simulation_api.adoc
+++ b/docs/4_2_co-simulation_api.adoc
@@ -191,17 +191,17 @@ The variables that can be retrieved by `fmi3GetXXX` calls are (1) defined in the
 Variables with `initial` = `"exact"`, as well as variables with `variability` = `"input"` can be set.
 
 slaveInitialized::
-In this state, the slave is initialized and the co-simulation computation is performed. The calculation until the next communication point is performed with function `fmi3DoStep`. Depending on the return value, the slave is in a different state (step complete, step failed, step canceled).
+In this state, the slave is initialized and the co-simulation computation is performed. The calculation until the next communication point is performed with function `fmi3DoStep`. Depending on the return value, the slave is in a different state (*step Complete*, *step Failed*, *step Canceled*).
 
 terminated::
 In this state, the solution at the final time of the simulation can be retrieved.
 
-Note that in Initialization Mode input variables can be set with `fmi3SetXXX` and output variables can be retrieved with `fmi3GetXXX` interchangeably according to the model structure defined under element `<ModelStructure><InitialUnknowns>` in the XML file.
+Note that in *Initialization Mode* input variables can be set with `fmi3SetXXX` and output variables can be retrieved with `fmi3GetXXX` interchangeably according to the model structure defined under element `<ModelStructure><InitialUnknowns>` in the XML file.
 _[For example, if one output `y1` depends on two inputs `u1`, `u2`, then these two inputs must be set, before `y1` can be retrieved.
 If additionally an output `y2` depends on an input `u3`, then `u3` can be set and `y2` can be retrieved afterwards.
-As a result, artificial or "real" algebraic loops over connected FMUs in Initialization Mode can be handled by using appropriate numerical algorithms.]_
+As a result, artificial or "real" algebraic loops over connected FMUs in *Initialization Mode* can be handled by using appropriate numerical algorithms.]_
 
-There is the additional restriction in `slaveInitialized` state that it is not allowed to call `fmi3GetXXX` functions after `fmi3SetXXX` functions without an `fmi3DoStep` call in between.
+There is the additional restriction in *slaveInitialized* state that it is not allowed to call `fmi3GetXXX` functions after `fmi3SetXXX` functions without an `fmi3DoStep` call in between.
 
 _[The reason is to avoid different interpretations of the caching, since contrary to FMI for Model Exchange, `fmi3DoStep` will perform the actual calculation instead of `fmi3GetXXX`, and therefore, dummy algebraic loops at communication points cannot be handeled by an appropriate sequence of `fmi3GetXXX` and, `fmi3SetXXX` calls as for ModelExchange.
 


### PR DESCRIPTION
States are now referenced in bold face everywhere, and function names
are referenced without '(..)' added to some of the reference.