### PR TITLE
Add new numeric variable types to C API

### DIFF
--- a/headers/fmi3FunctionTypes.h
+++ b/headers/fmi3FunctionTypes.h
@@ -126,12 +126,12 @@ typedef struct {
 
 /* tag::EventInfo[] */
 typedef struct {
-    fmi3Boolean newDiscreteStatesNeeded;
-    fmi3Boolean terminateSimulation;
-    fmi3Boolean nominalsOfContinuousStatesChanged;
-    fmi3Boolean valuesOfContinuousStatesChanged;
-    fmi3Boolean nextEventTimeDefined;
-    fmi3Real    nextEventTime;  /* next event if nextEventTimeDefined=fmi3True */
+    fmi3Bool    newDiscreteStatesNeeded;
+    fmi3Bool    terminateSimulation;
+    fmi3Bool    nominalsOfContinuousStatesChanged;
+    fmi3Bool    valuesOfContinuousStatesChanged;
+    fmi3Bool    nextEventTimeDefined;
+    fmi3Double  nextEventTime;  /* next event if nextEventTimeDefined=fmi3True */
 } fmi3EventInfo;
 /* end::EventInfo[] */
 
@@ -157,7 +157,7 @@ typedef const char* fmi3GetVersionTYPE(void);
 
 /* tag::SetDebugLogging[] */
 typedef fmi3Status  fmi3SetDebugLoggingTYPE(fmi3Component c,
-                                            fmi3Boolean loggingOn,
+                                            fmi3Bool loggingOn,
                                             size_t nCategories,
                                             const fmi3String categories[]);
 /* end::SetDebugLogging[] */
@@ -169,8 +169,8 @@ typedef fmi3Component fmi3InstantiateTYPE(fmi3String  instanceName,
                                           fmi3String  fmuGUID,
                                           fmi3String  fmuResourceLocation,
                                           const fmi3CallbackFunctions* functions,
-                                          fmi3Boolean visible,
-                                          fmi3Boolean loggingOn);
+                                          fmi3Bool visible,
+                                          fmi3Bool loggingOn);
 /* end::Instantiate[] */
 
 /* tag::FreeInstance[] */
@@ -180,11 +180,11 @@ typedef void fmi3FreeInstanceTYPE(fmi3Component c);
 /* Enter and exit initialization mode, terminate and reset */
 /* tag::SetupExperiment[] */
 typedef fmi3Status fmi3SetupExperimentTYPE(fmi3Component c,
-                                           fmi3Boolean toleranceDefined,
-                                           fmi3Real tolerance,
-                                           fmi3Real startTime,
-                                           fmi3Boolean stopTimeDefined,
-                                           fmi3Real stopTime);
+                                           fmi3Bool toleranceDefined,
+                                           fmi3Double tolerance,
+                                           fmi3Double startTime,
+                                           fmi3Bool stopTimeDefined,
+                                           fmi3Double stopTime);
 /* end::SetupExperiment[] */
 
 /* tag::EnterInitializationMode[] */
@@ -205,47 +205,111 @@ typedef fmi3Status fmi3ResetTYPE(fmi3Component c);
 
 /* Getting and setting variable values */
 /* tag::Getters[] */
-typedef fmi3Status fmi3GetRealTYPE   (fmi3Component c,
-                                      const fmi3ValueReference vr[], size_t nvr,
-                                      fmi3Real value[], size_t nValues);
+typedef fmi3Status fmi3GetFloatTYPE (fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     fmi3Float value[], size_t nValues);
 
-typedef fmi3Status fmi3GetIntegerTYPE(fmi3Component c,
-                                      const fmi3ValueReference vr[], size_t nvr,
-                                      fmi3Integer value[], size_t nValues);
+typedef fmi3Status fmi3GetDoubleTYPE(fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     fmi3Double value[], size_t nValues);
 
-typedef fmi3Status fmi3GetBooleanTYPE(fmi3Component c,
-                                      const fmi3ValueReference vr[], size_t nvr,
-                                      fmi3Boolean value[], size_t nValues);
+typedef fmi3Status fmi3GetInt8TYPE  (fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     fmi3Int8 value[], size_t nValues);
 
