### PR TITLE
Move BuildConfiguration to fmiModelDescription

### DIFF
--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -214,6 +214,9 @@ The `BuildConfiguration` provides the necessary information to compile and link 
 |Attribute
 |Description
 
+|modelIdentifier
+|The `modelIdentifier` of the `ModelExchange` or `CoSimulation` elements this build configuration is associated with.
+
 |platform
 |Platform tuple of the platform the build configuration is intended for (e.g. `x86_64-linux`)
 
@@ -331,16 +334,14 @@ The characters `>` (greater-than) and `<` (less-than) must be escaped as `&gt;` 
 .A minimal build configuration
 [source, xml]
 ----
-include::examples/build_configuration.xml[tags=ModelExchange]
+include::examples/build_configuration.xml[tags=PIDContoller]
 ----
 
 .Multiple complex build configurations
 [source, xml]
 ----
-include::examples/build_configuration.xml[tags=CoSimulation]
+include::examples/build_configuration.xml[tags=PlantModel]
 ----
-<1> Generic build configuration for desktop platforms
-<2> Build configuration for a specialized real-time board
 
 ==== Definition of Units (UnitDefinitions)
 

--- a/docs/examples/build_configuration.xml
+++ b/docs/examples/build_configuration.xml
@@ -4,54 +4,49 @@
   modelName=""
   instantiationToken="">
 
-<!-- tag::ModelExchange[] -->
-<ModelExchange modelIdentifier="PIDContoller">
-  <BuildConfiguration>
-    <SourceFileSet>
-      <SourceFile name="all.c"/>
-    </SourceFileSet>
-  </BuildConfiguration>
-</ModelExchange>
-<!-- end::ModelExchange[] -->
+  <ModelExchange modelIdentifier="PIDContoller"/>
 
-<!-- tag::CoSimulation[] -->
-<CoSimulation modelIdentifier="PlantModel">
-  <BuildConfiguration description="Build configuration for desktop platforms"> <!--1-->
-    <SourceFileSet language="C99">
-      <SourceFile name="fmi3Functions.c"/>
-      <SourceFile name="solver.c"/>
-    </SourceFileSet>
-    <SourceFileSet language="C++11">
-      <SourceFile name="model.c"/>
-      <SourceFile name="logging/src/logger.c"/>
-      <PreprocessorDefinition name="FMI_VERSION" value="3"/>
-      <PreprocessorDefinition name="LOG_TO_FILE" optional="true"/>
-      <PreprocessorDefinition name="LOG_LEVEL" value="0" optional="true">
-        <Option value="0" description="Log infos, warnings and errors"/>
-        <Option value="1" description="Log warnings and errors"/>
-        <Option value="2" description="Log only errors"/>
-      </PreprocessorDefinition>
-      <IncludeDirectory name="logging/include"/>
-    </SourceFileSet>
-    <Library name="hdf5" version="&gt;=1.8,!=1.8.17,&lt;1.10" external="true" description="HDF5"/>
-  </BuildConfiguration>
-  <BuildConfiguration platform="aarch64-linux" description=""> <!--2-->
-    <SourceFileSet language="C99">
-      <SourceFile name="fmi3Functions.c"/>
-    </SourceFileSet>
-    <SourceFileSet language="C++11" compiler="clang++" compilerOptions="-fno-rtti"> <!--3-->
-      <SourceFile name="model.c"/>
-      <PreprocessorDefinition name="NO_FILE_SYSTEM"/>
-    </SourceFileSet>
-    <Library name="libm.a" description="OpenLibm math library"/> <!--4-->
-  </BuildConfiguration>
-  <VendorAnnotations>
-    <Tool name="SimTool">
-      <License name="multi_thread"/>
-    </Tool>
-  </VendorAnnotations>
-</CoSimulation>
-<!-- end::CoSimulation[] -->
+  <CoSimulation modelIdentifier="PlantModel"/>
+
+<!-- tag::PIDContoller[] -->
+<BuildConfiguration modelIdentifier="PIDContoller">
+  <SourceFileSet>
+    <SourceFile name="all.c"/>
+  </SourceFileSet>
+</BuildConfiguration>
+<!-- end::PIDContoller[] -->
+
+<!-- tag::PlantModel[] -->
+<BuildConfiguration modelIdentifier="PlantModel" description="Build configuration for desktop platforms">
+  <SourceFileSet language="C99">
+    <SourceFile name="fmi3Functions.c"/>
+    <SourceFile name="solver.c"/>
+  </SourceFileSet>
+  <SourceFileSet language="C++11">
+    <SourceFile name="model.c"/>
+    <SourceFile name="logging/src/logger.c"/>
+    <PreprocessorDefinition name="FMI_VERSION" value="3"/>
+    <PreprocessorDefinition name="LOG_TO_FILE" optional="true"/>
+    <PreprocessorDefinition name="LOG_LEVEL" value="0" optional="true">
+      <Option value="0" description="Log infos, warnings and errors"/>
+      <Option value="1" description="Log warnings and errors"/>
+      <Option value="2" description="Log only errors"/>
+    </PreprocessorDefinition>
+    <IncludeDirectory name="logging/include"/>
+  </SourceFileSet>
+  <Library name="hdf5" version="&gt;=1.8,!=1.8.17,&lt;1.10" external="true" description="HDF5"/>
+</BuildConfiguration>
+<BuildConfiguration modelIdentifier="PlantModel" platform="aarch64-linux">
+  <SourceFileSet language="C99">
+    <SourceFile name="fmi3Functions.c"/>
+  </SourceFileSet>
+  <SourceFileSet language="C++11" compiler="clang++" compilerOptions="-fno-rtti">
+    <SourceFile name="model.c"/>
+    <PreprocessorDefinition name="NO_FILE_SYSTEM"/>
+  </SourceFileSet>
+  <Library name="libm.a" description="OpenLibm math library"/>
+</BuildConfiguration>
+<!-- end::PlantModel[] -->
 
   <ModelVariables>
     <Float64 name="x" valueReference="0"/>

