### PR TITLE
Use "discrete" as default variability for non-Float variables

### DIFF
--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -866,7 +866,7 @@ CoSimulation: By convention, the variable is from a "real" sampled data system a
 ModelExchange: No restrictions on value changes. +
 CoSimulation: By convention, the variable is from a differential
 
-The default is `"continuous"`.
+The default is `"continuous"` for variables of type `Float32` and `Float64`, and `"discrete"` for all other types.
 
 _[Note that the information about continuous states is defined with element `fmiModelDescription.ModelStructure.Derivatives`.]_
 


### PR DESCRIPTION
to be consistent with the previous rule that only Float32/64 (previously Real)
can be "continuous"