### PR TITLE
Initial support for numeric types in schemas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,14 @@ env:
 
 before_install:
   - docker pull asciidoctor/docker-asciidoctor
+  - sudo apt-get install -y python-lxml
   - gem install html-proofer
 
 script:
   # compile the headers
   - gcc headers/fmi3Functions.h
+  # parse the schema
+  - python -c "from lxml import etree; etree.XMLSchema(file='schema/fmi3ModelDescription.xsd')"
   # generate the HTML documentation
   - docker run -v $TRAVIS_BUILD_DIR:/documents/ --name asciidoc-to-html asciidoctor/docker-asciidoctor asciidoctor --base-dir /documents/ --backend html5 --failure-level WARN docs/fmi_specification.adoc
   # check the generated HTML

--- a/schema/fmi3AttributeGroups.xsd
+++ b/schema/fmi3AttributeGroups.xsd
@@ -62,7 +62,7 @@ the modified file must also be provided under this license).
 			</xs:annotation>
 		</xs:attribute>
 	</xs:attributeGroup>
-	<xs:attributeGroup name="fmi3Float64Attributes">
+	<xs:attributeGroup name="fmi3DoubleAttributes">
 		<xs:attributeGroup ref="fmi3RealAttributes"/>
 		<xs:attribute name="min" type="xs:double"/>
 		<xs:attribute name="max" type="xs:double">
@@ -76,7 +76,7 @@ the modified file must also be provided under this license).
 			</xs:annotation>
 		</xs:attribute>
 	</xs:attributeGroup>
-	<xs:attributeGroup name="fmi3Float32Attributes">
+	<xs:attributeGroup name="fmi3FloatAttributes">
 		<xs:attributeGroup ref="fmi3RealAttributes"/>
 		<xs:attribute name="min" type="xs:float"/>
 		<xs:attribute name="max" type="xs:float">

--- a/schema/fmi3AttributeGroups.xsd
+++ b/schema/fmi3AttributeGroups.xsd
@@ -56,6 +56,14 @@ the modified file must also be provided under this license).
 				<xs:documentation>If relativeQuantity=true, offset for displayUnit must be ignored.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
+		<xs:attribute name="unbounded" type="xs:boolean" default="false">
+			<xs:annotation>
+				<xs:documentation>Set to true, e.g., for crank angle. If true and variable is a state, relative tolerance should be zero on this variable.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:attributeGroup>
+	<xs:attributeGroup name="fmi3Float64Attributes">
+		<xs:attributeGroup ref="fmi3RealAttributes"/>
 		<xs:attribute name="min" type="xs:double"/>
 		<xs:attribute name="max" type="xs:double">
 			<xs:annotation>
@@ -67,18 +75,114 @@ the modified file must also be provided under this license).
 				<xs:documentation>nominal > 0.0 required</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		<xs:attribute name="unbounded" type="xs:boolean" default="false">
+	</xs:attributeGroup>
+	<xs:attributeGroup name="fmi3Float32Attributes">
+		<xs:attributeGroup ref="fmi3RealAttributes"/>
+		<xs:attribute name="min" type="xs:float"/>
+		<xs:attribute name="max" type="xs:float">
 			<xs:annotation>
-				<xs:documentation>Set to true, e.g., for crank angle. If true and variable is a state, relative tolerance should be zero on this variable.</xs:documentation>
+				<xs:documentation>max >= min required</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="nominal" type="xs:float">
+			<xs:annotation>
+				<xs:documentation>nominal > 0.0 required</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 	</xs:attributeGroup>
 	<xs:attributeGroup name="fmi3IntegerAttributes">
 		<xs:attribute name="quantity" type="xs:normalizedString"/>
