### PR TITLE
Add Clocks & Hybrid Co-Simulation API

### DIFF
--- a/headers/fmi3Functions.h
+++ b/headers/fmi3Functions.h
@@ -105,6 +105,7 @@ Common Functions
 #define fmi3SetupExperiment          fmi3FullName(fmi3SetupExperiment)
 #define fmi3EnterInitializationMode  fmi3FullName(fmi3EnterInitializationMode)
 #define fmi3ExitInitializationMode   fmi3FullName(fmi3ExitInitializationMode)
+#define fmi3EnterEventMode           fmi3FullName(fmi3EnterEventMode)
 #define fmi3Terminate                fmi3FullName(fmi3Terminate)
 #define fmi3Reset                    fmi3FullName(fmi3Reset)
 #define fmi3GetFloat32               fmi3FullName(fmi3GetFloat32)
@@ -144,13 +145,18 @@ Common Functions
 #define fmi3GetDirectionalDerivative fmi3FullName(fmi3GetDirectionalDerivative)
 #define fmi3EnterConfigurationMode   fmi3FullName(fmi3EnterConfigurationMode)
 #define fmi3ExitConfigurationMode    fmi3FullName(fmi3ExitConfigurationMode)
+#define fmi3SetClock                 fmi3FullName(fmi3SetClock)
+#define fmi3GetClock                 fmi3FullName(fmi3GetClock)
+#define fmi3GetIntervalDecimal       fmi3FullName(fmi3GetIntervalDecimal)
+#define fmi3SetIntervalDecimal       fmi3FullName(fmi3SetIntervalDecimal)
+#define fmi3GetIntervalFraction      fmi3FullName(fmi3GetIntervalFraction)
+#define fmi3SetIntervalFraction      fmi3FullName(fmi3SetIntervalFraction)
+#define fmi3NewDiscreteStates        fmi3FullName(fmi3NewDiscreteStates)
 
 /***************************************************
 Functions for FMI3 for Model Exchange
 ****************************************************/
 
-#define fmi3EnterEventMode                fmi3FullName(fmi3EnterEventMode)
-#define fmi3NewDiscreteStates             fmi3FullName(fmi3NewDiscreteStates)
 #define fmi3EnterContinuousTimeMode       fmi3FullName(fmi3EnterContinuousTimeMode)
 #define fmi3CompletedIntegratorStep       fmi3FullName(fmi3CompletedIntegratorStep)
 #define fmi3SetTime                       fmi3FullName(fmi3SetTime)
@@ -166,11 +172,12 @@ Functions for FMI3 for Model Exchange
 Functions for FMI3 for Co-Simulation
 ****************************************************/
 
+#define fmi3EnterStepMode                fmi3FullName(fmi3EnterStepMode)
 #define fmi3SetInputDerivatives          fmi3FullName(fmi3SetInputDerivatives)
 #define fmi3GetOutputDerivatives         fmi3FullName(fmi3GetOutputDerivatives)
 #define fmi3DoStep                       fmi3FullName(fmi3DoStep)
-#define fmi3CancelStep                   fmi3FullName(fmi3CancelStep)
-#define fmi3GetDoStepPendingStatus       fmi3FullName(fmi3GetDoStepPendingStatus)
+#define fmi3ActivateModelPartition       fmi3FullName(fmi3ActivateModelPartition)
+#define fmi3DoEarlyReturn                fmi3FullName(fmi3DoEarlyReturn)
 #define fmi3GetDoStepDiscardedStatus     fmi3FullName(fmi3GetDoStepDiscardedStatus)
 
 /* Version number */
@@ -192,6 +199,7 @@ FMI3_Export fmi3FreeInstanceTYPE fmi3FreeInstance;
 FMI3_Export fmi3SetupExperimentTYPE         fmi3SetupExperiment;
 FMI3_Export fmi3EnterInitializationModeTYPE fmi3EnterInitializationMode;
 FMI3_Export fmi3ExitInitializationModeTYPE  fmi3ExitInitializationMode;
+FMI3_Export fmi3EnterEventModeTYPE          fmi3EnterEventMode;
 FMI3_Export fmi3TerminateTYPE               fmi3Terminate;
 FMI3_Export fmi3ResetTYPE                   fmi3Reset;
 
@@ -244,13 +252,21 @@ FMI3_Export fmi3GetDirectionalDerivativeTYPE fmi3GetDirectionalDerivative;
 FMI3_Export fmi3EnterConfigurationModeTYPE fmi3EnterConfigurationMode;
 FMI3_Export fmi3ExitConfigurationModeTYPE  fmi3ExitConfigurationMode;
 