-typedef fmi3Status fmi3GetStringTYPE (fmi3Component c,
-                                      const fmi3ValueReference vr[], size_t nvr,
-                                      fmi3String value[], size_t nValues);
+typedef fmi3Status fmi3GetUInt8TYPE (fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     fmi3UInt8 value[], size_t nValues);
 
-typedef fmi3Status fmi3GetBinaryTYPE (fmi3Component c,
-                                      const fmi3ValueReference vr[], size_t nvr,
-                                      size_t size[], fmi3Binary value[], size_t nValues);
+typedef fmi3Status fmi3GetInt16TYPE (fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     fmi3Int16 value[], size_t nValues);
+
+typedef fmi3Status fmi3GetUInt16TYPE(fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     fmi3UInt16 value[], size_t nValues);
+
+typedef fmi3Status fmi3GetInt32TYPE (fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     fmi3Int32 value[], size_t nValues);
+
+typedef fmi3Status fmi3GetUInt32TYPE(fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     fmi3UInt32 value[], size_t nValues);
+
+typedef fmi3Status fmi3GetInt64TYPE (fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     fmi3Int64 value[], size_t nValues);
+
+typedef fmi3Status fmi3GetUInt64TYPE(fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     fmi3UInt64 value[], size_t nValues);
+
+typedef fmi3Status fmi3GetBoolTYPE  (fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     fmi3Bool value[], size_t nValues);
+
+typedef fmi3Status fmi3GetStringTYPE(fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     fmi3String value[], size_t nValues);
+
+typedef fmi3Status fmi3GetBinaryTYPE(fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     size_t size[], fmi3Binary value[], size_t nValues);
 /* end::Getters[] */
 
 /* tag::Setters[] */
-typedef fmi3Status fmi3SetRealTYPE   (fmi3Component c,
-                                      const fmi3ValueReference vr[], size_t nvr,
-                                      const fmi3Real value[], size_t nValues);
+typedef fmi3Status fmi3SetFloatTYPE (fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     const fmi3Float value[], size_t nValues);
 
-typedef fmi3Status fmi3SetIntegerTYPE(fmi3Component c,
-                                      const fmi3ValueReference vr[], size_t nvr,
-                                      const fmi3Integer value[], size_t nValues);
+typedef fmi3Status fmi3SetDoubleTYPE(fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     const fmi3Double value[], size_t nValues);
 
-typedef fmi3Status fmi3SetBooleanTYPE(fmi3Component c,
-                                      const fmi3ValueReference vr[], size_t nvr,
-                                      const fmi3Boolean value[], size_t nValues);
+typedef fmi3Status fmi3SetInt8TYPE  (fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     const fmi3Int8 value[], size_t nValues);
 
-typedef fmi3Status fmi3SetStringTYPE (fmi3Component c,
-                                      const fmi3ValueReference vr[], size_t nvr,
-                                      const fmi3String value[], size_t nValues);
+typedef fmi3Status fmi3SetUInt8TYPE (fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     const fmi3UInt8 value[], size_t nValues);
 
-typedef fmi3Status fmi3SetBinaryTYPE (fmi3Component c,
-                                      const fmi3ValueReference vr[], size_t nvr,
-                                      const size_t size[], const fmi3Binary value[], size_t nValues);
+typedef fmi3Status fmi3SetInt16TYPE (fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     const fmi3Int16 value[], size_t nValues);
+
+typedef fmi3Status fmi3SetUInt16TYPE(fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     const fmi3UInt16 value[], size_t nValues);
+
+typedef fmi3Status fmi3SetInt32TYPE (fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     const fmi3Int32 value[], size_t nValues);
+
+typedef fmi3Status fmi3SetUInt32TYPE(fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     const fmi3UInt32 value[], size_t nValues);
+
+typedef fmi3Status fmi3SetInt64TYPE (fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     const fmi3Int64 value[], size_t nValues);
+
+typedef fmi3Status fmi3SetUInt64TYPE(fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     const fmi3UInt64 value[], size_t nValues);
+
+typedef fmi3Status fmi3SetBoolTYPE  (fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     const fmi3Bool value[], size_t nValues);
+
+typedef fmi3Status fmi3SetStringTYPE(fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     const fmi3String value[], size_t nValues);
+
+typedef fmi3Status fmi3SetBinaryTYPE(fmi3Component c,
+                                     const fmi3ValueReference vr[], size_t nvr,
+                                     const size_t size[], const fmi3Binary value[], size_t nValues);
 /* end::Setters[] */
 
 /* Getting Variable Dependency Information */