+	</xs:attributeGroup>
+	<xs:attributeGroup name="fmi3Int8Attributes">
+		<xs:attributeGroup ref="fmi3IntegerAttributes"/>
+		<xs:attribute name="min" type="xs:byte"/>
+		<xs:attribute name="max" type="xs:byte">
+			<xs:annotation>
+				<xs:documentation>max >= min required</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:attributeGroup>
+	<xs:attributeGroup name="fmi3UInt8Attributes">
+		<xs:attributeGroup ref="fmi3IntegerAttributes"/>
+		<xs:attribute name="min" type="xs:unsignedByte"/>
+		<xs:attribute name="max" type="xs:unsignedByte">
+			<xs:annotation>
+				<xs:documentation>max >= min required</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:attributeGroup>
+	<xs:attributeGroup name="fmi3Int16Attributes">
+		<xs:attributeGroup ref="fmi3IntegerAttributes"/>
+		<xs:attribute name="min" type="xs:short"/>
+		<xs:attribute name="max" type="xs:short">
+			<xs:annotation>
+				<xs:documentation>max >= min required</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:attributeGroup>
+	<xs:attributeGroup name="fmi3UInt16Attributes">
+		<xs:attributeGroup ref="fmi3IntegerAttributes"/>
+		<xs:attribute name="min" type="xs:unsignedShort"/>
+		<xs:attribute name="max" type="xs:unsignedShort">
+			<xs:annotation>
+				<xs:documentation>max >= min required</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:attributeGroup>
+	<xs:attributeGroup name="fmi3Int32Attributes">
+		<xs:attributeGroup ref="fmi3IntegerAttributes"/>
 		<xs:attribute name="min" type="xs:int"/>
 		<xs:attribute name="max" type="xs:int">
 			<xs:annotation>
 				<xs:documentation>max >= min required</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:attributeGroup>
+	<xs:attributeGroup name="fmi3UInt32Attributes">
+		<xs:attributeGroup ref="fmi3IntegerAttributes"/>
+		<xs:attribute name="min" type="xs:unsignedInt"/>
+		<xs:attribute name="max" type="xs:unsignedInt">
+			<xs:annotation>
+				<xs:documentation>max >= min required</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:attributeGroup>
+	<xs:attributeGroup name="fmi3Int64Attributes">
+		<xs:attributeGroup ref="fmi3IntegerAttributes"/>
+		<xs:attribute name="min" type="xs:long"/>
+		<xs:attribute name="max" type="xs:long">
+			<xs:annotation>
+				<xs:documentation>max >= min required</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:attributeGroup>
+	<xs:attributeGroup name="fmi3UInt64Attributes">
+		<xs:attributeGroup ref="fmi3IntegerAttributes"/>
+		<xs:attribute name="min" type="xs:unsignedLong"/>
+		<xs:attribute name="max" type="xs:unsignedLong">
+			<xs:annotation>
+				<xs:documentation>max >= min required</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:attributeGroup>
+	<xs:attributeGroup name="fmi3RealVariableAttributes">
+		<xs:attribute name="derivative" type="xs:unsignedInt">
+			<xs:annotation>
+				<xs:documentation>If present, this variable is the derivative of variable with Variable index "derivative".</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="reinit" type="xs:boolean" use="optional" default="false">
+			<xs:annotation>
+				<xs:documentation>Only for ModelExchange and if variable is a continuous-time state:
+					If true, state can be reinitialized at an event by the FMU
+					If false, state will never be reinitialized at an event by the FMU</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:attributeGroup>
+	<xs:attributeGroup name="fmi3VariableCommonAttributes">
+		<xs:attribute name="declaredType" type="xs:normalizedString">
+			<xs:annotation>
+				<xs:documentation>If present, name of type defined with TypeDefinitions / SimpleType providing defaults.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 	</xs:attributeGroup>

--- a/schema/fmi3Type.xsd
+++ b/schema/fmi3Type.xsd
@@ -50,14 +50,54 @@ the modified file must also be provided under this license).
 		</xs:annotation>
 		<xs:sequence>
 			<xs:choice>
-				<xs:element name="Real">
+				<xs:element name="Float64">
 					<xs:complexType>
-						<xs:attributeGroup ref="fmi3RealAttributes"/>
+						<xs:attributeGroup ref="fmi3Float64Attributes"/>
 					</xs:complexType>
 				</xs:element>
-				<xs:element name="Integer">
+				<xs:element name="Float32">
 					<xs:complexType>
