### PR TITLE
Remove const qualifiers in fmi3CallbackFunctions

### DIFF
--- a/headers/fmi3FunctionTypes.h
+++ b/headers/fmi3FunctionTypes.h
@@ -107,11 +107,11 @@ typedef void  (*fmi3StepFinished)           (fmi3ComponentEnvironment componentE
                                              fmi3Status status);
 
 typedef struct {
-    const fmi3CallbackLogger         logger;
-    const fmi3CallbackAllocateMemory allocateMemory;
-    const fmi3CallbackFreeMemory     freeMemory;
-    const fmi3StepFinished           stepFinished;
-    const fmi3ComponentEnvironment   componentEnvironment;
+    fmi3CallbackLogger         logger;
+    fmi3CallbackAllocateMemory allocateMemory;
+    fmi3CallbackFreeMemory     freeMemory;
+    fmi3StepFinished           stepFinished;
+    fmi3ComponentEnvironment   componentEnvironment;
 } fmi3CallbackFunctions;
 /* end::CallbackFunctions[] */
 


### PR DESCRIPTION
to allow importers to use the header files without modifications.

(solves #433)