### PR TITLE
Add "platform tuple" for binary directories

### DIFF
--- a/docs/2_3_fmu_distribution.adoc
+++ b/docs/2_3_fmu_distribution.adoc
@@ -14,42 +14,35 @@ This ZIP file has the following structure:
 
 ----
 // Structure of ZIP file of an FMU
-modelDescription.xml      // Description of FMU (required file)
-model.png                 // Optional image file of FMU icon
-documentation             // Optional directory containing the FMU documentation
-index.html                // Entry point of the documentation
-<other documentation files>
-sources                   // Optional directory containing all C sources
+modelDescription.xml          // description of FMU (required file)
+model.png                     // image file of FMU icon (optional)
+documentation                 // directory containing the documentation (optional)
+   index.html                 // entry point of the documentation
+   <other documentation files>
+sources                       // directory containing the C sources (optional)
    // all needed C sources and C header files to compile and link the FMU
-   // with exception of: fmi3TypesPlatform.h , fmi3FunctionTypes.h and fmi3Functions.h
+   // with exception of: fmi3TypesPlatform.h, fmi3FunctionTypes.h and fmi3Functions.h
    // The files to be compiled (but not the files included from these files)
    // have to be reported in the XML file under the structure
    // <ModelExchange><SourceFiles> ... and <CoSimulation><SourceFiles>
-binaries                     // Optional directory containing the binaries win32 // Optional binaries for 32-bit Windows
-   win32                     // Optional binaries for 32-bit Windows
-      <modelIdentifier>.dll  // DLL of the FMI implementation
-                             // (build with option "MT" to include run-time environment)
-      <other DLLs>           // The DLL can include other DLLs
-      // Optional object Libraries for a particular compiler VisualStudio8
-      VisualStudio8        // Binaries for 32-bit Windows generated with
-                           // Microsoft Visual Studio 8 (2005)
-         <modelIdentifier>.lib   // Binary libraries
-      gcc3.1               // Binaries for gcc 3.1.
-         ...
-  win64      // Optional binaries for 64-bit Windows
-     ...
-  linux32    // Optional binaries for 32-bit Linux
-     <modelIdentifier>.so    // Shared library of the FMI implementation
-     ...
-  linux64    // Optional binaries for 64-bit Linux
-     ...
-resources    // Optional resources needed by the FMU
-   < data in FMU specific files which will be read during initialization;
-     also more folders can be added under resources (tool/model specific).
-     In order for the FMU to access these resource files, the resource directory
-     must be available in unzipped form and the absolute path to this directory
-     must be reported via argument "fmuResourceLocation" via fmi3Instantiate.
-   >
+binaries                      // directory containing the binaries (optional)
+   x86_64-windows             // binaries for Windows on Intel 64-bit
+      <modelIdentifier>.dll   // shared library of the FMI implementation
+      <other DLLs>            // the DLL can include other DLLs
+   x86_64-windows-msvc14mt    // static libraries for 64-bit Windows generated with
+      <modelIdentifier>.lib   // Visual Studio 14 (2015) with /MT flag
+   i686-linux                 // binaries for Linux on Intel 32-bit
+      <modelIdentifier>.so    // shared library of the FMI implementation
+   aarch32-linux              // binaries for Linux on ARM 32-bit
+      <modelIdentifier>.so    // shared library of the FMI implementation
+   x86_64-darwin              // binaries for macOS
+      <modelIdentifier>.dylib // shared library of the FMI implementation
+resources                     // resources needed by the FMU (optional)
+   // data in FMU specific files which will be read during initialization;
+   // also more folders can be added under resources (tool/model specific).
+   // In order for the FMU to access these resource files, the resource directory
+   // must be available in unzipped form and the absolute path to this directory
+   // must be reported via argument "fmuResourceLocation" via fmi3Instantiate.
 ----
 
 An FMU has to implement all common functions (according to tables in sections 3.2.3 and 4.2.4).
@@ -57,11 +50,130 @@ ModelExchange FMUs have to provide additionally the respective Model Exchange fu
 
 The FMU must be distributed with [underline]#at least# one implementation, in other words, either [underline]#sources# or one of the [underline]#binaries# for a particular machine.
 It is also possible to provide the sources and binaries for different target machines together in one ZIP file.
-The following names are standardized: for Windows: "win32", "win64"- for Linux: "linux32", "linux64", for Mac: "darwin32", "darwin64".
-Furthermore, also the names "VisualStudioX" and "gccX" are standardized and define the compiler with which the binary has been generated _[, for example, VisualStudio8]_.
+The names of the binary directories are standardized by the "platform tuple".
 Further names can be introduced by vendors.
 Dynamic link libraries must include all referenced resources that are not available on a standard target machine _[for example, DLLs on Windows machines must be built with option "MT" to include the run-time environment of VisualStudio in the DLL, and not use the option "MD" where this is not the case]_.
 When compiling a shared object on Linux, `RPATH="$ORIGIN"` has to be set when generating the shared object in order that shared objects used from it, can be dynamically loaded.
