### PR TITLE
Fix #461 clarify valid calls after canceled step

### DIFF
--- a/docs/4_2_co-simulation_api.adoc
+++ b/docs/4_2_co-simulation_api.adoc
@@ -106,8 +106,9 @@ fmi3Status fmi3CancelStep(fmi3Component c);
 
 Can be called if `fmi3DoStep` returned `fmi3Pending` in order to stop the current asynchronous execution.
 The master calls this function if, for example, the co-simulation run is stopped by the user or one of the slaves.
-Afterwards it is only allowed to call `fmi3Reset` or `fmi3FreeInstance`.
-
+Afterwards only calls to `fmi3Reset`, `fmi3FreeInstance`, or `fmi3SetFMUstate` are valid to exit the *step Canceled* state.
+Refer to section 4.2.4 for all other valid functions in this state.
+ 
 It depends on the capabilities of the slave which parameter constellations and calling sequences are allowed (see 4.3.1)
 
 ==== Retrieving Status Information from the Slave


### PR DESCRIPTION
Port clarification from 2.0.1 (see #460 and #426).