-						<xs:attributeGroup ref="fmi3IntegerAttributes"/>
+						<xs:attributeGroup ref="fmi3Float32Attributes"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Int8">
+					<xs:complexType>
+						<xs:attributeGroup ref="fmi3Int8Attributes"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="UInt8">
+					<xs:complexType>
+						<xs:attributeGroup ref="fmi3UInt8Attributes"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Int16">
+					<xs:complexType>
+						<xs:attributeGroup ref="fmi3Int16Attributes"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="UInt16">
+					<xs:complexType>
+						<xs:attributeGroup ref="fmi3UInt16Attributes"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Int32">
+					<xs:complexType>
+						<xs:attributeGroup ref="fmi3Int32Attributes"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="UInt32">
+					<xs:complexType>
+						<xs:attributeGroup ref="fmi3UInt32Attributes"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Int64">
+					<xs:complexType>
+						<xs:attributeGroup ref="fmi3Int64Attributes"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="UInt64">
+					<xs:complexType>
+						<xs:attributeGroup ref="fmi3UInt64Attributes"/>
 					</xs:complexType>
 				</xs:element>
 				<xs:element name="Boolean"/>

--- a/schema/fmi3Type.xsd
+++ b/schema/fmi3Type.xsd
@@ -50,14 +50,14 @@ the modified file must also be provided under this license).
 		</xs:annotation>
 		<xs:sequence>
 			<xs:choice>
-				<xs:element name="Float64">
+				<xs:element name="Double">
 					<xs:complexType>
-						<xs:attributeGroup ref="fmi3Float64Attributes"/>
+						<xs:attributeGroup ref="fmi3DoubleAttributes"/>
 					</xs:complexType>
 				</xs:element>
-				<xs:element name="Float32">
+				<xs:element name="Float">
 					<xs:complexType>
-						<xs:attributeGroup ref="fmi3Float32Attributes"/>
+						<xs:attributeGroup ref="fmi3FloatAttributes"/>
 					</xs:complexType>
 				</xs:element>
 				<xs:element name="Int8">

--- a/schema/fmi3Variable.xsd
+++ b/schema/fmi3Variable.xsd
@@ -51,18 +51,14 @@ the modified file must also be provided under this license).
 		</xs:annotation>
 		<xs:sequence>
 			<xs:choice>
-				<xs:element name="Real">
+				<xs:element name="Float64">
 					<xs:complexType>
-						<xs:attribute name="declaredType" type="xs:normalizedString">
-							<xs:annotation>
-								<xs:documentation>If present, name of type defined with TypeDefinitions / SimpleType providing defaults.</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attributeGroup ref="fmi3RealAttributes"/>
+						<xs:attributeGroup ref="fmi3VariableCommonAttributes"/>
+						<xs:attributeGroup ref="fmi3Float64Attributes"/>
 						<xs:attribute name="start">
 							<xs:annotation>
 								<xs:documentation>List of start values. Value before initialization, if initial=exact or approx.
-max >= start[i] >= min required</xs:documentation>
+									max >= start[i] >= min required</xs:documentation>
 							</xs:annotation>
 							<xs:simpleType>
 								<xs:list>
@@ -72,32 +68,113 @@ max >= start[i] >= min required</xs:documentation>
 								</xs:list>
 							</xs:simpleType>
 						</xs:attribute>
-						<xs:attribute name="derivative" type="xs:unsignedInt">
-							<xs:annotation>
-								<xs:documentation>If present, this variable is the derivative of variable with Variable index "derivative".</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="reinit" type="xs:boolean" use="optional" default="false">
-							<xs:annotation>
-								<xs:documentation>Only for ModelExchange and if variable is a continuous-time state:
-If true, state can be reinitialized at an event by the FMU
-If false, state will never be reinitialized at an event by the FMU</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
+						<xs:attributeGroup ref="fmi3RealVariableAttributes"/>
 					</xs:complexType>
 				</xs:element>
-				<xs:element name="Integer">
+				<xs:element name="Float32">
 					<xs:complexType>
-						<xs:attribute name="declaredType" type="xs:normalizedString">
+						<xs:attributeGroup ref="fmi3VariableCommonAttributes"/>
+						<xs:attributeGroup ref="fmi3Float32Attributes"/>
+						<xs:attribute name="start">
 							<xs:annotation>
-								<xs:documentation>If present, name of type defined with TypeDefinitions / SimpleType providing defaults.</xs:documentation>
+								<xs:documentation>List of start values. Value before initialization, if initial=exact or approx.
+									max >= start[i] >= min required</xs:documentation>
 							</xs:annotation>
