### PR TITLE
Fix <abi_ver> in platform tuple for Visual Studio

### DIFF
--- a/docs/2_3_fmu_distribution.adoc
+++ b/docs/2_3_fmu_distribution.adoc
@@ -148,7 +148,7 @@ ABI version `<abi_ver>`::
 |140
 |Visual Studio 2015 (MSVC++ 14.0)
 
-|150
+|141
 |Visual Studio 2017 (MSVC++ 15.0)
 |====
 

--- a/docs/2_3_fmu_distribution.adoc
+++ b/docs/2_3_fmu_distribution.adoc
@@ -29,8 +29,8 @@ binaries                      // directory containing the binaries (optional)
    x86_64-windows             // binaries for Windows on Intel 64-bit
       <modelIdentifier>.dll   // shared library of the FMI implementation
       <other DLLs>            // the DLL can include other DLLs
-   x86_64-windows-msvc14mt    // static libraries for 64-bit Windows generated with
-      <modelIdentifier>.lib   // Visual Studio 14 (2015) with /MT flag
+   x86_64-windows-msvc140mt   // static libraries for 64-bit Windows generated with
+      <modelIdentifier>.lib   // Visual Studio 2015 with /MT flag
    i686-linux                 // binaries for Linux on Intel 32-bit
       <modelIdentifier>.so    // shared library of the FMI implementation
    aarch32-linux              // binaries for Linux on ARM 32-bit
@@ -130,29 +130,26 @@ ABI version `<abi_ver>`::
 |Name
 |Description
 
-|160
-|Visual Studio 16.0 (2019)
-
-|150
-|Visual Studio 15.0 (2017)
-
-|140
-|Visual Studio 14.0 (2015)
-
-|120
-|Visual Studio 12.0 (2013)
-
-|110
-|Visual Studio 11.0 (2012)
-
-|100
-|Visual Studio 10.0 (2010)
+|80
+|Visual Studio 2005 (MSVC++ 8.0)
 
 |90
-|Visual Studio 9.0 (2008)
+|Visual Studio 2008 (MSVC++ 9.0)
 
-|80
-|Visual Studio 8.0 (2005)
+|100
+|Visual Studio 2010 (MSVC++ 10.0)
+
+|110
+|Visual Studio 2012 (MSVC++ 11.0)
+
+|120
+|Visual Studio 2013 (MSVC++ 12.0)
+
+|140
+|Visual Studio 2015 (MSVC++ 14.0)
+
+|150
+|Visual Studio 2017 (MSVC++ 15.0)
 |====
 
 Sub-ABI `<abi_sub>`::


### PR DESCRIPTION
and order versions from low to high

see also comments by @traversaro in #516 