### PR TITLE
Remove "#type" style variable references in log messages (#442)

### DIFF
--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -358,15 +358,7 @@ _[Typically, this function prints the message and stores it optionally in a log 
 All string-valued arguments passed by the FMU to the `logger` may be deallocated by the FMU directly after function `logger` returns.
 The environment must therefore create copies of these strings if it needs to access these strings later. +
 The `logger` function will append a line break to each message when writing messages after each other to a terminal or a file (the messages may also be shown in other ways, for example, as separate text-boxes in a GUI).
-The caller may include line-breaks (using "\n") within the message, but should avoid trailing line breaks. +
-Variables are referenced in a message with `\#<Type><ValueReference>#` where <Type> is "r" for `fmi3Real`, "i" for `fmi3Integer`, "b" for `fmi3Boolean` and "s" for `fmi3String`.
-If character `pass:[#]` shall be included in the message, it has to be prefixed with `pass:[#]`, so `#` is an escape character.
-+
-_[Example:_ +
-_A message of the form "\#r1365#" must be larger than zero (used in IO channel ##4)"_ +
-_might be changed by the `logger` function to_ +
-_`"body.m must be larger than zero (used in IO channel #4)"`_ +
-_if `"body.m"` is the name of the `fmi3Real` variable with `fmi3ValueReference = 1365`.]_
+The caller may include line-breaks (using "\n") within the message, but should avoid trailing line breaks.
 
 Function `allocateMemory`::
 Pointer to a function that is called in the FMU if memory needs to be allocated.


### PR DESCRIPTION
See #442.