### PR TITLE
Add hybrid co-simulation functions and types

### DIFF
--- a/docs/4_2_co-simulation_api.adoc
+++ b/docs/4_2_co-simulation_api.adoc
@@ -90,30 +90,11 @@ An alternative is to wait until the callback function `fmi3StepFinished` is call
 `fmi3CancelStep` can be called to cancel the current computation.
 It is not allowed to call any other function during a pending `fmi3DoStep`.
 
-[source, C]
-----
-include::../headers/fmi3FunctionTypes.h[tags=CancelStep]
-----
-
-Can be called if `fmi3DoStep` returned `fmi3Pending` in order to stop the current asynchronous execution.
-The master calls this function if, for example, the co-simulation run is stopped by the user or one of the slaves.
-Afterwards only calls to `fmi3Reset`, `fmi3FreeInstance`, or `fmi3SetFMUState` are valid to exit the *step Canceled* state.
-Refer to <<state-machine-co-simulation>> for all other valid functions in this state.
-
 It depends on the capabilities of the slave which parameter constellations and calling sequences are allowed (see <<CoSimulation>>)
 
 ==== Retrieving Status Information from the Slave [[retrieving-status-from-slave]]
 
-Status information is retrieved from the slave by the following functions:
-
-[source, C]
-----
-include::../headers/fmi3FunctionTypes.h[tags=GetDoStepPendingStatus]
-----
-
-Can be called when the `fmi3DoStep` function returned `fmi3Pending`.
-`status` is the result of the asynchronously executed `fmi3DoStep` call or `fmi3Pending` if the computation is not finished.
-`message` is a pointer to string which informs about the status of the currently running asynchronous `fmi3DoStep` computation.
+Status information is retrieved from the slave by the following function:
 
 [source, C]
 ----

--- a/headers/fmi3FunctionTypes.h
+++ b/headers/fmi3FunctionTypes.h
@@ -61,7 +61,6 @@ typedef enum {
     fmi3Discard,
     fmi3Error,
     fmi3Fatal,
-    fmi3Pending
 } fmi3Status;
 /* end::Status[] */
 
@@ -71,6 +70,23 @@ typedef enum {
     fmi3CoSimulation
 } fmi3InterfaceType;
 /* end::InterfaceType[] */
