### PR TITLE
correct minor NULL vs void pointer error

### DIFF
--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -336,7 +336,7 @@ _if `"body.m"` is the name of the `fmi3Real` variable with `fmi3ValueReference =
 
 Function `allocateMemory`::
 Pointer to a function that is called in the FMU if memory needs to be allocated.
-If attribute `canNotUseMemoryManagementFunctions = "true"` in `<fmiModelDescription><ModelExchange / CoSimulation>`, then function `allocateMemory` is not used in the FMU and a void pointer can be provided.
+If attribute `canNotUseMemoryManagementFunctions = "true"` in `<fmiModelDescription><ModelExchange / CoSimulation>`, then function `allocateMemory` is not used in the FMU and a null pointer can be provided.
 If this attribute has a value of `false` (which is the default), the FMU must not use `malloc`, `calloc` or other memory allocation functions.
 One reason is that these functions might not be available for embedded systems on the target machine.
 Another reason is that the environment may have optimized or specialized memory allocation functions.


### PR DESCRIPTION
error in the standard text section 2_1_common_api.adoc
void pointer is incorrect here. It should say (as above in other cases) "null" pointer