+/* Clock related functions */
+FMI3_Export fmi3SetClockTYPE                fmi3SetClock;
+FMI3_Export fmi3GetClockTYPE                fmi3GetClock;
+FMI3_Export fmi3GetIntervalDecimalTYPE      fmi3GetIntervalDecimal;
+FMI3_Export fmi3SetIntervalDecimalTYPE      fmi3SetIntervalDecimal;
+FMI3_Export fmi3GetIntervalFractionTYPE     fmi3GetIntervalFraction;
+FMI3_Export fmi3SetIntervalFractionTYPE     fmi3SetIntervalFraction;
+FMI3_Export fmi3NewDiscreteStatesTYPE       fmi3NewDiscreteStates;
+
+
 /***************************************************
 Functions for FMI3 for Model Exchange
 ****************************************************/
 
-/* Enter and exit the different modes */
-FMI3_Export fmi3EnterEventModeTYPE               fmi3EnterEventMode;
-FMI3_Export fmi3NewDiscreteStatesTYPE            fmi3NewDiscreteStates;
+
 FMI3_Export fmi3EnterContinuousTimeModeTYPE      fmi3EnterContinuousTimeMode;
 FMI3_Export fmi3CompletedIntegratorStepTYPE      fmi3CompletedIntegratorStep;
 
@@ -271,15 +287,17 @@ Functions for FMI3 for Co-Simulation
 ****************************************************/
 
 /* Simulating the slave */
+FMI3_Export fmi3EnterStepModeTYPE        fmi3EnterStepMode;
 FMI3_Export fmi3SetInputDerivativesTYPE  fmi3SetInputDerivatives;
 FMI3_Export fmi3GetOutputDerivativesTYPE fmi3GetOutputDerivatives;
 
-FMI3_Export fmi3DoStepTYPE     fmi3DoStep;
-FMI3_Export fmi3CancelStepTYPE fmi3CancelStep;
+FMI3_Export fmi3ActivateModelPartitionTYPE     fmi3ActivateModelPartition;
+FMI3_Export fmi3DoStepTYPE                     fmi3DoStep;
+
+FMI3_Export fmi3DoEarlyReturnTYPE              fmi3DoEarlyReturn;
 
 /* Inquire slave status */
-FMI3_Export fmi3GetDoStepPendingStatusTYPE   fmi3GetDoStepPendingStatus;
-FMI3_Export fmi3GetDoStepDiscardedStatusTYPE fmi3GetDoStepDiscardedStatus;
+FMI3_Export fmi3GetDoStepDiscardedStatusTYPE   fmi3GetDoStepDiscardedStatus;
 
 #ifdef __cplusplus
 }  /* end of extern "C" { */

--- a/headers/fmi3PlatformTypes.h
+++ b/headers/fmi3PlatformTypes.h
@@ -78,6 +78,7 @@ typedef char            fmi3Byte;     /* Smallest addressable unit of the machin
                                          (typically one byte) */
 typedef const fmi3Byte* fmi3Binary;   /* Data type for binary data
                                          (out-of-band length terminated) */
+typedef int             fmi3Clock;    /* Data type to be used for activating clocks with fmi3True and fmi3False */
 
 /* Values for fmi3Boolean */
 #define fmi3True  1

--- a/schema/fmi3AttributeGroups.xsd
+++ b/schema/fmi3AttributeGroups.xsd
@@ -104,4 +104,27 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		<xs:attribute name="derivative" type="xs:unsignedInt"/>
 		<xs:attribute name="reinit" type="xs:boolean" use="optional" default="false"/>
 	</xs:attributeGroup>
+	<xs:attributeGroup name="fmi3ClockAttributes">
+		<xs:attribute name="clockType" use="required">
+			<xs:simpleType>
+				<xs:restriction base="xs:normalizedString">
+					<xs:enumeration value="STClocks"/>
+					<xs:enumeration value="CPClocks"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="priority" use="required">
+			<xs:simpleType>
+				<xs:restriction base="xs:unsignedInt">
+					<xs:minInclusive value="0"></xs:minInclusive>
+					<xs:maxInclusive value="99"></xs:maxInclusive>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="periodic" type="xs:boolean" use="optional"/>
+		<xs:attribute name="strict" type="xs:boolean" use="optional"/>
+		<xs:attribute name="intervalCounter" type="xs:unsignedLong" use="optional"/>
+		<xs:attribute name="shiftCounter" type="xs:unsignedLong" use="optional"/>
+		<xs:attribute name="resolution" type="xs:unsignedLong" use="optional"/>
+	</xs:attributeGroup>
 </xs:schema>

--- a/schema/fmi3ModelDescription.xsd
+++ b/schema/fmi3ModelDescription.xsd
@@ -59,7 +59,11 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 									<xs:attribute name="canHandleVariableCommunicationStepSize" type="xs:boolean" default="false"/>
 									<xs:attribute name="canInterpolateInputs" type="xs:boolean" default="false"/>
 									<xs:attribute name="maxOutputDerivativeOrder" type="xs:unsignedInt" default="0"/>