+							<xs:simpleType>
+								<xs:list>
+									<xs:simpleType>
+										<xs:restriction base="xs:float"/>
+									</xs:simpleType>
+								</xs:list>
+							</xs:simpleType>
 						</xs:attribute>
-						<xs:attributeGroup ref="fmi3IntegerAttributes"/>
+						<xs:attributeGroup ref="fmi3RealVariableAttributes"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Int8">
+					<xs:complexType>
+						<xs:attributeGroup ref="fmi3VariableCommonAttributes"/>
+						<xs:attributeGroup ref="fmi3Int8Attributes"/>
 						<xs:attribute name="start">
 							<xs:annotation>
 								<xs:documentation>Value before initialization, if initial=exact or approx.
-max >= start[i] >= min required</xs:documentation>
+									max >= start[i] >= min required</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:list>
+									<xs:simpleType>
+										<xs:restriction base="xs:byte"/>
+									</xs:simpleType>
+								</xs:list>
+							</xs:simpleType>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="UInt8">
+					<xs:complexType>
+						<xs:attributeGroup ref="fmi3VariableCommonAttributes"/>
+						<xs:attributeGroup ref="fmi3UInt8Attributes"/>
+						<xs:attribute name="start">
+							<xs:annotation>
+								<xs:documentation>Value before initialization, if initial=exact or approx.
+									max >= start[i] >= min required</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:list>
+									<xs:simpleType>
+										<xs:restriction base="xs:unsignedByte"/>
+									</xs:simpleType>
+								</xs:list>
+							</xs:simpleType>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Int16">
+					<xs:complexType>
+						<xs:attributeGroup ref="fmi3VariableCommonAttributes"/>
+						<xs:attributeGroup ref="fmi3Int16Attributes"/>
+						<xs:attribute name="start">
+							<xs:annotation>
+								<xs:documentation>Value before initialization, if initial=exact or approx.
+									max >= start[i] >= min required</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:list>
+									<xs:simpleType>
+										<xs:restriction base="xs:short"/>
+									</xs:simpleType>
+								</xs:list>
+							</xs:simpleType>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="UInt16">
+					<xs:complexType>
+						<xs:attributeGroup ref="fmi3VariableCommonAttributes"/>
+						<xs:attributeGroup ref="fmi3UInt16Attributes"/>
+						<xs:attribute name="start">
+							<xs:annotation>
+								<xs:documentation>Value before initialization, if initial=exact or approx.
+									max >= start[i] >= min required</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:list>
+									<xs:simpleType>
+										<xs:restriction base="xs:unsignedShort"/>
+									</xs:simpleType>
+								</xs:list>
+							</xs:simpleType>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Int32">
+					<xs:complexType>
+						<xs:attributeGroup ref="fmi3VariableCommonAttributes"/>
+						<xs:attributeGroup ref="fmi3Int32Attributes"/>
+						<xs:attribute name="start">
+							<xs:annotation>
+								<xs:documentation>Value before initialization, if initial=exact or approx.
+									max >= start[i] >= min required</xs:documentation>
 							</xs:annotation>
 							<xs:simpleType>
 								<xs:list>
@@ -109,13 +186,66 @@ max >= start[i] >= min required</xs:documentation>
 						</xs:attribute>
 					</xs:complexType>
 				</xs:element>
+				<xs:element name="UInt32">
+					<xs:complexType>
+						<xs:attributeGroup ref="fmi3VariableCommonAttributes"/>
+						<xs:attributeGroup ref="fmi3UInt32Attributes"/>
+						<xs:attribute name="start">
+							<xs:annotation>
+								<xs:documentation>Value before initialization, if initial=exact or approx.
+									max >= start[i] >= min required</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:list>
+									<xs:simpleType>
+										<xs:restriction base="xs:unsignedInt"/>
+									</xs:simpleType>
+								</xs:list>
+							</xs:simpleType>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Int64">
+					<xs:complexType>
+						<xs:attributeGroup ref="fmi3VariableCommonAttributes"/>
+						<xs:attributeGroup ref="fmi3Int64Attributes"/>
+						<xs:attribute name="start">
+							<xs:annotation>
+								<xs:documentation>Value before initialization, if initial=exact or approx.
+									max >= start[i] >= min required</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:list>
+									<xs:simpleType>
+										<xs:restriction base="xs:long"/>
+									</xs:simpleType>
+								</xs:list>
+							</xs:simpleType>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="UInt64">
+					<xs:complexType>
+						<xs:attributeGroup ref="fmi3VariableCommonAttributes"/>
+						<xs:attributeGroup ref="fmi3UInt64Attributes"/>
+						<xs:attribute name="start">
+							<xs:annotation>
+								<xs:documentation>Value before initialization, if initial=exact or approx.
+									max >= start[i] >= min required</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:list>
+									<xs:simpleType>
+										<xs:restriction base="xs:unsignedLong"/>
+									</xs:simpleType>
+								</xs:list>
+							</xs:simpleType>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
 				<xs:element name="Boolean">
 					<xs:complexType>