+
+The binaries must be placed in the respective <platformTuple> directory with the general format `<arch>-<sys>{-<abi>{<abi_ver>}{<abi_sub>}}`.
+
+Architecture `<arch>`::
++
+[width="50%",cols="1,5",options="header"]
+|====
+|Name
+|Description
+
+|aarch32
+|ARM 32-bit Architecture
+
+|aarch64
+|ARM 64-bit Architecture
+
+|i386
+|Intel 3rd generation x86 32-bit
+
+|i586
+|Intel 5th generation x86 32-bit w/o SSE
+
+|i686
+|Intel 6th generation x86 32-bit with SSE2
+
+|x86_64
+|Intel/AMD x86 64-bit
+|====
+
+Operating system `<sys>`::
++
+[width="50%",cols="1,5",options="header"]
+|====
+|Name
+|Description
+
+|darwin
+|Darwin (macOS, iOS, watchOS, tvOS, audioOS)
+
+|linux
+|Linux
+
+|windows
+|Microsoft Windows
+|====
+
+Application Binary Interface (ABI) `<abi>`::
++
+[width="50%",cols="1,5",options="header"]
+|====
+|Name
+|Description
+
+|elf
+|ELF file format
+
+|gnu
+|GNU
+
+|android
+|Android
+
+|macho
+|Mach object file format
+
+|msvc
+|Microsoft Visual C
+|====
+
+ABI version `<abi_ver>`::
++
+[width="50%",cols="1,5",options="header"]
+|====
+|Name
+|Description
+
+|160
+|Visual Studio 16.0 (2019)
+
+|150
+|Visual Studio 15.0 (2017)
+
+|140
+|Visual Studio 14.0 (2015)
+
+|120
+|Visual Studio 12.0 (2013)
+
+|110
+|Visual Studio 11.0 (2012)
+
+|100
+|Visual Studio 10.0 (2010)
+
+|90
+|Visual Studio 9.0 (2008)
+
+|80
+|Visual Studio 8.0 (2005)
+|====
+
+Sub-ABI `<abi_sub>`::
++
+[width="50%",cols="1,5",options="header"]
+|====
+|Name
+|Description
+
+|md
+|Visual Studio with /MD
+
+|mt
+|Visual Studio with /MT
+
+|mdd
+|Visual Studio with /MDd
+
+|mtd
+|Visual Studio with /MTd
+|====
 
 Typical scenarios are to provide binaries only for one machine type (for example, on the machine where the target simulator is running and for which licenses of run-time libraries are available) or to provide only sources (for example, for translation and download for a particular micro-processor).
 If run-time libraries cannot be shipped due to licensing, special handling is needed, for example, by providing the run-time libraries at appropriate places by the receiver.
@@ -70,13 +182,13 @@ FMI provides the means for two kinds of implementation: `needsExecutionTool = "t
 In the first case a tool specific wrapper DLL/SharedObject has to be provided as the binary, in the second a compiled or source code version of the model with its solver is stored (see section 4.3.1 for details).
 
 In an FMU both a version for ModelExchange and for CoSimulation might be present.
-If in both cases the executable part is provided as DLL/SharedObject, then two different or only one library can be provided.
+If in both cases the executable part is provided as a shared library, then two different or only one library can be provided.
 The library names are defined in the `modelIdentifier` attribute of elements `fmiModelDescription.ModelExchange` and `fmiModelDescription.CoSimulation`:
 
 ----
 [Example for different libraries:
-  binaries
-     win32
+   binaries
+     x86_64-windows
         MyModel_ModelExchange.dll   // ModelExchange.modelIdentifier =
                                     //    "MyModel_ModelExchange"
         MyModel_CoSimulation.dll    // CoSimulation.modelIdentifier =
@@ -106,10 +218,10 @@ In the case of a co-simulation implementation of `needsExecutionTool = "true"` t
 _[Note that the header files `fmi3TypesPlatform.h` and `fmi3FunctionTypes.h/fmi3Functions.h` are not included in the FMU due to the following reasons:_
 
 _pass:[]`fmi3TypesPlatform.h` makes no sense in the `sources` directory, because if sources are provided, then the target simulator defines this header file and not the FMU. +
-This header file is not included in the `binaries` directory, because it is implicitly defined by the platform directory (for example, win32 for 32-bit machine or linux64 for 64-bit machine)._
+This header file is not included in the `binaries` directory, because it is implicitly defined by the platform directory (for example, i686-windows for a 32-bit machine or x86_64-linux for a 64-bit machine)._
 
 _pass:[]`fmi3FunctionTypes.h` / `fmi3Functions.h` are not needed in the `sources` directory, because they are implicitly defined by attribute `fmiVersion` in file `modelDescription.xml`.
 Furthermore, in order that the C compiler can check for consistent function arguments, the header file from the target simulator should be used when compiling the C sources.
 It would therefore be counter-productive (unsafe) if this header file was present. +
 These header files are not included in the `binaries` directory, since they are already utilized to build the target simulator executable.
-The version number of the header file used to construct the FMU can be deduced via attribute `fmiVersion` in file `modelDescription.xml` or via function call `fmi3GetVersion()`.]_
+The version number of the header file used to construct the FMU can be deduced via attribute `fmiVersion` in file `modelDescription.xml` or via function call `fmi3GetVersion`.]_


### PR DESCRIPTION
as discussed in https://github.com/modelica/fmi-design/tree/master/Meetings/2018/2018-12-10-FMI-Steering#21-platform-tuple.

This PR contains only an initial set of platforms that can be extended as we see fit.