-									<xs:attribute name="canRunAsynchronuously" type="xs:boolean" default="false"/>
+									<xs:attribute name="providesIntermediateVariableAccess" type="xs:boolean" default="false"/>
+									<xs:attribute name="canReturnEarlyAfterIntermediateUpdate" type="xs:boolean" default="false"/>
+									<xs:attribute name="providesHybridCoSimulation" type="xs:boolean" default="false"/>
+									<xs:attribute name="providesScheduledExecutionSimulation" type="xs:boolean" default="false"/>
+									<xs:attribute name="canNotUseBasicCoSimulation" type="xs:boolean" default="false"/>
 								</xs:extension>
 							</xs:complexContent>
 						</xs:complexType>

--- a/schema/fmi3Type.xsd
+++ b/schema/fmi3Type.xsd
@@ -163,6 +163,15 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 					</xs:complexContent>
 				</xs:complexType>
 			</xs:element>
+			<xs:element name="Clock">
+				<xs:complexType>
+					<xs:complexContent>
+						<xs:extension base="fmi3TypeDefinitionBase">
+							<xs:attributeGroup ref="fmi3ClockAttributes"/>
+						</xs:extension>
+					</xs:complexContent>
+				</xs:complexType>
+			</xs:element>
 		</xs:choice>
 	</xs:group>
 </xs:schema>

--- a/schema/fmi3Variable.xsd
+++ b/schema/fmi3Variable.xsd
@@ -269,6 +269,18 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
+	<xs:complexType name="fmi3Clock">
+		<xs:complexContent>
+			<xs:extension base="fmi3VariableBase">
+				<xs:attributeGroup ref="fmi3ClockAttributes"/>
+				<xs:attribute name="start" type="xs:boolean">
+					<xs:annotation>
+						<xs:documentation>Value before initialization, if initial=exact </xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>	
 	<xs:complexType name="fmi3VariableBase" abstract="true">
 		<xs:sequence>
 			<xs:element name="Dimension" minOccurs="0" maxOccurs="unbounded">
@@ -292,6 +304,8 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 					<xs:enumeration value="local"/>
 					<xs:enumeration value="independent"/>
 					<xs:enumeration value="structuralParameter"/>
+					<xs:enumeration value="inferred"/>
+					<xs:enumeration value="triggered"/>
 				</xs:restriction>
 			</xs:simpleType>
 		</xs:attribute>
@@ -303,6 +317,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 					<xs:enumeration value="tunable"/>
 					<xs:enumeration value="discrete"/>
 					<xs:enumeration value="continuous"/>
+					<xs:enumeration value="clock"/>
 				</xs:restriction>
 			</xs:simpleType>
 		</xs:attribute>
@@ -317,6 +332,8 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		</xs:attribute>
 		<xs:attribute name="canHandleMultipleSetPerTimeInstant" type="xs:boolean"/>
 		<xs:attribute name="declaredType" type="xs:normalizedString"/>
+		<xs:attribute name="clockReference" type="xs:unsignedInt" use="optional"/>
+		<xs:attribute name="intermediateAccess" type="xs:boolean" use="optional"/>
 	</xs:complexType>
 
 	<xs:group name="fmi3Variable">
@@ -335,6 +352,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<xs:element name="String" type="fmi3String"/>
 			<xs:element name="Binary" type="fmi3Binary"/>
 			<xs:element name="Enumeration" type="fmi3Enumeration"/>
+			<xs:element name="Clock" type="fmi3Clock"/>
 		</xs:choice>
 	</xs:group>
 </xs:schema>


### PR DESCRIPTION
Removed from fmi3Status:

- fmi3Pending

Removed functions:

- fmi3CancelStep
- fmi3GetDoStepPendingStatus
- fmi3GetDoStepDiscardedStatus

New functions:

- fmi3EnterEventMode
- fmi3SetClock
- fmi3GetClock
- fmi3GetIntervalDecimal
- fmi3SetIntervalDecimal
- fmi3GetIntervalFraction
- fmi3SetIntervalFraction
- fmi3NewDiscreteStates
- fmi3EnterStepMode
- fmi3ActivateModelPartition
- fmi3DoEarlyReturn

New enumerations:

- fmi3CoSimulationMode
- fmi3CoSimulationConfiguration

Removed callbacks:

- fmi3CallbackStepFinished

New callbacks:

- fmi3CallbackIntermediateUpdate
- fmi3CallbackLockPreemption
- fmi3CallbackUnlockPreemption

New types:

- fmi3Clock

New XML elements:

- Clock

Removed attributes in CoSimulation element:

- canRunAsynchronuously

New attributes in CoSimulation element:

- providesIntermediateVariableAccess
- canReturnEarlyAfterIntermediateUpdate
- providesHybridCoSimulation
- providesScheduledExecutionSimulation
- canNotUseBasicCoSimulation