@@ -298,9 +362,9 @@ typedef fmi3Status fmi3GetDirectionalDerivativeTYPE(fmi3Component c,
                                                     size_t nUnknown,
                                                     const fmi3ValueReference vrKnown[],
                                                     size_t nKnown,
-                                                    const fmi3Real dvKnown[],
+                                                    const fmi3Double dvKnown[],
                                                     size_t nDvKnown,
-                                                    fmi3Real dvUnknown[],
+                                                    fmi3Double dvUnknown[],
                                                     size_t nDvUnknown);
 /* end::GetDirectionalDerivative[] */
 
@@ -325,20 +389,20 @@ typedef fmi3Status fmi3EnterContinuousTimeModeTYPE(fmi3Component c);
 
 /* tag::CompletedIntegratorStep[] */
 typedef fmi3Status fmi3CompletedIntegratorStepTYPE(fmi3Component c,
-                                                   fmi3Boolean noSetFMUStatePriorToCurrentPoint,
-						   fmi3Boolean* enterEventMode,
-                                                   fmi3Boolean* terminateSimulation);
+                                                   fmi3Bool noSetFMUStatePriorToCurrentPoint,
+                                                   fmi3Bool* enterEventMode,
+                                                   fmi3Bool* terminateSimulation);
 /* end::CompletedIntegratorStep[] */
 
 /* Providing independent variables and re-initialization of caching */
 
 /* tag::SetTime[] */
-typedef fmi3Status fmi3SetTimeTYPE(fmi3Component c, fmi3Real time);
+typedef fmi3Status fmi3SetTimeTYPE(fmi3Component c, fmi3Double time);
 /* end::SetTime[] */
 
 /* tag::SetContinuousStates[] */
 typedef fmi3Status fmi3SetContinuousStatesTYPE(fmi3Component c,
-                                               const fmi3Real x[],
+                                               const fmi3Double x[],
                                                size_t nx);
 /* end::SetContinuousStates[] */
 