--- a/schema/fmi3FMUType.xsd
+++ b/schema/fmi3FMUType.xsd
@@ -37,57 +37,6 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	<xs:include schemaLocation="fmi3Annotation.xsd"/>
 	<xs:complexType name="fmi3FMUType">
 		<xs:sequence minOccurs="0">
-			<xs:element name="BuildConfiguration" minOccurs="0" maxOccurs="unbounded">
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element name="SourceFileSet" minOccurs="0" maxOccurs="unbounded">
-							<xs:complexType>
-								<xs:sequence>
-									<xs:element name="SourceFile" maxOccurs="unbounded">
-										<xs:complexType>
-											<xs:attribute name="name" type="xs:normalizedString" use="required"/>
-										</xs:complexType>
-									</xs:element>
-									<xs:element name="PreprocessorDefinition" minOccurs="0" maxOccurs="unbounded">
-										<xs:complexType>
-											<xs:sequence>
-												<xs:element name="Option" minOccurs="0" maxOccurs="unbounded">
-													<xs:complexType>
-														<xs:attribute name="value" type="xs:normalizedString"/>
-														<xs:attribute name="description" type="xs:string"/>
-													</xs:complexType>
-												</xs:element>
-											</xs:sequence>
-											<xs:attribute name="name" type="xs:normalizedString" use="required"/>
-											<xs:attribute name="optional" type="xs:boolean" default="false"/>
-											<xs:attribute name="value" type="xs:normalizedString"/>
-											<xs:attribute name="description" type="xs:string"/>
-										</xs:complexType>
-									</xs:element>
-									<xs:element name="IncludeDirectory" minOccurs="0" maxOccurs="unbounded">
-										<xs:complexType>
-											<xs:attribute name="name" type="xs:normalizedString" use="required"/>
-										</xs:complexType>
-									</xs:element>
-								</xs:sequence>
-								<xs:attribute name="language" type="xs:normalizedString"/>
-								<xs:attribute name="compiler" type="xs:normalizedString"/>
-								<xs:attribute name="compilerOptions" type="xs:string"/>
-							</xs:complexType>
-						</xs:element>
-						<xs:element name="Library" minOccurs="0" maxOccurs="unbounded">
-							<xs:complexType>
-								<xs:attribute name="name" type="xs:normalizedString" use="required"/>
-								<xs:attribute name="version" type="xs:normalizedString"/>
-								<xs:attribute name="external" type="xs:boolean" default="false"/>
-								<xs:attribute name="description" type="xs:string"/>
-							</xs:complexType>
-						</xs:element>
-					</xs:sequence>
-					<xs:attribute name="platform" type="xs:normalizedString"/>
-					<xs:attribute name="description" type="xs:string"/>
-				</xs:complexType>
-			</xs:element>
 			<xs:element name="VendorAnnotations" type="fmi3Annotation" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="modelIdentifier" type="xs:normalizedString" use="required"/>

--- a/schema/fmi3ModelDescription.xsd
+++ b/schema/fmi3ModelDescription.xsd
@@ -65,6 +65,58 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 						</xs:complexType>
 					</xs:element>
 				</xs:sequence>
+				<xs:element name="BuildConfiguration" minOccurs="0" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="SourceFileSet" minOccurs="0" maxOccurs="unbounded">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="SourceFile" maxOccurs="unbounded">
+											<xs:complexType>
+												<xs:attribute name="name" type="xs:normalizedString" use="required"/>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="PreprocessorDefinition" minOccurs="0" maxOccurs="unbounded">
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="Option" minOccurs="0" maxOccurs="unbounded">
+														<xs:complexType>
+															<xs:attribute name="value" type="xs:normalizedString"/>
+															<xs:attribute name="description" type="xs:string"/>
+														</xs:complexType>
+													</xs:element>
+												</xs:sequence>
+												<xs:attribute name="name" type="xs:normalizedString" use="required"/>
+												<xs:attribute name="optional" type="xs:boolean" default="false"/>
+												<xs:attribute name="value" type="xs:normalizedString"/>
+												<xs:attribute name="description" type="xs:string"/>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="IncludeDirectory" minOccurs="0" maxOccurs="unbounded">
+											<xs:complexType>
+												<xs:attribute name="name" type="xs:normalizedString" use="required"/>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+									<xs:attribute name="language" type="xs:normalizedString"/>
+									<xs:attribute name="compiler" type="xs:normalizedString"/>
+									<xs:attribute name="compilerOptions" type="xs:string"/>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="Library" minOccurs="0" maxOccurs="unbounded">
+								<xs:complexType>
+									<xs:attribute name="name" type="xs:normalizedString" use="required"/>
+									<xs:attribute name="version" type="xs:normalizedString"/>
+									<xs:attribute name="external" type="xs:boolean" default="false"/>
+									<xs:attribute name="description" type="xs:string"/>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="modelIdentifier" type="xs:normalizedString" use="required"/>
+						<xs:attribute name="platform" type="xs:normalizedString"/>
+						<xs:attribute name="description" type="xs:string"/>
+					</xs:complexType>
+				</xs:element>
 				<xs:element name="UnitDefinitions" minOccurs="0">
 					<xs:complexType>
 						<xs:sequence maxOccurs="unbounded">


### PR DESCRIPTION
to avoid redundant BuildConfigurations and allow recreation of a
shared or static library from source that supports both Co-Simulation
AND Model Exchange. The build configuration is associated with the
respective interface type element via the "modelIdentifier" attribute.