### PR TITLE
Support of arrays of strings with whitespace

### DIFF
--- a/schema/fmi3Variable.xsd
+++ b/schema/fmi3Variable.xsd
@@ -253,19 +253,18 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				</xs:element>
 				<xs:element name="String">
 					<xs:complexType>
+						<xs:sequence maxOccurs="unbounded">
+							<xs:element name="Start">
+								<xs:complexType>
+									<xs:attribute name="value" type="xs:string">
+										<xs:annotation>
+											<xs:documentation>Value before initialization, if initial=exact or approx</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
 						<xs:attributeGroup ref="fmi3VariableCommonAttributes"/>
-						<xs:attribute name="start">
-							<xs:annotation>
-								<xs:documentation>Value before initialization, if initial=exact or approx</xs:documentation>
-							</xs:annotation>
-							<xs:simpleType>
-								<xs:list>
-									<xs:simpleType>
-										<xs:restriction base="xs:string"/>
-									</xs:simpleType>
-								</xs:list>
-							</xs:simpleType>
-						</xs:attribute>
 					</xs:complexType>
 				</xs:element>
 				<xs:element name="Binary">


### PR DESCRIPTION
Changes for the support of arrays of strings with whitespace according to 
https://github.com/modelica/fmi-standard/issues/513 