### PR TITLE
#411 Expanded text on mandatory api functions

### DIFF
--- a/docs/2_3_fmu_distribution.adoc
+++ b/docs/2_3_fmu_distribution.adoc
@@ -1,9 +1,11 @@
 === FMU Distribution
 
 An FMU description consists of several files.
-n FMU implementation may be distributed in source code and/or in binary format.
+An FMU implementation may be distributed in source code and/or in binary format.
 All relevant files are stored in a ZIP file with a pre-defined structure.
 The implementation must either implement all the functions of FMI for Model Exchange or all the functions of FMI for Co-Simulation or both.
+Specifically it is required that all functions specified for Model Exchange and/or Co-Simulation are present, even if they are only needed for capabilities that the FMU does not support.
+The behavior of those functions is unspecified, so while calling environments can rely on the functions being present, they cannot rely on any particular behavior for functions only needed for capabilities the FMU does not support.
 The extension of the ZIP file must be "**.fmu**", for example, "HybridVehicle.fmu".
 The compression method used for the ZIP file must be "deflate" _[(most free tools, such as zlib, offer only the common compression method "deflate")]_.
 


### PR DESCRIPTION
# Conflicts:
#	docs/2_3_fmu_distribution.adoc

Fixed spelling errors caught by Beutlich

@KarlWernersson The cherry-picking of eddabe0011d7fce1d203da4fbb93d14609053483 and 1a31ef8510bfdb3f13820eb4be3f15d204cb3dd4 for master branch was painful due the new line breaks. Best to avoid them in future.