-						<xs:attribute name="declaredType" type="xs:normalizedString">
-							<xs:annotation>
-								<xs:documentation>If present, name of type defined with TypeDefinitions / SimpleType providing defaults.</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
+						<xs:attributeGroup ref="fmi3VariableCommonAttributes"/>
 						<xs:attribute name="start">
 							<xs:annotation>
 								<xs:documentation>Value before initialization, if initial=exact or approx</xs:documentation>
@@ -132,11 +262,7 @@ max >= start[i] >= min required</xs:documentation>
 				</xs:element>
 				<xs:element name="String">
 					<xs:complexType>
-						<xs:attribute name="declaredType" type="xs:normalizedString">
-							<xs:annotation>
-								<xs:documentation>If present, name of type defined with TypeDefinitions / SimpleType providing defaults.</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
+						<xs:attributeGroup ref="fmi3VariableCommonAttributes"/>
 						<xs:attribute name="start">
 							<xs:annotation>
 								<xs:documentation>Value before initialization, if initial=exact or approx</xs:documentation>
@@ -153,11 +279,7 @@ max >= start[i] >= min required</xs:documentation>
 				</xs:element>
 				<xs:element name="Binary">
 					<xs:complexType>
-						<xs:attribute name="declaredType" type="xs:normalizedString">
-							<xs:annotation>
-								<xs:documentation>If present, name of type defined with TypeDefinitions / SimpleType providing defaults.</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
+						<xs:attributeGroup ref="fmi3VariableCommonAttributes"/>
 						<xs:attribute name="mimeType" type="xs:normalizedString" use="optional" default="application/octet-stream">
 							<xs:annotation>
 								<xs:documentation>Should indicate the type of data passed as a binary. Defaults to application/octet-stream,

--- a/schema/fmi3Variable.xsd
+++ b/schema/fmi3Variable.xsd
@@ -51,10 +51,10 @@ the modified file must also be provided under this license).
 		</xs:annotation>
 		<xs:sequence>
 			<xs:choice>
-				<xs:element name="Float64">
+				<xs:element name="Double">
 					<xs:complexType>
 						<xs:attributeGroup ref="fmi3VariableCommonAttributes"/>
-						<xs:attributeGroup ref="fmi3Float64Attributes"/>
+						<xs:attributeGroup ref="fmi3DoubleAttributes"/>
 						<xs:attribute name="start">
 							<xs:annotation>
 								<xs:documentation>List of start values. Value before initialization, if initial=exact or approx.
@@ -71,10 +71,10 @@ the modified file must also be provided under this license).
 						<xs:attributeGroup ref="fmi3RealVariableAttributes"/>
 					</xs:complexType>
 				</xs:element>
-				<xs:element name="Float32">
+				<xs:element name="Float">
 					<xs:complexType>
 						<xs:attributeGroup ref="fmi3VariableCommonAttributes"/>
-						<xs:attributeGroup ref="fmi3Float32Attributes"/>
+						<xs:attributeGroup ref="fmi3FloatAttributes"/>
 						<xs:attribute name="start">
 							<xs:annotation>
 								<xs:documentation>List of start values. Value before initialization, if initial=exact or approx.


### PR DESCRIPTION
This change does not change the enumeration type to map to any of the
new types, but leaves it still implicitly mapped to fmi3Int32 (the successor
of the original fmi3Integer type).  Making the enumeration type map to
any of the new integer types would be useful addition, but would make
code quite a bit more complex, and also leave the schema definitions not
as expressive, since the valid ranges for min/max, etc. will depend on
an attribute.