@@ -346,23 +410,23 @@ typedef fmi3Status fmi3SetContinuousStatesTYPE(fmi3Component c,
 
 /* tag::GetDerivatives[] */
 typedef fmi3Status fmi3GetDerivativesTYPE(fmi3Component c,
-                                          fmi3Real derivatives[],
+                                          fmi3Double derivatives[],
                                           size_t nx);
 /* end::GetDerivatives[] */
 
 /* tag::GetEventIndicators[] */
 typedef fmi3Status fmi3GetEventIndicatorsTYPE(fmi3Component c,
-                                              fmi3Real eventIndicators[],
+                                              fmi3Double eventIndicators[],
                                               size_t ni);
 /* end::GetEventIndicators[] */
 
 /* tag::GetContinuousStates[] */
-typedef fmi3Status fmi3GetContinuousStatesTYPE(fmi3Component c, fmi3Real x[], size_t nx);
+typedef fmi3Status fmi3GetContinuousStatesTYPE(fmi3Component c, fmi3Double x[], size_t nx);
 /* end::GetContinuousStates[] */
 
 /* tag::GetNominalsOfContinuousStates[] */
 typedef fmi3Status fmi3GetNominalsOfContinuousStatesTYPE(fmi3Component c,
-                                                         fmi3Real x_nominal[],
+                                                         fmi3Double x_nominal[],
                                                          size_t nx);
 /* end::GetNominalsOfContinuousStates[] */
 
@@ -380,29 +444,29 @@ Types for Functions for FMI3 for Co-Simulation
 
 /* Simulating the slave */
 
-/* tag::SetRealInputDerivatives[] */
-typedef fmi3Status fmi3SetRealInputDerivativesTYPE(fmi3Component c,
-                                                   const fmi3ValueReference vr[],
-                                                   size_t nvr,
-                                                   const fmi3Integer order[],
-                                                   const fmi3Real value[],
-                                                   size_t nValues);
-/* end::SetRealInputDerivatives[] */
+/* tag::SetInputDerivatives[] */
+typedef fmi3Status fmi3SetInputDerivativesTYPE(fmi3Component c,
+                                               const fmi3ValueReference vr[],
+                                               size_t nvr,
+                                               const fmi3Int32 order[],
+                                               const fmi3Double value[],
+                                               size_t nValues);
+/* end::SetInputDerivatives[] */
 
-/* tag::GetRealOutputDerivatives[] */
-typedef fmi3Status fmi3GetRealOutputDerivativesTYPE(fmi3Component c,
-                                                    const fmi3ValueReference vr[],
-                                                    size_t nvr,
-                                                    const fmi3Integer order[],
-                                                    fmi3Real value[],
-                                                    size_t nValues);
-/* end::GetRealOutputDerivatives[] */
+/* tag::GetOutputDerivatives[] */
+typedef fmi3Status fmi3GetOutputDerivativesTYPE(fmi3Component c,
+                                                const fmi3ValueReference vr[],
+                                                size_t nvr,
+                                                const fmi3Int32 order[],
+                                                fmi3Double value[],
+                                                size_t nValues);
+/* end::GetOutputDerivatives[] */
 
 /* tag::DoStep[] */
 typedef fmi3Status fmi3DoStepTYPE(fmi3Component c,
-                                  fmi3Real currentCommunicationPoint,
-                                  fmi3Real communicationStepSize,
-                                  fmi3Boolean noSetFMUStatePriorToCurrentPoint);
+                                  fmi3Double currentCommunicationPoint,
+                                  fmi3Double communicationStepSize,
+                                  fmi3Bool noSetFMUStatePriorToCurrentPoint);
 /* end::DoStep[] */
 
 /* tag::CancelStep[] */
@@ -416,17 +480,17 @@ typedef fmi3Status fmi3GetStatusTYPE       (fmi3Component c,
                                             const fmi3StatusKind s,
                                             fmi3Status* value);
 
-typedef fmi3Status fmi3GetRealStatusTYPE   (fmi3Component c,
+typedef fmi3Status fmi3GetDoubleStatusTYPE (fmi3Component c,
                                             const fmi3StatusKind s,
-                                            fmi3Real* value);
+                                            fmi3Double* value);
 
 typedef fmi3Status fmi3GetIntegerStatusTYPE(fmi3Component c,
                                             const fmi3StatusKind s,
-                                            fmi3Integer* value);
+                                            fmi3Int32* value);
 
