### PR TITLE
Move auxiliary scripts to docinfo.html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # generated files
 *.html
 *.pdf
+
+# keep docinfo
+!docinfo.html

--- a/docs/docinfo.html
+++ b/docs/docinfo.html
@@ -1,4 +1,3 @@
-++++
 <script>
 // hide / show the Table of Contents (TOC)
 function toggleTOC() {
@@ -21,4 +20,3 @@ document.addEventListener('keydown', (event) => {
   }
 });
 </script>
-++++

--- a/docs/fmi_specification.adoc
+++ b/docs/fmi_specification.adoc
@@ -4,6 +4,8 @@
 :toc-title: Contents
 :toclevels: 3
 :xrefstyle: short
+:docinfo: shared
+:docinfodir: docs
 :stylesheet: docs/fmi-spec.css
 :stem: latexmath
 :source-highlighter: highlightjs
@@ -43,5 +45,3 @@ include::docs/4_3_co-simulation_schema.adoc[]
 include::docs/5___literature.adoc[]
 
 include::docs/6___appendix.adoc[]
-
-include::docs/util.adoc[]


### PR DESCRIPTION
to allow compilation to other formats than HTML5