### PR TITLE
ModelDescription - Main Source of Truth

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,7 +20,6 @@ https://fmi-standard.org/downloads/[Releases] and the https://fmi-standard.org/d
 == Branches
 
 - `master` -- development of the next release
-Note: During development of the next FMI version the XSD files for the `modeldescription.xml` file are to be considered normative compared to the standard text in case of inconsistencies except for comments, where the standard text is to be considered normative. Please open issues and/or PRs in this case of discovering inconsistencies.
 - `support/v2.0.x` -- maintenance of the 2.0 release
 - `feature/*` -- development of features for the next release
 

--- a/README.adoc
+++ b/README.adoc
@@ -20,7 +20,7 @@ https://fmi-standard.org/downloads/[Releases] and the https://fmi-standard.org/d
 == Branches
 
 - `master` -- development of the next release
-Note: During development of the next FMI version the XSD files for the `modeldescription.xml` file trusted more than the specification in case of inconsistencies. Please open issues and/or PRs in this case.
+Note: During development of the next FMI version the XSD files for the `modeldescription.xml` file are to be considered normative compared to the standard text in case of inconsistencies except for comments, where the standard text is to be considered normative. Please open issues and/or PRs in this case of discovering inconsistencies.
 - `support/v2.0.x` -- maintenance of the 2.0 release
 - `feature/*` -- development of features for the next release
 

--- a/README.adoc
+++ b/README.adoc
@@ -20,6 +20,7 @@ https://fmi-standard.org/downloads/[Releases] and the https://fmi-standard.org/d
 == Branches
 
 - `master` -- development of the next release
+Note: During development of the next FMI version the XSD files for the `modeldescription.xml` file trusted more than the specification in case of inconsistencies. Please open issues and/or PRs in this case.
 - `support/v2.0.x` -- maintenance of the 2.0 release
 - `feature/*` -- development of features for the next release
 

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -20,7 +20,7 @@ With the enterprise edition of XMLSpy it is possible to automatically generate C
 C# and Java code that reads an XML file of fmiModelDescription.xsd.
 An efficient open source XML parser is SAX (http://sax.sourceforge.net/, http://en.wikipedia.org/wiki/Simple_API_for_XML).
 All data from the XML file is only defined via "attributes" and not via "elements".
-Therefore, only an "attribute" handler needs to be defined for a SAX parser.].
+Therefore, only an "attribute" handler needs to be defined for a SAX parser.] except for comments. If comments within the above mentioned schema files are inconsistent with the standard text, then the standard text is to be considered normative.
 Below, optional elements are marked with a "dashed" box.
 The required data types (like: xs:normalizedString) are defined in the XML-schema standard: http://www.w3.org/TR/XMLschema-2/.
 The types used in the fmi3 schema files are:

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -155,7 +155,7 @@ The value for this version is "2.0".
 Future minor revisions are denoted as "2.0.1", "2.0.2", ...
 
 Note: During development of FMI version 3.0 prototype FMU implementations can indicate compliance with a certain development version of FMI 3.0 based on the tags available at: https://github.com/modelica/fmi-standard/tags.
-For example: the value for the FMI 3.0 alpha 2 release is: "v3.0-alpha.2".
+For example: the value for the FMI 3.0 alpha 2 release is: "3.0-alpha.2".
 
 
 |`modelName`

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -20,7 +20,7 @@ With the enterprise edition of XMLSpy it is possible to automatically generate C
 C# and Java code that reads an XML file of fmiModelDescription.xsd.
 An efficient open source XML parser is SAX (http://sax.sourceforge.net/, http://en.wikipedia.org/wiki/Simple_API_for_XML).
 All data from the XML file is only defined via "attributes" and not via "elements".
-Therefore, only an "attribute" handler needs to be defined for a SAX parser.] except for comments. If comments within the above mentioned schema files are inconsistent with the standard text, then the standard text is to be considered normative.
+Therefore, only an "attribute" handler needs to be defined for a SAX parser.]
 Below, optional elements are marked with a "dashed" box.
 The required data types (like: xs:normalizedString) are defined in the XML-schema standard: http://www.w3.org/TR/XMLschema-2/.
 The types used in the fmi3 schema files are:

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -154,6 +154,10 @@ image::images/fmiModelDescription_schema_2.png[width=80%, align="center"]
 The value for this version is "2.0".
 Future minor revisions are denoted as "2.0.1", "2.0.2", ...
 
+Note: During development of FMI version 3.0 prototype FMU implementations can indicate compliance with a certain development version of FMI 3.0 based on the tags available at: https://github.com/modelica/fmi-standard/tags.
+For example: the value for the FMI 3.0 alpha 2 release is: "v3.0-alpha.2".
+
+
 |`modelName`
 |The name of the model as used in the modeling environment that generated the XML file, such as "Modelica.Mechanics.Rotational.Examples.CoupledClutches".
 


### PR DESCRIPTION
Clarifying whether the XSD files or the standard is to be considered normative.

Added additional information on fmiVersion value for prototyping efforts.

Added information to readme on XSD/standard truth priority.

Related to issue: https://github.com/modelica/fmi-standard/issues/678