+
+/* tag::CoSimulationMode[] */
+typedef enum {
+    fmi3ModeCoSimulation,
+    fmi3ModeHybridCoSimulation,
+    fmi3ModeScheduledExecutionSimulation
+} fmi3CoSimulationMode;
+/* end::CoSimulationMode[] */
+
+/* tag::CoSimulationConfiguration[] */
+typedef struct{
+    fmi3Boolean intermediateVariableGet;
+    fmi3Boolean intermediateInternalVariableGet;
+    fmi3Boolean intermediateVariableSet;
+    fmi3CoSimulationMode coSimulationMode;
+} fmi3CoSimulationConfiguration;
+/* end::CoSimulationConfiguration[] */
 
 /* tag::DependencyKind[] */
 typedef enum {
@@ -83,6 +99,18 @@ typedef enum {
 } fmi3DependencyKind;
 /* end::DependencyKind[] */
 
+/* tag::IntermediateUpdateInfo[] */
+typedef struct{
+    fmi3Float64 intermediateUpdateTime; 
+    fmi3Boolean eventOccurred;
+    fmi3Boolean clocksTicked;
+    fmi3Boolean intermediateVariableSetAllowed;
+    fmi3Boolean intermediateVariableGetAllowed;
+    fmi3Boolean intermediateStepFinished;
+    fmi3Boolean canReturnEarly;
+} fmi3IntermediateUpdateInfo;
+/* end::IntermediateUpdateInfo[] */
+
 /* tag::CallbackFunctions[] */
 typedef void  (*fmi3CallbackLogMessage)     (fmi3InstanceEnvironment instanceEnvironment,
                                              fmi3String instanceName,
@@ -94,15 +122,24 @@ typedef void* (*fmi3CallbackAllocateMemory) (fmi3InstanceEnvironment instanceEnv
                                              size_t size);
 typedef void  (*fmi3CallbackFreeMemory)     (fmi3InstanceEnvironment instanceEnvironment,
                                              void* obj);
-typedef void  (*fmi3CallbackStepFinished)   (fmi3InstanceEnvironment instanceEnvironment,
-                                             fmi3Status status);
+
+/* tag::CallbackIntermediateUpdate[] */
+typedef fmi3Status (*fmi3CallbackIntermediateUpdate) (fmi3InstanceEnvironment instanceEnvironment,
+                                                      fmi3IntermediateUpdateInfo* intermediateUpdateInfo);
+/* end::CallbackIntermediateUpdate[] */
+/* tag::PreemptionLock[] */
+typedef void       (*fmi3CallbackStartPreemptionLock)   ();
+typedef void       (*fmi3CallbackStopPreemptionLock)    ();
+/* end::PreemptionLock[] */
 
 typedef struct {
     fmi3CallbackLogMessage     logMessage;
     fmi3CallbackAllocateMemory allocateMemory;
     fmi3CallbackFreeMemory     freeMemory;
-    fmi3CallbackStepFinished   stepFinished;
     fmi3InstanceEnvironment    instanceEnvironment;
+    fmi3CallbackIntermediateUpdate  intermediateUpdate;
+    fmi3CallbackStartPreemptionLock startPreemptionLock;
+    fmi3CallbackStopPreemptionLock  stopPreemptionLock;
 } fmi3CallbackFunctions;
 /* end::CallbackFunctions[] */
 
@@ -149,14 +186,15 @@ typedef fmi3Instance fmi3InstantiateTYPE(fmi3String        instanceName,
                                          fmi3String        fmuResourceLocation,
                                          const fmi3CallbackFunctions* functions,
                                          fmi3Boolean       visible,
-                                         fmi3Boolean       loggingOn);
+                                         fmi3Boolean       loggingOn,
+                                         const fmi3CoSimulationConfiguration* fmuCoSimulationConfiguration);
 /* end::Instantiate[] */
 
 /* tag::FreeInstance[] */
 typedef void fmi3FreeInstanceTYPE(fmi3Instance instance);
 /* end::FreeInstance[] */
 
-/* Enter and exit initialization mode, terminate and reset */
+/* Enter and exit initialization mode, enter event mode, terminate and reset */
 /* tag::SetupExperiment[] */
 typedef fmi3Status fmi3SetupExperimentTYPE(fmi3Instance instance,
                                            fmi3Boolean toleranceDefined,
@@ -173,6 +211,10 @@ typedef fmi3Status fmi3EnterInitializationModeTYPE(fmi3Instance instance);
 /* tag::ExitInitializationMode[] */
 typedef fmi3Status fmi3ExitInitializationModeTYPE(fmi3Instance instance);
 /* end::ExitInitializationMode[] */
+
+/* tag::EnterEventMode[] */
+typedef fmi3Status fmi3EnterEventModeTYPE(fmi3Instance instance);
+/* end::EnterEventMode[] */
 
 /* tag::Terminate[] */
 typedef fmi3Status fmi3TerminateTYPE(fmi3Instance instance);
@@ -237,6 +279,23 @@ typedef fmi3Status fmi3GetBinaryTYPE (fmi3Instance instance,
                                       size_t sizes[], fmi3Binary values[], size_t nValues);
 /* end::Getters[] */
 
+/* tag::GetClock[] */
+typedef fmi3Status fmi3GetClockTYPE(fmi3Instance instance, 
+                                    const fmi3ValueReference valueReferences[], size_t nValueReferences, 
+                                    fmi3Boolean value[]);
+/* end::GetClock[] */
+
+/* tag::GetInterval[] */
+typedef fmi3Status fmi3GetIntervalDecimalTYPE(fmi3Instance instance, 
+                                              const fmi3ValueReference valueReferences[], size_t nValueReferences, 
+                                              fmi3Float64 interval[]);
+
+typedef fmi3Status fmi3GetIntervalFractionTYPE(fmi3Instance instance, 
+                                               const fmi3ValueReference valueReferences[], size_t nValueReferences, 
+                                               fmi3UInt64 intervalCounter[], fmi3UInt64 resolution[]);
+/* end::GetInterval[] */
+
+
 /* tag::Setters[] */
 typedef fmi3Status fmi3SetFloat32TYPE(fmi3Instance instance,
                                       const fmi3ValueReference valueReferences[], size_t nValueReferences,
@@ -290,6 +349,22 @@ typedef fmi3Status fmi3SetBinaryTYPE (fmi3Instance instance,
                                       const fmi3ValueReference valueReferences[], size_t nValueReferences,
                                       const size_t sizes[], const fmi3Binary values[], size_t nValues);
 /* end::Setters[] */
+
+/* tag::SetClock[] */
+typedef fmi3Status fmi3SetClockTYPE(fmi3Instance instance,
+                                    const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                    const fmi3Boolean value[], const fmi3Boolean *subactive);
+/* end::SetClock[] */
+
+/* tag::SetInterval[] */
+typedef fmi3Status fmi3SetIntervalDecimalTYPE(fmi3Instance instance,
+                                              const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                              fmi3Float64 interval[]);
+
+typedef fmi3Status fmi3SetIntervalFractionTYPE(fmi3Instance instance,
+                                               const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                               fmi3UInt64 intervalCounter[], fmi3UInt64 resolution[]);
+/* end::SetInterval[] */
 
 /* Getting Variable Dependency Information */
 
@@ -347,6 +422,8 @@ typedef fmi3Status fmi3GetDirectionalDerivativeTYPE(fmi3Instance instance,
                                                     size_t nDeltaOfUnknowns);
 /* end::GetDirectionalDerivative[] */
 
+/* Entering and exiting the Configuration or Reconfiguration Mode */
+
 /* tag::EnterConfigurationMode[] */
 typedef fmi3Status fmi3EnterConfigurationModeTYPE(fmi3Instance instance);
 /* end::EnterConfigurationMode[] */
@@ -355,20 +432,14 @@ typedef fmi3Status fmi3EnterConfigurationModeTYPE(fmi3Instance instance);
 typedef fmi3Status fmi3ExitConfigurationModeTYPE(fmi3Instance instance);
 /* end::ExitConfigurationMode[] */
 
-/***************************************************
-Types for Functions for FMI3 for Model Exchange
-****************************************************/
-
-/* Enter and exit the different modes */
-
-/* tag::EnterEventMode[] */
-typedef fmi3Status fmi3EnterEventModeTYPE(fmi3Instance instance);
-/* end::EnterEventMode[] */
-
 /* tag::NewDiscreteStates[] */
 typedef fmi3Status fmi3NewDiscreteStatesTYPE(fmi3Instance instance,
                                              fmi3EventInfo* eventInfo);
 /* end::NewDiscreteStates[] */
+
+/***************************************************
+Types for Functions for FMI3 for Model Exchange
+****************************************************/
 
 /* tag::EnterContinuousTimeMode[] */
 typedef fmi3Status fmi3EnterContinuousTimeModeTYPE(fmi3Instance instance);
@@ -431,6 +502,10 @@ Types for Functions for FMI3 for Co-Simulation
 
 /* Simulating the slave */
 
+/* tag::EnterStepMode[] */
+typedef fmi3Status fmi3EnterStepModeTYPE(fmi3Instance instance);
+/* end::EnterStepMode[] */
+
 /* tag::SetInputDerivatives[] */
 typedef fmi3Status fmi3SetInputDerivativesTYPE(fmi3Instance instance,
                                                const fmi3ValueReference valueReferences[],
@@ -453,20 +528,19 @@ typedef fmi3Status fmi3GetOutputDerivativesTYPE(fmi3Instance instance,
 typedef fmi3Status fmi3DoStepTYPE(fmi3Instance instance,
                                   fmi3Float64 currentCommunicationPoint,
                                   fmi3Float64 communicationStepSize,
-                                  fmi3Boolean noSetFMUStatePriorToCurrentPoint);
+                                  fmi3Boolean noSetFMUStatePriorToCurrentPoint,
+                                  fmi3Boolean* earlyReturn);
 /* end::DoStep[] */
 
-/* tag::CancelStep[] */
-typedef fmi3Status fmi3CancelStepTYPE(fmi3Instance instance);
-/* end::CancelStep[] */
+/* tag::ActivateModelPartition[] */
+typedef fmi3Status fmi3ActivateModelPartitionTYPE(fmi3Instance instance,
+                                                  fmi3ValueReference clockReference,
+                                                  fmi3Float64 activationTime);
+/* end::ActivateModelPartition[] */
 
-/* Inquire slave status */
-
-/* tag::GetDoStepPendingStatus[] */
-typedef fmi3Status fmi3GetDoStepPendingStatusTYPE(fmi3Instance instance,
-                                                  fmi3Status* status,
-                                                  fmi3String* message);
-/* end::GetDoStepPendingStatus[] */
+/* tag::DoEarlyReturn[] */
+typedef fmi3Status fmi3DoEarlyReturnTYPE(fmi3Instance instance, fmi3Float64 earlyReturnTime);
+/* end::DoEarlyReturn[] */
 
 /* tag::GetDoStepDiscardedStatus[] */
 typedef fmi3Status fmi3GetDoStepDiscardedStatusTYPE(fmi3Instance instance,

--- a/headers/fmi3Functions.h
+++ b/headers/fmi3Functions.h
@@ -105,6 +105,7 @@ Common Functions
 #define fmi3SetupExperiment          fmi3FullName(fmi3SetupExperiment)
 #define fmi3EnterInitializationMode  fmi3FullName(fmi3EnterInitializationMode)
 #define fmi3ExitInitializationMode   fmi3FullName(fmi3ExitInitializationMode)
+#define fmi3EnterEventMode           fmi3FullName(fmi3EnterEventMode)
 #define fmi3Terminate                fmi3FullName(fmi3Terminate)
 #define fmi3Reset                    fmi3FullName(fmi3Reset)
 #define fmi3GetFloat32               fmi3FullName(fmi3GetFloat32)
@@ -145,12 +146,20 @@ Common Functions
 #define fmi3EnterConfigurationMode   fmi3FullName(fmi3EnterConfigurationMode)
 #define fmi3ExitConfigurationMode    fmi3FullName(fmi3ExitConfigurationMode)
 
+#define fmi3SetClock                      fmi3FullName(fmi3SetClock)
+#define fmi3GetClock                      fmi3FullName(fmi3GetClock)
+#define fmi3GetIntervalDecimal            fmi3FullName(fmi3GetIntervalDecimal)
+#define fmi3SetIntervalDecimal            fmi3FullName(fmi3SetIntervalDecimal)
+#define fmi3GetIntervalFraction           fmi3FullName(fmi3GetIntervalFraction)
+#define fmi3SetIntervalFraction           fmi3FullName(fmi3SetIntervalFraction)
+#define fmi3NewDiscreteStates             fmi3FullName(fmi3NewDiscreteStates)
+
+
+
 /***************************************************
 Functions for FMI3 for Model Exchange
 ****************************************************/
 
-#define fmi3EnterEventMode                fmi3FullName(fmi3EnterEventMode)
-#define fmi3NewDiscreteStates             fmi3FullName(fmi3NewDiscreteStates)
 #define fmi3EnterContinuousTimeMode       fmi3FullName(fmi3EnterContinuousTimeMode)
 #define fmi3CompletedIntegratorStep       fmi3FullName(fmi3CompletedIntegratorStep)
 #define fmi3SetTime                       fmi3FullName(fmi3SetTime)
@@ -166,15 +175,16 @@ Functions for FMI3 for Model Exchange
 Functions for FMI3 for Co-Simulation
 ****************************************************/
 
+#define fmi3EnterStepMode                fmi3FullName(fmi3EnterStepMode)
 #define fmi3SetInputDerivatives          fmi3FullName(fmi3SetInputDerivatives)
 #define fmi3GetOutputDerivatives         fmi3FullName(fmi3GetOutputDerivatives)
 #define fmi3DoStep                       fmi3FullName(fmi3DoStep)
-#define fmi3CancelStep                   fmi3FullName(fmi3CancelStep)
-#define fmi3GetDoStepPendingStatus       fmi3FullName(fmi3GetDoStepPendingStatus)
+#define fmi3ActivateModelPartition       fmi3FullName(fmi3ActivateModelPartition)
+#define fmi3DoEarlyReturn                fmi3FullName(fmi3DoEarlyReturn)
 #define fmi3GetDoStepDiscardedStatus     fmi3FullName(fmi3GetDoStepDiscardedStatus)
 
 /* Version number */
-#define fmi3Version "3.0-wg003.3"
+#define fmi3Version "3.0-wg007.0"
 
 /***************************************************
 Common Functions
@@ -192,6 +202,7 @@ FMI3_Export fmi3FreeInstanceTYPE fmi3FreeInstance;
 FMI3_Export fmi3SetupExperimentTYPE         fmi3SetupExperiment;
 FMI3_Export fmi3EnterInitializationModeTYPE fmi3EnterInitializationMode;
 FMI3_Export fmi3ExitInitializationModeTYPE  fmi3ExitInitializationMode;
+FMI3_Export fmi3EnterEventModeTYPE          fmi3EnterEventMode;
 FMI3_Export fmi3TerminateTYPE               fmi3Terminate;
 FMI3_Export fmi3ResetTYPE                   fmi3Reset;
 
@@ -244,13 +255,21 @@ FMI3_Export fmi3GetDirectionalDerivativeTYPE fmi3GetDirectionalDerivative;
 FMI3_Export fmi3EnterConfigurationModeTYPE fmi3EnterConfigurationMode;
 FMI3_Export fmi3ExitConfigurationModeTYPE  fmi3ExitConfigurationMode;
 
+/* Clock related functions */
+FMI3_Export fmi3SetClockTYPE                fmi3SetClock;
+FMI3_Export fmi3GetClockTYPE                fmi3GetClock;
+FMI3_Export fmi3GetIntervalDecimalTYPE      fmi3GetIntervalDecimal;
+FMI3_Export fmi3SetIntervalDecimalTYPE      fmi3SetIntervalDecimal;
+FMI3_Export fmi3GetIntervalFractionTYPE     fmi3GetIntervalFraction;
+FMI3_Export fmi3SetIntervalFractionTYPE     fmi3SetIntervalFraction;
+FMI3_Export fmi3NewDiscreteStatesTYPE       fmi3NewDiscreteStates;
+
+
 /***************************************************
 Functions for FMI3 for Model Exchange
 ****************************************************/
 
-/* Enter and exit the different modes */
-FMI3_Export fmi3EnterEventModeTYPE               fmi3EnterEventMode;
-FMI3_Export fmi3NewDiscreteStatesTYPE            fmi3NewDiscreteStates;
+
 FMI3_Export fmi3EnterContinuousTimeModeTYPE      fmi3EnterContinuousTimeMode;
 FMI3_Export fmi3CompletedIntegratorStepTYPE      fmi3CompletedIntegratorStep;
 
@@ -271,15 +290,17 @@ Functions for FMI3 for Co-Simulation
 ****************************************************/
 
 /* Simulating the slave */
+FMI3_Export fmi3EnterStepModeTYPE        fmi3EnterStepMode;
 FMI3_Export fmi3SetInputDerivativesTYPE  fmi3SetInputDerivatives;
 FMI3_Export fmi3GetOutputDerivativesTYPE fmi3GetOutputDerivatives;
 
-FMI3_Export fmi3DoStepTYPE     fmi3DoStep;
-FMI3_Export fmi3CancelStepTYPE fmi3CancelStep;
+FMI3_Export fmi3ActivateModelPartitionTYPE     fmi3ActivateModelPartition;
+FMI3_Export fmi3DoStepTYPE                     fmi3DoStep;
+
+FMI3_Export fmi3DoEarlyReturnTYPE              fmi3DoEarlyReturn;
 
 /* Inquire slave status */
-FMI3_Export fmi3GetDoStepPendingStatusTYPE   fmi3GetDoStepPendingStatus;
-FMI3_Export fmi3GetDoStepDiscardedStatusTYPE fmi3GetDoStepDiscardedStatus;
+FMI3_Export fmi3GetDoStepDiscardedStatusTYPE   fmi3GetDoStepDiscardedStatus;
 
 #ifdef __cplusplus
 }  /* end of extern "C" { */

--- a/headers/fmi3PlatformTypes.h
+++ b/headers/fmi3PlatformTypes.h
@@ -78,6 +78,7 @@ typedef char            fmi3Byte;     /* Smallest addressable unit of the machin
                                          (typically one byte) */
 typedef const fmi3Byte* fmi3Binary;   /* Data type for binary data
                                          (out-of-band length terminated) */
+typedef int             fmi3Clock;    /* Data type to be used for activating clocks with fmi3True and fmi3False */
 
 /* Values for fmi3Boolean */
 #define fmi3True  1

--- a/schema/fmi3AttributeGroups.xsd
+++ b/schema/fmi3AttributeGroups.xsd
@@ -104,4 +104,20 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		<xs:attribute name="derivative" type="xs:unsignedInt"/>
 		<xs:attribute name="reinit" type="xs:boolean" use="optional" default="false"/>
 	</xs:attributeGroup>
+	<xs:attributeGroup name="fmi3ClockAttributes">
+		<xs:attribute name="clockType" use="required">
+			<xs:simpleType>
+				<xs:restriction base="xs:normalizedString">
+					<xs:enumeration value="STClocks"/>
+					<xs:enumeration value="CPClocks"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="priority" type="xs:int" use="required"/>
+		<xs:attribute name="periodic" type="xs:boolean" use="optional"/>
+		<xs:attribute name="strict" type="xs:boolean" use="optional"/>
+		<xs:attribute name="intervalCounter" type="xs:unsignedLong" use="optional"/>
+		<xs:attribute name="shiftCounter" type="xs:unsignedLong" use="optional"/>
+		<xs:attribute name="resolution" type="xs:unsignedLong" use="optional"/>
+	</xs:attributeGroup>
 </xs:schema>

--- a/schema/fmi3ModelDescription.xsd
+++ b/schema/fmi3ModelDescription.xsd
@@ -59,7 +59,11 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 									<xs:attribute name="canHandleVariableCommunicationStepSize" type="xs:boolean" default="false"/>
 									<xs:attribute name="canInterpolateInputs" type="xs:boolean" default="false"/>
 									<xs:attribute name="maxOutputDerivativeOrder" type="xs:unsignedInt" default="0"/>
-									<xs:attribute name="canRunAsynchronuously" type="xs:boolean" default="false"/>
+									<xs:attribute name="providesIntermediateVariableAccess" type="xs:boolean" default="false"/>
+									<xs:attribute name="canReturnEarlyAfterIntermediateUpdate" type="xs:boolean" default="false"/>
+									<xs:attribute name="providesHybridCoSimulation" type="xs:boolean" default="false"/>
+									<xs:attribute name="providesScheduledExecutionSimulation" type="xs:boolean" default="false"/>
+									<xs:attribute name="canNotUseBasicCoSimulation" type="xs:boolean" default="false"/>
 								</xs:extension>
 							</xs:complexContent>
 						</xs:complexType>

--- a/schema/fmi3Type.xsd
+++ b/schema/fmi3Type.xsd
@@ -163,6 +163,15 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 					</xs:complexContent>
 				</xs:complexType>
 			</xs:element>
+			<xs:element name="Clock">
+				<xs:complexType>
+					<xs:complexContent>
+						<xs:extension base="fmi3TypeDefintionBase">
+							<xs:attributeGroup ref="fmi3ClockAttributes"/>
+						</xs:extension>
+					</xs:complexContent>
+				</xs:complexType>
+			</xs:element>
 		</xs:choice>
 	</xs:group>
 </xs:schema>

--- a/schema/fmi3Variable.xsd
+++ b/schema/fmi3Variable.xsd
@@ -269,6 +269,18 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
+	<xs:complexType name="fmi3Clock">
+		<xs:complexContent>
+			<xs:extension base="fmi3VariableBase">
+				<xs:attributeGroup ref="fmi3ClockAttributes"/>
+				<xs:attribute name="start" type="xs:boolean">
+					<xs:annotation>
+						<xs:documentation>Value before initialization, if initial=exact </xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>	
 	<xs:complexType name="fmi3VariableBase" abstract="true">
 		<xs:sequence>
 			<xs:element name="Dimension" minOccurs="0" maxOccurs="unbounded">
@@ -292,6 +304,8 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 					<xs:enumeration value="local"/>
 					<xs:enumeration value="independent"/>
 					<xs:enumeration value="structuralParameter"/>
+					<xs:enumeration value="inferred"/>
+					<xs:enumeration value="triggered"/>
 				</xs:restriction>
 			</xs:simpleType>
 		</xs:attribute>
@@ -303,6 +317,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 					<xs:enumeration value="tunable"/>
 					<xs:enumeration value="discrete"/>
 					<xs:enumeration value="continuous"/>
+					<xs:enumeration value="clock"/>
 				</xs:restriction>
 			</xs:simpleType>
 		</xs:attribute>
@@ -317,6 +332,8 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		</xs:attribute>
 		<xs:attribute name="canHandleMultipleSetPerTimeInstant" type="xs:boolean"/>
 		<xs:attribute name="declaredType" type="xs:normalizedString"/>
+		<xs:attribute name="clockReference" type="xs:unsignedInt" use="optional"/>
+		<xs:attribute name="intermediateAccess" type="xs:boolean" use="optional"/>
 	</xs:complexType>
 
 	<xs:group name="fmi3Variable">
@@ -335,6 +352,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<xs:element name="String" type="fmi3String"/>
 			<xs:element name="Binary" type="fmi3Binary"/>
 			<xs:element name="Enumeration" type="fmi3Enumeration"/>
+			<xs:element name="Clock" type="fmi3Clock"/>
 		</xs:choice>
 	</xs:group>
 </xs:schema>


### PR DESCRIPTION
to headers and schema. This commit adds the technical infrastructure of
FCP007: Hybrid Co-Simulation
FCP010: Intermediate Outputs
FCP015: Intermediate Variable Access