-typedef fmi3Status fmi3GetBooleanStatusTYPE(fmi3Component c,
+typedef fmi3Status fmi3GetBoolStatusTYPE   (fmi3Component c,
                                             const fmi3StatusKind s,
-                                            fmi3Boolean* value);
+                                            fmi3Bool* value);
 
 typedef fmi3Status fmi3GetStringStatusTYPE (fmi3Component c,
                                             const fmi3StatusKind s,

--- a/headers/fmi3Functions.h
+++ b/headers/fmi3Functions.h
@@ -117,14 +117,30 @@ Common Functions
 #define fmi3ExitInitializationMode   fmi3FullName(fmi3ExitInitializationMode)
 #define fmi3Terminate                fmi3FullName(fmi3Terminate)
 #define fmi3Reset                    fmi3FullName(fmi3Reset)
-#define fmi3GetReal                  fmi3FullName(fmi3GetReal)
-#define fmi3GetInteger               fmi3FullName(fmi3GetInteger)
-#define fmi3GetBoolean               fmi3FullName(fmi3GetBoolean)
+#define fmi3GetFloat                 fmi3FullName(fmi3GetFloat)
+#define fmi3GetDouble                fmi3FullName(fmi3GetDouble)
+#define fmi3GetInt8                  fmi3FullName(fmi3GetInt8)
+#define fmi3GetUInt8                 fmi3FullName(fmi3GetUInt8)
+#define fmi3GetInt16                 fmi3FullName(fmi3GetInt16)
+#define fmi3GetUInt16                fmi3FullName(fmi3GetUInt16)
+#define fmi3GetInt32                 fmi3FullName(fmi3GetInt32)
+#define fmi3GetUInt32                fmi3FullName(fmi3GetUInt32)
+#define fmi3GetInt64                 fmi3FullName(fmi3GetInt64)
+#define fmi3GetUInt64                fmi3FullName(fmi3GetUInt64)
+#define fmi3GetBool                  fmi3FullName(fmi3GetBool)
 #define fmi3GetString                fmi3FullName(fmi3GetString)
 #define fmi3GetBinary                fmi3FullName(fmi3GetBinary)
-#define fmi3SetReal                  fmi3FullName(fmi3SetReal)
-#define fmi3SetInteger               fmi3FullName(fmi3SetInteger)
-#define fmi3SetBoolean               fmi3FullName(fmi3SetBoolean)
+#define fmi3SetFloat                 fmi3FullName(fmi3SetFloat)
+#define fmi3SetDouble                fmi3FullName(fmi3SetDouble)
+#define fmi3SetInt8                  fmi3FullName(fmi3SetInt8)
+#define fmi3SetUInt8                 fmi3FullName(fmi3SetUInt8)
+#define fmi3SetInt16                 fmi3FullName(fmi3SetInt16)
+#define fmi3SetUInt16                fmi3FullName(fmi3SetUInt16)
+#define fmi3SetInt32                 fmi3FullName(fmi3SetInt32)
+#define fmi3SetUInt32                fmi3FullName(fmi3SetUInt32)
+#define fmi3SetInt64                 fmi3FullName(fmi3SetInt64)
+#define fmi3SetUInt64                fmi3FullName(fmi3SetUInt64)
+#define fmi3SetBool                  fmi3FullName(fmi3SetBool)
 #define fmi3SetString                fmi3FullName(fmi3SetString)
 #define fmi3SetBinary                fmi3FullName(fmi3SetBinary)
 #define fmi3GetNumberOfVariableDependencies fmi3FullName(fmi3GetNumberOfVariableDependencies)
@@ -158,14 +174,14 @@ Functions for FMI3 for Model Exchange
 Functions for FMI3 for Co-Simulation
 ****************************************************/
 
-#define fmi3SetRealInputDerivatives      fmi3FullName(fmi3SetRealInputDerivatives)
-#define fmi3GetRealOutputDerivatives     fmi3FullName(fmi3GetRealOutputDerivatives)
+#define fmi3SetInputDerivatives          fmi3FullName(fmi3SetInputDerivatives)
+#define fmi3GetOutputDerivatives         fmi3FullName(fmi3GetOutputDerivatives)
 #define fmi3DoStep                       fmi3FullName(fmi3DoStep)
 #define fmi3CancelStep                   fmi3FullName(fmi3CancelStep)
 #define fmi3GetStatus                    fmi3FullName(fmi3GetStatus)
-#define fmi3GetRealStatus                fmi3FullName(fmi3GetRealStatus)
-#define fmi3GetIntegerStatus             fmi3FullName(fmi3GetIntegerStatus)
-#define fmi3GetBooleanStatus             fmi3FullName(fmi3GetBooleanStatus)
+#define fmi3GetDoubleStatus              fmi3FullName(fmi3GetDoubleStatus)
+#define fmi3GetInt32Status               fmi3FullName(fmi3GetInt32Status)
+#define fmi3GetBoolStatus                fmi3FullName(fmi3GetBoolStatus)
 #define fmi3GetStringStatus              fmi3FullName(fmi3GetStringStatus)
 
 /* Version number */
@@ -192,15 +208,32 @@ FMI3_Export fmi3TerminateTYPE               fmi3Terminate;
 FMI3_Export fmi3ResetTYPE                   fmi3Reset;
 
 /* Getting and setting variables values */
-FMI3_Export fmi3GetRealTYPE    fmi3GetReal;
-FMI3_Export fmi3GetIntegerTYPE fmi3GetInteger;
-FMI3_Export fmi3GetBooleanTYPE fmi3GetBoolean;
+FMI3_Export fmi3GetFloatTYPE   fmi3GetFloat;
+FMI3_Export fmi3GetDoubleTYPE  fmi3GetDouble;
+FMI3_Export fmi3GetInt8TYPE    fmi3GetInt8;
+FMI3_Export fmi3GetUInt8TYPE   fmi3GetUInt8;
+FMI3_Export fmi3GetInt16TYPE   fmi3GetInt16;
+FMI3_Export fmi3GetUInt16TYPE  fmi3GetUInt16;
+FMI3_Export fmi3GetInt32TYPE   fmi3GetInt32;
+FMI3_Export fmi3GetUInt32TYPE  fmi3GetUInt32;
+FMI3_Export fmi3GetInt64TYPE   fmi3GetInt64;
+FMI3_Export fmi3GetUInt64TYPE  fmi3GetUInt64;
+FMI3_Export fmi3GetBoolTYPE    fmi3GetBool;
 FMI3_Export fmi3GetStringTYPE  fmi3GetString;
 FMI3_Export fmi3GetBinaryTYPE  fmi3GetBinary;
-
-FMI3_Export fmi3SetRealTYPE    fmi3SetReal;
-FMI3_Export fmi3SetIntegerTYPE fmi3SetInteger;
-FMI3_Export fmi3SetBooleanTYPE fmi3SetBoolean;
+FMI3_Export fmi3SetFloatTYPE   fmi3SetFloat;
+FMI3_Export fmi3SetDoubleTYPE  fmi3SetDouble;
+FMI3_Export fmi3SetInt8TYPE    fmi3SetInt8;
+FMI3_Export fmi3SetUInt8TYPE   fmi3SetUInt8;
+FMI3_Export fmi3SetInt16TYPE   fmi3SetInt16;
+FMI3_Export fmi3SetUInt16TYPE  fmi3SetUInt16;
+FMI3_Export fmi3SetInt32TYPE   fmi3SetInt32;
+FMI3_Export fmi3SetUInt32TYPE  fmi3SetUInt32;
+FMI3_Export fmi3SetInt64TYPE   fmi3SetInt64;
+FMI3_Export fmi3SetUInt64TYPE  fmi3SetUInt64;
+FMI3_Export fmi3SetBoolTYPE    fmi3SetBool;
+FMI3_Export fmi3SetStringTYPE  fmi3SetString;
+FMI3_Export fmi3SetBinaryTYPE  fmi3SetBinary;
 FMI3_Export fmi3SetStringTYPE  fmi3SetString;
 FMI3_Export fmi3SetBinaryTYPE  fmi3SetBinary;
 
@@ -246,17 +279,17 @@ Functions for FMI3 for Co-Simulation
 ****************************************************/
 
 /* Simulating the slave */
-FMI3_Export fmi3SetRealInputDerivativesTYPE  fmi3SetRealInputDerivatives;
-FMI3_Export fmi3GetRealOutputDerivativesTYPE fmi3GetRealOutputDerivatives;
+FMI3_Export fmi3SetInputDerivativesTYPE  fmi3SetInputDerivatives;
+FMI3_Export fmi3GetOutputDerivativesTYPE fmi3GetOutputDerivatives;
 
 FMI3_Export fmi3DoStepTYPE     fmi3DoStep;
 FMI3_Export fmi3CancelStepTYPE fmi3CancelStep;
 
 /* Inquire slave status */
 FMI3_Export fmi3GetStatusTYPE        fmi3GetStatus;
-FMI3_Export fmi3GetRealStatusTYPE    fmi3GetRealStatus;
-FMI3_Export fmi3GetIntegerStatusTYPE fmi3GetIntegerStatus;
-FMI3_Export fmi3GetBooleanStatusTYPE fmi3GetBooleanStatus;
+FMI3_Export fmi3GetDoubleStatusTYPE  fmi3GetDoubleStatus;
+FMI3_Export fmi3GetInt32StatusTYPE   fmi3GetInt32Status;
+FMI3_Export fmi3GetBoolStatusTYPE    fmi3GetBoolStatus;
 FMI3_Export fmi3GetStringStatusTYPE  fmi3GetStringStatus;
 
 #ifdef __cplusplus

--- a/headers/fmi3TypesPlatform.h
+++ b/headers/fmi3TypesPlatform.h
@@ -59,9 +59,17 @@ fmi3Component           : an opaque object pointer
 fmi3ComponentEnvironment: an opaque object pointer
 fmi3FMUstate            : an opaque object pointer
 fmi3ValueReference      : value handle type
-fmi3Real                : double precision floating-point data type
-fmi3Integer             : basic signed integer data type
-fmi3Boolean             : datatype to be used with fmi3True and fmi3False
+fmi3Float               : single precision floating point (32-bit)
+fmi3Double              : double precision floating point (64-bit)
+fmi3Int8                : 8-bit signed integer
+fmi3UInt8               : 8-bit unsigned integer
+fmi3Int16               : 16-bit signed integer
+fmi3UInt16              : 16-bit unsigned integer
+fmi3Int32               : 32-bit signed integer
+fmi3UInt32              : 32-bit unsigned integer
+fmi3Int64               : 64-bit signed integer
+fmi3UInt64              : 64-bit unsigned integer
+fmi3Bool                : datatype to be used with fmi3True and fmi3False
 fmi3Char                : character data type (size of one character)
 fmi3String              : a pointer to a vector of fmi3Char characters
                           ('\0' terminated, UTF8 encoded)
@@ -86,19 +94,27 @@ typedef unsigned int    fmi3ValueReference;        /* Handle to the value of a v
 /* end::ValueReference[] */
 
 /* tag::VariableTypes[] */
-typedef double          fmi3Real;     /* Data type for floating point real numbers */
-typedef int             fmi3Integer;  /* Data type for signed integer numbers */
-typedef int             fmi3Boolean;  /* Data type for Boolean numbers
+typedef    float        fmi3Float;    /* single precision floating point (32-bit) */
+typedef   double        fmi3Double;   /* double precision floating point (64-bit) */
+typedef   int8_t        fmi3Int8;     /* 8-bit signed integer */
+typedef  uint8_t        fmi3UInt8;    /* 8-bit unsigned integer */
+typedef  int16_t        fmi3Int16;    /* 16-bit signed integer */
+typedef uint16_t        fmi3UInt16;   /* 16-bit unsigned integer */
+typedef  int16_t        fmi3Int32;    /* 32-bit signed integer */
+typedef uint16_t        fmi3UInt32;   /* 32-bit unsigned integer */
+typedef  int16_t        fmi3Int64;    /* 64-bit signed integer */
+typedef uint16_t        fmi3UInt64;   /* 64-bit unsigned integer */
+typedef      int        fmi3Bool;     /* Data type for Boolean numbers
                                          (only two values: fmi3False, fmi3True) */
 typedef char            fmi3Char;     /* Data type for one character */
-typedef const fmi3Char* fmi3String;   /* Data type for character strings 
-					 ('\0' terminated, UTF8 encoded) */
+typedef const fmi3Char* fmi3String;   /* Data type for character strings
+                                         ('\0' terminated, UTF8 encoded) */
 typedef char            fmi3Byte;     /* Smallest addressable unit of the machine
-					 (typically one byte) */
+                                         (typically one byte) */
 typedef const fmi3Byte* fmi3Binary;   /* Data type for binary data
                                          (out-of-band length terminated) */
 
-/* Values for fmi3Boolean  */
+/* Values for fmi3Bool */
 #define fmi3True  1
 #define fmi3False 0
 /* end::VariableTypes[] */


### PR DESCRIPTION
- add new fmi3[U]Int{8,16,32,64} and fmi3Float variable types
- rename fmi3Boolean to fmi3Bool
- replace fmi3Integer with fmi3Int32
- replace fmi3Real with fmi3Double
- rename getters, setter and status functions accordingly
- remove "Real" from fmi3SetRealInputDerivatives and fmi3GetRealOutputDerivatives