### PR TITLE
Fix formatting

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -333,6 +333,16 @@ will be rendered as
 
 > A variable with `variability &#8800; constant`...
 
+=== Italic paragraphs
+
+Every line of an italic paragraph (e.g. in non-normative text) should be surrounded by underscores, so the text is highlighted correctly in code editors.
+Example:
+
+----
+_[This is the first line._
+_This is the second line.]_
+----
+
 == Adding and editing figures
 
 The figures in the document should be provided as SVGs (Scalable Vector Graphics) and stored in `docs/images`. We use https://www.draw.io/[draw.io] to create and edit the figures. When you have created or edited a figure

--- a/docs/1___overview.adoc
+++ b/docs/1___overview.adoc
@@ -105,9 +105,7 @@ For details, see <<fmi-for-model-exchange>> and <<fmi-for-co-simulation>>.
 [blue]#Blue# arrows: Information provided by the FMU.
 [red]#Red# arrows: Information provided to the FMU.
 
-Publications for FMI are available from https://fmi-standard.org/literature/,
-specially Blochwitz et.al. http://www.ep.liu.se/ecp/063/013/ecp11063013.pdf[2011] and http://www.ep.liu.se/ecp/076/017/ecp12076017.pdf[2012].
-
+Publications for FMI are available from https://fmi-standard.org/literature/, especially <<BOA11>> and <<BOA12>>.
 
 === Properties and Guiding Ideas
 

--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -1045,7 +1045,7 @@ _If the sparsity of a matrix shall be taken into account, then the matrix can be
 . _For the columns determined in (2), one call to <<fmi3GetDirectionalDerivative>> is made._
 _After each such call, the elements of the resulting directional derivative vector are copied into their correct locations of the partial derivative matrix._
 
-_More details and implementational notes are available from (&#197;kesson et.al. 2012).]_
+_More details and implementational notes are available from <<ABL12>>.]_
 
 ==== Getting Number of Event Indicators
 

--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -11,12 +11,12 @@ The FMU itself does not implement any services to support this.]_
 
 - FMI functions must not change global settings which affect other processes/threads.
 An FMI function may change settings of the process/thread in which it is called (such as floating point control registers), provided these changes are restored before leaving the function or before a callback function is called. +
-_[This property ensures that functions of different FMU instances can be called safely in any order.
-Additionally, they can be called in parallel provided the functions are called in different process/threads.
-If an FMI function changes for example the floating point control word of the CPU, it must restore the previous value before return of the function.
-For x86 CPUs, the floating point control word is set using the `fldcw` instruction.
-This can be used to switch on additional exceptions such as floating point division by zero.
-An FMU might temporarily change the floating point control word and get notified on floating point exceptions internally, but has to restore the flag and clear the floating point status word before return of the respective FMI function.]_
+_[This property ensures that functions of different FMU instances can be called safely in any order._
+_Additionally, they can be called in parallel provided the functions are called in different process/threads._
+_If an FMI function changes for example the floating point control word of the CPU, it must restore the previous value before return of the function._
+_For x86 CPUs, the floating point control word is set using the `fldcw` instruction._
+_This can be used to switch on additional exceptions such as floating point division by zero._
+_An FMU might temporarily change the floating point control word and get notified on floating point exceptions internally, but has to restore the flag and clear the floating point status word before return of the respective FMI function.]_
 
 ==== Header Files and Naming of Functions [[header-files-and-naming-of-functions]]
 
@@ -31,15 +31,30 @@ If the target simulator has different definitions in
 the header file (for example, `typedef float fmi3Real` instead of `typedef double** fmi3Real`),
 then the FMU needs to be re-compiled with the header file used by the target simulator.
 +
-_[Example of a definition in this header file: +
-`typedef double fmi3Real;` +
-]_
+// TODO: include example from header
+_[Example of a definition in this header file:_
++
+[source, C]
+----
+typedef double fmi3Real;
+----
++
+_]_
 
 `fmi3FunctionTypes.h`::
 contains `typedef` definitions of all function prototypes of an FMU.
 When dynamically loading an FMU, these definitions can be used to type-cast the function pointers to the respective function definition.
-_[Example of a definition in this header file: +
-`typedef fmi3Status fmi3SetTimeTYPE(fmi3Instance, fmi3Real);`]_
+// TODO: add note why "TYPE" suffix is necessary
++
+// TODO: include example from header
+_[Example of a definition in this header file:_
++
+[source, C]
+----
+typedef fmi3Status fmi3SetTimeTYPE(fmi3Instance, fmi3Real);
+----
++
+_]_
 
 `fmi3Functions.h`::
 contains the function prototypes of an FMU that can be accessed in simulation environments and that are defined in <<fmi-common-concepts>>, <<fmi-for-model-exchange>> and
@@ -47,16 +62,20 @@ contains the function prototypes of an FMU that can be accessed in simulation en
 +
 This header file includes `fmi3PlatformTypes.h` and `fmi3FunctionTypes.h`.
 The header file version number for which the model was compiled, can be inquired in the target simulator with <<fmi3GetVersion>> (see <<inquire-platform-and-version-number>>). +
++
 _[Example of a definition in this header file_ footnote:[For Microsoft and Cygwin compilers; `FMI3_Export` is defined as `pass:[__]declspec(dllexport)` and for Gnu-Compilers `FMI3_Export` is defined as `pass:[__]attribute__ ( ( visibility("default") ) )` in order to export the name for dynamic loading.
-Otherwise it is an empty definition.]: +
-`FMI3_Export fmi3SetTimeTYPE fmi3SetTime;`]_
+Otherwise it is an empty definition.] _:_
++
+[source, C]
+----
+FMI3_Export fmi3SetTimeTYPE fmi3SetTime;
+----
++
+_]_
 
-The goal is that both textual and binary representations of FMUs are supported and that several FMUs
-might be present at the same time in an executable (for example, FMU A may use an FMU B).
-In order for this to be possible,
-the names of the functions in different FMUs must be different, or function pointers must be used.
-To support the first variant macros are provided in `fmi3Functions.h` to build the actual
-function names by using a function prefix that depends on how the FMU is shipped.
+The goal is that both textual and binary representations of FMUs are supported and that several FMUs might be present at the same time in an executable (for example, FMU A may use an FMU B).
+In order for this to be possible, the names of the functions in different FMUs must be different, or function pointers must be used.
+To support the first variant macros are provided in `fmi3Functions.h` to build the actual function names by using a function prefix that depends on how the FMU is shipped.
 Typically, FMU functions are used as follows:
 
 [source, C]
@@ -84,9 +103,9 @@ The constructed function name is `fmi3GetReal`, in other words, it is not change
 A simulation environment will then dynamically load this library and will explicitly import the function symbols by providing the FMI function names as strings.
 The name of the library is `MyModel.dll` on Windows or `MyModel.so` on Linux; in other words the `modelIdentifier` attribute is used as library name.
 
-_[An FMU can be optionally shipped so that it basically contains only the communication to another tool (`needsExecutionTool = true`, see <<fmi-for-co-simulation>>).
-This is particularily common for co-simulation tasks.
-In this tool coupling case one DLL/Shared Object can be used for all models due to no function prefixing.]_
+_[An FMU can be optionally shipped so that it basically contains only the communication to another tool (`needsExecutionTool = true`, see <<fmi-for-co-simulation>>)._
+_This is particularily common for co-simulation tasks._
+_In this tool coupling case one DLL/Shared Object can be used for all models due to no function prefixing.]_
 
 Since `modelIdentifier` is used as prefix of a C-function name it must fulfill the restrictions on C-function
 names (only letters, digits and/or underscores are allowed).
@@ -94,7 +113,6 @@ _[For example, if `modelName = "A.B.C"`, then `modelIdentifier` might be "A_B_C"
 Since `modelIdentifier` is also used as name in a file system, it must also fulfill the restrictions of the targeted operating system.
 Basically, this means that it should be short.
 For example, the Windows API only supports full path-names of a file up to 260 characters (see: http://msdn.microsoft.com/en-us/library/aa365247%28VS.85%29.aspx).
-
 
 ==== Platform Dependent Definitions (fmi3PlatformTypes.h)
 
@@ -191,7 +209,7 @@ If not, these functions could return with `fmi3Discard`.]:
 (Model Exchange: `fmi3SetReal`, `fmi3SetInteger`, `fmi3SetBoolean`, `fmi3SetString`, <<fmi3SetContinuousStates>>, `fmi3GetReal`, <<fmi3GetDerivatives>>,
 <<fmi3GetContinuousStates>>, <<fmi3GetEventIndicators>>; Co-Simulation: `fmi3SetReal`, `fmi3SetInteger`, `fmi3SetBoolean`, `fmi3SetString`, <<fmi3DoStep>>,
 `fmi3GetXXXStatus`): +
-For Model Exchange: It is recommended to perform a smaller step size and evaluate the model equations again, for example because an iterative solver in the model did not converge or because a function is outside of its domain [for example, `sqrt(<negative number>)`].
+For Model Exchange: It is recommended to perform a smaller step size and evaluate the model equations again, for example because an iterative solver in the model did not converge or because a function is outside of its domain _[for example, `sqrt(<negative number>)`]_.
 If this is not possible, the simulation has to be terminated. +
 For Co-Simulation: `fmi3Discard` is returned also if the slave is not able to return the required status information.
 The master has to decide if the simulation run can be continued. +
@@ -278,8 +296,8 @@ The following schemes must be understood by the FMU:
 
 - Reserved: `fmi3` for FMI for PLM.
 
-_[Example: An FMU is unzipped in directory "C:\temp\MyFMU", then fmuResourceLocation = "file:///C:/temp/MyFMU/resources" or "file:/C:/temp/MyFMU/resources".
-Function <<fmi3Instantiate>> is then able to read all needed resources from this directory, for example maps or tables used by the FMU.]_
+_[Example: An FMU is unzipped in directory `C:\temp\MyFMU`, then `fmuResourceLocation` = `file:///C:/temp/MyFMU/resources` or `file:/C:/temp/MyFMU/resources`._
+_Function <<fmi3Instantiate>> is then able to read all needed resources from this directory, for example maps or tables used by the FMU.]_
 
 Argument `functions` provides callback functions to be used from the FMU functions to utilize resources from the environment (see type <<fmi3CallbackFunctions>> below).
 
@@ -290,8 +308,8 @@ If `visible = fmi3True`, the FMU is executed in interactive mode, and the FMU mi
 If `loggingOn = fmi3True`, debug logging is enabled. +
 If `loggingOn = fmi3False`, debug logging is disabled.
 
-_[The FMU enable/disables `LogCategories` which are useful for debugging according to this argument.
-Which `LogCategories` the FMU sets is unspecified.]_
+_[The FMU enable/disables `LogCategories` which are useful for debugging according to this argument._
+_Which `LogCategories` the FMU sets is unspecified.]_
 
 Argument `fmuCoSimulationConfiguration` is used to configure Co-Simulation features used by the Co-Simulation master.
 //TODO: add cross reference
@@ -308,7 +326,8 @@ include::../headers/fmi3FunctionTypes.h[tags=CallbackFunctions]
 The struct contains pointers to functions provided by the environment to be used by the FMU.
 It is not allowed to change these functions between <<fmi3Instantiate>> and <<fmi3Terminate>> calls.
 Additionally, a pointer to the environment is provided (instanceEnvironment) that needs to be passed to all of the callback functions, in order that those functions can utilize data from the environment, such as mapping a <<valueReference>> to a string, or assigning memory to a certain FMU instance.
-In the unlikely case that `fmi3Instance` is also needed in those functions, it has to be passed via argument `instanceEnvironment`. Argument `instanceEnvironment` may be a null pointer.
+In the unlikely case that `fmi3Instance` is also needed in those functions, it has to be passed via argument `instanceEnvironment`.
+Argument `instanceEnvironment` may be a null pointer.
 
 The `instanceEnvironment` pointer is also passed to the <<fmi3CallbackIntermediateUpdate>> function in order that the environment can provide an efficient way to identify the slave that called <<fmi3CallbackIntermediateUpdate>>.
 
@@ -334,11 +353,7 @@ The caller may include line-breaks (using "\n") within the message, but should a
 Variables can be referenced in a message with `pass:[#]<ValueReference>pass:[#]`.
 If the character `pass:[#]` shall be included in the message, it has to be prefixed with `pass:[#]`, so `pass:[#]` is an escape character.
 +
-_[Example:_ +
-_The message_ `\#1365# must be larger than zero (used in IO channel ##4)` +
-_might be changed by the_ <<logMessage>> _function to_ +
-`body.m must be larger than zero (used in IO channel #4)` +
-_if `body.m` is the name of the variable with value reference 1365.]_
+_[Example: The message `\#1365# must be larger than zero (used in IO channel ##4)` might be changed by the <<logMessage>> function to `body.m must be larger than zero (used in IO channel #4)` if `body.m` is the name of the variable with value reference 1365.]_
 
 [[allocateMemory,`allocateMemory`]]
 Function `allocateMemory`::
@@ -360,7 +375,7 @@ If attribute `canNotUseMemoryManagementFunctions = true` in `<fmiModelDescriptio
 Function `intermediateUpdate`::
 This callback allows internal events of different types (e.g. associated to <<outputClock>> ticks or intermediate variable access) to be signaled from an FMU to the Co-Simulation master.
 If `fmu3Type` is set to `fmi3CoSimulation` and either the `coSimulationMode` in `fmi3CoSimulationConfiguration` is set to `fmi3ModeHybridCoSimulation` or `fmi3ModeScheduledExecutionSimulation` or any of the intermediate variable access modes is set to `true`, then the <<fmi3CallbackIntermediateUpdate>> callback must be defined in <<fmi3CallbackFunctions>> in <<fmi3Instantiate>>.
-In other cases a NULL pointer can be assigned to the `intermediateUpdate` callback, such as if the `fmu3Type` is set to  `fmi3ModelExchange`.
+In other cases a NULL pointer can be assigned to the `intermediateUpdate` callback, such as if the `fmu3Type` is set to `fmi3ModelExchange`.
 
 Function `lockPreemption` and `unlockPreemption`::
 To provide more options to secure the code against unwanted preemption these callback functions are defined.
@@ -413,7 +428,7 @@ An FMU for Co-Simulation might ignore this argument.
 
 The arguments `startTime` and `stopTime` can be used to check whether the model is valid within the given boundaries or to allocate memory which is necessary for storing results.
 Argument `startTime` is the <<fixed>> <<initial>> value of the <<independent>> variable footnote:[The variable that is defined with <<causality>> = <<independent>> in the `fmiModelDescription.xml` file.] value _[if the <<independent>> variable is `time`, `startTime` is the starting time of initializaton]_.
-If `stopTimeDefined = fmi3True`, then `stopTime` is the defined final value of the <<independent>> variable [if the <<independent>> variable is `time`, `stopTime` is the stop time of the simulation] and if the environment tries to compute past `stopTime` the FMU has to return `fmi3Status = fmi3Error`.
+If `stopTimeDefined = fmi3True`, then `stopTime` is the defined final value of the <<independent>> variable _[if the <<independent>> variable is `time`, `stopTime` is the stop time of the simulation]_ and if the environment tries to compute past `stopTime` the FMU has to return `fmi3Status = fmi3Error`.
 If `stopTimeDefined = fmi3False`, then no final value of the <<independent>> variable is defined and argument `stopTime` is meaningless.
 
 [[fmi3EnterConfigurationMode,`fmi3EnterConfigurationMode`]]
@@ -459,8 +474,7 @@ include::../headers/fmi3FunctionTypes.h[tags=Terminate]
 ----
 
 Informs the FMU that the simulation run is terminated.
-After calling this function,
-the final values of all variables can be inquired with the `fmi3GetXXX` functions.
+After calling this function, the final values of all variables can be inquired with the `fmi3GetXXX` functions.
 It is not allowed to call this function after one of the functions returned with a status flag of `fmi3Error` or `fmi3Fatal`.
 
 [[fmi3Reset,`fmi3Reset`]]
@@ -553,7 +567,7 @@ For Co-Simulation FMUs, additional functions are defined in <<transfer-of-input-
 ==== Operation on Clocks [[operation-on-clocks]]
 In the following section the operations on <<clock,`clocks`>> are described.
 Clocks are defined for the evaluation of *clocked model partitions* and the related definition of suitable *communication points*.
-Two types of <<clock,`clocks`>> are available, desinged to address similar use cases with differences in details.
+Two types of <<clock,`clocks`>> are available, designed to address similar use cases with differences in details.
 One <<clock>> type (Synchronous Clocks) complies with the limitations imposed by the synchronous clock theory, the other clock type (Communication Point Clocks) is a general purpose Co-Simulation clock for providing suitable communication points for the timed evaluation of model partitions.
 The term <<clock>> and clocked is therefore used for both <<clock>> types.
 Both clock types can handle two different variants, the <<inputClock,`input clocks`>> and the <<outputClock,`output clocks`>>. First the two different clock types are presented with the mathematical definition of their use cases.
@@ -594,12 +608,14 @@ They can have initial values defined by xml-attributes <<initial>> and <<start>>
 
 There are two kinds of evaluation modes:
 [start=1]
-. Regular evaluation for an active <<clock>>: <<state>> and <<output>> equations are evaluated. States get updated.
+. Regular evaluation for an active <<clock>>: <<state>> and <<output>> equations are evaluated.
+States get updated.
 . Partly evaluation for a subactive <<clock>>: <<state,`states`>> are left unmodified.
 _[Modelica uses this mode for the first tick in clocked continuous equations._
 _This mode can also be requested by the calling environment with <<fmi3SetClock>>, e.g. to form partial derivatives_ latexmath:[\delta y_j / \delta x_{j-1}] _.]_
 
 ====== Communication Point Clocks
+
 In addition to the above definition also a simplified <<clock>> definition used only in FMI for Co-Simulation is available that can be used to define the communication points of model partitions of the model (in the following such partitions are called model partitions).
 Such <<clock,`clocks`>> are called Communication Point Clocks (CPClocks).
 These <<clock,`clocks`>> are not compatible to synchronous clocks theory and must not be used together with synchronous clocks in one model.
@@ -629,21 +645,26 @@ It can be periodic or non-periodic.
 _[Example: If_ latexmath:[b = x > 0] _, and a state event is defined when b changes from `false` to `true`, and b is defined as <<outputClock>>, then this <<clock>> is active whenever x changes from negative to positive values.]_
 
 Since <<outputClock,`output clocks`>> are ticking based on model internal information it is required in case of FMI for Co-Simulation to signal the ticking of an <<outputClock>> to the simulation environment during a `fmi3DoStep` computation.
-In most cases the signaling of an <<outputClock>> tick is a `strong event` that requires creating a communication point for exchanging additional information (i.e. variable values) with the simulation environment. Additional cases need to be handled if a <<clock>> tick is not associated to an event that requires the creation of a communication point for the model partition that generated the event.
+In most cases the signaling of an <<outputClock>> tick is a `strong event` that requires creating a communication point for exchanging additional information (i.e. variable values) with the simulation environment.
+Additional cases need to be handled if a <<clock>> tick is not associated to an event that requires the creation of a communication point for the model partition that generated the event.
 
-[Outside of the FMU it is not known in advance when this <<clock>> ticks. Instead, only when the <<clock>> is activated by the FMU, then the environment is informed that the <<clock>> ticks at this time instant.
-It is the task of the environment to handle the messaged events appropriately based on the <<clockReference>> information.
-Example:
-]
+_[Outside of the FMU it is not known in advance when this <<clock>> ticks._
+_Instead, only when the <<clock>> is activated by the FMU, then the environment is informed that the <<clock>> ticks at this time instant._
+_It is the task of the environment to handle the messaged events appropriately based on the <<clockReference>> information._
+_Example:_
+// TODO: add example
+_]_
 
 ====== Input Clocks
 
 An <<inputClock>> is a periodic or non-periodic <<clock>> that is defined directly or indirectly by a <<clock>> outside of the FMU.
 Its interval is initialized by the environment.
 
-_[Inside of the FMU it is not known in advance when this <<clock>> ticks. Instead, only when the <<clock>> is activated by the environment of the FMU, then the FMU is informed that the <<clock>> ticks at this time instant.]_
-_[Example:]_
-_[A clocked PI controller can be defined as FMU and the input and output signal of the controller can be defined to be on the same <<inputClock>>. In such a case, the environment deduces the <<clock>> ticks from the components that are connected to the PI controller (e.g. a component connected to the input, or to the output may define the relevant <<clock>>).]_
+_[Inside of the FMU it is not known in advance when this <<clock>> ticks._
+_Instead, only when the <<clock>> is activated by the environment of the FMU, then the FMU is informed that the <<clock>> ticks at this time instant._
+_Example:_
+_A clocked PI controller can be defined as an FMU and the input and output signal of the controller can be defined to be on the same <<inputClock>>._
+_In such a case, the environment deduces the <<clock>> ticks from the components that are connected to the PI controller (e.g. a component connected to the input, or to the output may define the relevant <<clock>>).]_
 
 ===== Additional Clock Properties [[additional-clock-properties]]
 
@@ -651,7 +672,8 @@ This section gives a definition of additional clock properties.
 
 ====== Periodic Clock Ticks
 
-Either <<output>> or <<input>>, a periodic <<clock>> ticks at equidistant sample time points that are known a priori (defined in `modelDescription.xml`) or are alternatively determined by the environment in case of <<inputClock,`input clocks`>>. Mathematically, the next <<clock>> tick at time instant ti is defined as:
+Either <<output>> or <<input>>, a periodic <<clock>> ticks at equidistant sample time points that are known a priori (defined in `modelDescription.xml`) or are alternatively determined by the environment in case of <<inputClock,`input clocks`>>.
+Mathematically, the next <<clock>> tick at time instant ti is defined as:
 
 [latexmath]
 ++++
@@ -672,10 +694,11 @@ where:
 |The previous time instant in seconds, where the <<clock>> ticked.
 
 |latexmath:[\Delta T > 0]
-|The constant time interval from the previous <<clock>> tick to the current <<clock>> tick. It is defined as a rational number based on `intervalCounter` and `resolution` via <<clock>> variable attributes.
+|The constant time interval from the previous <<clock>> tick to the current <<clock>> tick.
+It is defined as a rational number based on `intervalCounter` and `resolution` via <<clock>> variable attributes.
 |===
 
-The interval latexmath:[\Delta T] and latexmath:[t_{offset}] must be defined for periodic <<clock,`clocks`>> in the xml-file.
+The interval latexmath:[\Delta T] and latexmath:[t_{offset}] must be defined for periodic <<clock,`clocks`>> in the XML file.
 In case of periodic <<inputClock,`input clocks`>> these values are the start interval values if they are not given by the simulation master.
 _[This information can be used for emulating periodic <<inputClock,`input clocks`>> in Co-Simulation mode `fmi3ModeCoSimulation`]_.
 
@@ -696,7 +719,7 @@ For periodic <<clock,`clocks`>> it is recommended to derive the priorities based
 
 If <<outputClock,`output clocks`>> and <<inputClock,`input clocks`>> are defined it is possible to define a tick relationship from an <<outputClock>> to an <<inputClock>>.
 This is needed to allow for an external resource management to achieve an optimal control of model partitions.
-The <<outputClock,`output clocks`>> and the associtated <<inputClock,`input clocks`>> define a union of <<clock,`clocks`>>.
+The <<outputClock,`output clocks`>> and the associated <<inputClock,`input clocks`>> define a union of <<clock,`clocks`>>.
 In that sense, if an <<outputClock>> ticks the associated <<inputClock>> ticks at the same time instant in such a union.
 It is only meaningful to combine one or multiple <<outputClock,`output clocks`>> with a single aperiodic <<inputClock>> in such a union.
 It is possible to define multiple unions of <<clock,`clocks`>>, with the maximum number defined by the number of available aperiodic <<inputClock,`input clocks`>>.
@@ -755,7 +778,8 @@ include::../headers/fmi3FunctionTypes.h[tag=GetClock]
 
 Inquires whether a set of <<clock,`clocks`>> is active by providing the value references of the corresponding <<clock>> varaibels.
 A <<clock>> with <<valueReference>>[i] is active at the current time instant if `value[i] = fmi3True`, otherwise the <<clock>> is not active. It is allowed to call this function within the callback function `fmi3IntermediateUpdate()`.
-It is required for an FMU to directly internally set back the activation <<state>> of an <<outputClock>> latexmath:[i] to `fmi3False` if the function <<fmi3GetClock>> is called for a <<clock>> latexmath:[i] and the Co-Simulation mode is set to `fmi3ModeScheduledExecutionSimulation`. _[This is required to allow preemption.]_
+It is required for an FMU to directly internally set back the activation <<state>> of an <<outputClock>> latexmath:[i] to `fmi3False` if the function <<fmi3GetClock>> is called for a <<clock>> latexmath:[i] and the Co-Simulation mode is set to `fmi3ModeScheduledExecutionSimulation`.
+_[This is required to allow preemption.]_
 // TODO: add xref to 4.4.5
 
 A <<clock>> interval is set by the environment for the current time instant by the function <<fmi3SetIntervalDecimal>> or <<fmi3SetIntervalFraction>>, and it can be inquired with the function <<fmi3GetIntervalDecimal>> or <<fmi3GetIntervalFraction>>:
@@ -784,7 +808,8 @@ include::../headers/fmi3FunctionTypes.h[tag=GetIntervalDecimal]
 include::../headers/fmi3FunctionTypes.h[tag=GetIntervalFraction]
 ----
 
-Both functions inquire the interval value for the provided <<clock,`clocks`>> (periodic or non-periodic). If the <<clock,`clocks`>> are non-periodic, the interval has to be inquired at every <<clock>> tick, to define the follow-up <<clock>> tick.
+Both functions inquire the interval value for the provided <<clock,`clocks`>> (periodic or non-periodic).
+If the <<clock,`clocks`>> are non-periodic, the interval has to be inquired at every <<clock>> tick, to define the follow-up <<clock>> tick.
 
 The following table summarizes the use of the API functions by the environment for different kind of <<clock,`clocks`>>:
 
@@ -828,11 +853,12 @@ _For variable step-size control of Co-Simulation master algorithms (get the FMU 
 
 _For nonlinear Kalman filters (get the FMU state just before initialization; in every sample period, set new continuous states from the Kalman filter algorithm based on measured values; integrate to the next sample instant and inquire the predicted continuous states that are used in the Kalman filter algorithm as basis to set new continuous states)._
 
-_For nonlinear model predictive control (get the FMU state just before initialization; in every sample period, set new continuous states from an observer, initialize and get the FMU state after initialization. From this state, perform many simulations that are restarted after the initialization with new input signals proposed by the optimizer).]_
+_For nonlinear model predictive control (get the FMU state just before initialization; in every sample period, set new continuous states from an observer, initialize and get the FMU state after initialization._
+_From this state, perform many simulations that are restarted after the initialization with new input signals proposed by the optimizer).]_
 
 Furthermore, the FMU state can be serialized and copied in a byte vector:
-_[This can be, for example, used to perform an expensive steady-state initialization, copy the received FMU state in a byte vector and store this vector on file. Whenever needed, the byte vector can be loaded from file and deserialized, and the simulation can be restarted from this FMU state, in other words, from the steady-state initialization.]_
-
+_[This can be, for example, used to perform an expensive steady-state initialization, copy the received FMU state in a byte vector and store this vector on file._
+_Whenever needed, the byte vector can be loaded from file and deserialized, and the simulation can be restarted from this FMU state, in other words, from the steady-state initialization.]_
 
 [[fmi3GetFMUState, `fmi3GetFMUState`]]
 [source, C]
@@ -856,8 +882,7 @@ include::../headers/fmi3FunctionTypes.h[tags=FreeFMUState]
 If on entry `*FMUState == NULL`, a new allocation is required.
 If `*FMUState != NULL`, then `*FMUState` points to a previously returned `FMUState` that has not been modified since.
 In particular, <<fmi3FreeFMUState>> had not been called with this `FMUState` as an argument.
-_[Function <<fmi3GetFMUState>> typically reuses the memory of this `FMUState`
-in this case and returns the same pointer to it, but with the actual `FMUState`.]_
+_[Function <<fmi3GetFMUState>> typically reuses the memory of this `FMUState` in this case and returns the same pointer to it, but with the actual `FMUState`.]_
 
 <<fmi3SetFMUState>> copies the content of the previously copied `FMUState` back and uses it as actual new FMU state.
 The `FMUState` copy still exists.
@@ -867,8 +892,7 @@ The input argument to this function is the `FMUState` to be freed.
 If a null pointer is provided, the call is ignored.
 The function returns a null pointer in argument `FMUState`.
 
-These functions are only supported by the FMU,
-if the optional capability flag `canGetAndSetFMUState` in `<fmiModelDescription> <ModelExchange / CoSimulation>` in the XML file is explicitly set to `true` (see <<ModelExchange>> and <<fmi-for-co-simulation>>).
+These functions are only supported by the FMU, if the optional capability flag `canGetAndSetFMUState` in `<fmiModelDescription> <ModelExchange / CoSimulation>` in the XML file is explicitly set to `true` (see <<ModelExchange>> and <<fmi-for-co-simulation>>).
 
 [source, C]
 ----
@@ -888,9 +912,7 @@ serializes the data which is referenced by pointer `FMUState` and copies this da
 `fmi3DeSerializeFMUState` deserializes the byte vector `serializedState` of length `size`, constructs a copy of the FMU state and returns `FMUState`, the pointer to this copy.
 _[The simulation is restarted at this state, when calling <<fmi3SetFMUState>> with `FMUState`.]_
 
-These functions are only supported by the FMU,
-if the optional capability flags `canGetAndSetFMUState` and `canSerializeFMUState` in
-`<fmiModelDescription><ModelExchange / CoSimulation>` in the XML file are explicitly set to `true` (see <<ModelExchange>> and <<fmi-for-co-simulation>>).
+These functions are only supported by the FMU, if the optional capability flags `canGetAndSetFMUState` and `canSerializeFMUState` in `<fmiModelDescription><ModelExchange / CoSimulation>` in the XML file are explicitly set to `true` (see <<ModelExchange>> and <<fmi-for-co-simulation>>).
 
 ==== Getting Partial Derivatives
 
@@ -908,10 +930,16 @@ include::../headers/fmi3FunctionTypes.h[tags=GetDirectionalDerivative]
 
 This function computes the directional derivatives of an FMU.
 
-- Argument `vrUnknown` contains the <<valueReference>>pass:[s] of the unknown variables. The number of <<valueReference>>pass:[s] is given by the argument `nUnknown`.
-- Argument `vrKnown` contains the <<valueReference>>pass:[s] of the known variables. The number of <<valueReference>>pass:[s] is given by the argument `nKnown`.
-- Arguments `dvKnown` and `dvUnknown` contain the serialized values of the referenced Variables (serializiation of values as defined in <<get-and-set-variable-values>>).
+- Argument `vrUnknown` contains the <<valueReference>>pass:[s] of the unknown variables.
+The number of <<valueReference>>pass:[s] is given by the argument `nUnknown`.
+
+- Argument `vrKnown` contains the <<valueReference>>pass:[s] of the known variables.
+The number of <<valueReference>>pass:[s] is given by the argument `nKnown`.
+
+- Arguments `dvKnown` and `dvUnknown` contain the serialized values of the referenced Variables (serialization of values as defined in <<get-and-set-variable-values>>).
+
 - Argument `nDvKnown` provides the number of values in `dvKnown` which is only equal to `nKnown` if all <<valueReference>>pass:[s] of `vrKnown` point to variables.
+
 - Argument `nDvUnknown` provides the number of values in `dvUnknown` which is only equal to `nUnknown` if all <<valueReference>>pass:[s] of `vrUnknown` point to variables.
 
 An FMU has different Modes and in every Mode an FMU might be described by different equations and different unknowns.
@@ -936,12 +964,11 @@ where
 ** Step Mode (Co-Simulation): The variables listed under `<ModelStructure><Outputs>` with type Real and <<variability>> = <<continuous>> or <<discrete>>.
 If `<ModelStructure><Derivatives>` is present, also the variables listed here as state derivatives.
 
-* latexmath:[\color{blue}{\mathbf{v}_{known}}] is the vector of Real <<input>> variables of function *h*
-that changes its value in the actual Mode.
+* latexmath:[\color{blue}{\mathbf{v}_{known}}] is the vector of Real <<input>> variables of function *h* that changes its value in the actual Mode.
 Details are described in the description of element <<dependencies>> in <<ModelStructure>>.
-_[For example continuous-time <<input,`inputs`>> in Continuous-Time Mode.
-If a variable with <<causality>> = <<independent>> is explicitly defined under `Variable`pass:[s], a directional derivative with respect to this variable can be computed.
-If such a variable is not defined, the directional derivative with respect to the <<independent>> variable cannot be calculated]._
+_[For example continuous-time <<input,`inputs`>> in Continuous-Time Mode._
+_If a variable with <<causality>> = <<independent>> is explicitly defined under `Variable`pass:[s], a directional derivative with respect to this variable can be computed._
+_If such a variable is not defined, the directional derivative with respect to the <<independent>> variable cannot be calculated]._
 
 * latexmath:[\color{blue}{\mathbf{v}_{rest}}] is the set of <<input>> variables of function *h* that either changes its value in the actual Mode but are non-Real variables, or do not change their values in this Mode, but change their values in other Modes _[for example, discrete-time <<input,`inputs`>> in Continuous-Time Mode]_.
 
@@ -952,13 +979,12 @@ If the capability attribute `providesDirectionalDerivative = true`, <<fmi3GetDir
 \Delta \mathbf{v}_{unknown} = \frac{\delta \mathbf{h}}{\delta \mathbf{v}_{known}}\mathbf{v}_{known}
 ++++
 
-Accordingly, it computes the directional derivative vector
-latexmath:[\color{blue}{\Delta \mathbf{v}_{unknown}}] (`dvUnknown`) from the seed vector
-latexmath:[\color{blue}{\Delta \mathbf{v}_{known}}] (`dvKnown`)
+Accordingly, it computes the directional derivative vector latexmath:[\color{blue}{\Delta \mathbf{v}_{unknown}}] (`dvUnknown`) from the seed vector latexmath:[\color{blue}{\Delta \mathbf{v}_{known}}] (`dvKnown`)
 
-_[The variable relationships are different in different modes.
-For example, during Continuous-Time Mode, a continuous-time output y does not depend on discrete-time <<input,`inputs`>> (because they are held constant between events).
-However, at Event Mode, y depends on discrete-time <<input,`inputs`>>.]_ + _The function may compute the directional derivatives by numerical differentiation taking into account the sparseness of the equation system, or (preferred) by analytic derivatives._
+_[The variable relationships are different in different modes._
+_For example, during Continuous-Time Mode, a continuous-time output y does not depend on discrete-time <<input,`inputs`>> (because they are held constant between events)._
+_However, at Event Mode, y depends on discrete-time <<input,`inputs`>>._
+_The function may compute the directional derivatives by numerical differentiation taking into account the sparseness of the equation system, or (preferred) by analytic derivatives._
 
 _Example:_ +
 _Assume an FMU has the output equations_
@@ -978,9 +1004,9 @@ g_2(x, u_1)
 \end{bmatrix}
 ++++
 
-_and this FMU is connected, so that latexmath:[\color{blue}{y_1, u_1, u_3}] appear in an algebraic loop.
-Then the nonlinear solver needs a Jacobian and this Jacobian can be computed (without numerical differentiation) provided the partial derivative of latexmath:[\color{blue}{y_1}] with respect to latexmath:[\color{blue}{u_1}] and latexmath:[\color{blue}{u_3}] is available.
-Depending on the environment where the FMUs are connected, these <<derivative,`derivatives`>> can be provided_
+_and this FMU is connected, so that latexmath:[\color{blue}{y_1, u_1, u_3}] appear in an algebraic loop._
+_Then the nonlinear solver needs a Jacobian and this Jacobian can be computed (without numerical differentiation) provided the partial derivative of latexmath:[\color{blue}{y_1}] with respect to latexmath:[\color{blue}{u_1}] and latexmath:[\color{blue}{u_3}] is available._
+_Depending on the environment where the FMUs are connected, these <<derivative,`derivatives`>> can be provided_
 
 (a) _with one wrapper function around function <<fmi3GetDirectionalDerivative>> to compute the directional derivatives with respect to these two variables (in other words, latexmath:[\color{blue}{v_{unknown} = y_1}], latexmath:[\color{blue}{v_{known} = \left \{ u_1, u_3 \right \}}]), and then the environment calls this wrapper function with latexmath:[\color{blue}{\Delta v_{known} = \left \{ 1, 0 \right \}}] to compute the partial derivative with respect to latexmath:[\color{blue}{u_1}] and latexmath:[\color{blue}{\Delta v_{known} = \left \{ 0, 1 \right \}}] to compute the partial derivative with respect to latexmath:[\color{blue}{u_3}], or_
 
@@ -1002,26 +1028,22 @@ _[Note, function <<fmi3GetDirectionalDerivative>> can be utilized for the follow
 
 - _If the FMU shall be linearized, the same <<derivative,`derivatives`>> as in the previous item are needed._
 
-- _If the FMU is used as the model for an extended Kalman filter,
-latexmath:[\color{blue}{\frac{\delta \mathbf{f}}{\delta \mathbf{x}}}] and
-latexmath:[\color{blue}{\frac{\delta \mathbf{g}}{\delta \mathbf{x}}}] are needed._
+- _If the FMU is used as the model for an extended Kalman filter, latexmath:[\color{blue}{\frac{\delta \mathbf{f}}{\delta \mathbf{x}}}] and latexmath:[\color{blue}{\frac{\delta \mathbf{g}}{\delta \mathbf{x}}}] are needed._
 
-_If a dense matrix shall be computed, the columns of the matrix can be easily constructed by successive calls of <<fmi3GetDirectionalDerivative>>.
-For example, constructing the system Jacobian latexmath:[\color{blue}{\mathbf{A} = \frac{\delta \mathbf{f}}{\delta \mathbf{x}}}] as dense matrix can be performed in the following way:_
+_If a dense matrix shall be computed, the columns of the matrix can be easily constructed by successive calls of <<fmi3GetDirectionalDerivative>>._
+_For example, constructing the system Jacobian latexmath:[\color{blue}{\mathbf{A} = \frac{\delta \mathbf{f}}{\delta \mathbf{x}}}] as dense matrix can be performed in the following way:_
 
 [source, C]
 ----
 include::examples/c-code/jacobian.c[tags=GetJacobian]
 ----
 
-_If the sparsity of a matrix shall be taken into account,
-then the matrix can be constructed in the following way:_
+_If the sparsity of a matrix shall be taken into account, then the matrix can be constructed in the following way:_
 
-. _The incidence information of the matrix (whether an element is zero or not zero)
-is extracted from the XML file from element <ModelStructure>._
+. _The incidence information of the matrix (whether an element is zero or not zero) is extracted from the XML file from element <ModelStructure>._
 
-. _For the columns determined in (2), one call to <<fmi3GetDirectionalDerivative>> is made.
-After each such call, the elements of the resulting directional derivative vector are copied into their correct locations of the partial derivative matrix._
+. _For the columns determined in (2), one call to <<fmi3GetDirectionalDerivative>> is made._
+_After each such call, the elements of the resulting directional derivative vector are copied into their correct locations of the partial derivative matrix._
 
 _More details and implementational notes are available from (&#197;kesson et.al. 2012).]_
 
@@ -1034,7 +1056,10 @@ The number of event indicators can change during simulation if it depends on one
 include::../headers/fmi3FunctionTypes.h[tags=GetNumberOfEventIndicators]
 ----
 
-This function returns the number of event indicators.  The dependency of the number of event indicators on <<structuralParameter,`structural parameters`>> must be specified in the `ModelStructure` in the element `NumberOfEventIndicators`. This element is optional but necessary if the number of event indicators depends on <<structuralParameter,`structural parameters`>>. If the `NumberOfEventIndicators` element is not present or its <<dependencies>> list is empty, the number of event indicators does not depend on <<structuralParameter,`structural parameters`>>, i.e. it is constant.
+This function returns the number of event indicators.
+The dependency of the number of event indicators on <<structuralParameter,`structural parameters`>> must be specified in the `ModelStructure` in the element `NumberOfEventIndicators`.
+This element is optional but necessary if the number of event indicators depends on <<structuralParameter,`structural parameters`>>.
+If the `NumberOfEventIndicators` element is not present or its <<dependencies>> list is empty, the number of event indicators does not depend on <<structuralParameter,`structural parameters`>>, i.e. it is constant.
 
 The `numberOfEventIndicators` attribute of the `fmiModelDescription` element holds the number of event indicators if all <<structuralParameter,`structural parameters`>> are unchanged, i.e. set to their <<start>> value.
 
@@ -1055,9 +1080,14 @@ This function returns the number of <<state,`states`>>.
 
 ==== Getting Number of Variable Dependencies and Variable Dependencies
 
-The sparseness information within arrays is not given in the xml description. The sparseness muss be retrieved during run-time using the C-API functions. Zeros in the Jacobian are not necessarily due to the structure of the model. Zero in the Jacobian might be due to the current operating point (current <<state>>, current <<input,`inputs`>>) and not due to a structural independence.
+The sparseness information within arrays is not given in the xml description.
+The sparseness muss be retrieved during run-time using the C-API functions.
+Zeros in the Jacobian are not necessarily due to the structure of the model.
+Zero in the Jacobian might be due to the current operating point (current <<state>>, current <<input,`inputs`>>) and not due to a structural independence.
 
-The variable dependency information in the XML description does not resolve to dependencies of individual array elements, nor does it take into account changing dependencies due to resizing of arrays via <<structuralParameter,`structural parameters`>>. An FMU can indicate via the `providesPerElementDependencies` capability flag that it is able to provide detailed dependency information at runtime through the following C-API. Note that these functions are only defined if the `providesPerElementDependencies` capability flag = `true`.
+The variable dependency information in the XML description does not resolve to dependencies of individual array elements, nor does it take into account changing dependencies due to resizing of arrays via <<structuralParameter,`structural parameters`>>.
+An FMU can indicate via the `providesPerElementDependencies` capability flag that it is able to provide detailed dependency information at runtime through the following C-API.
+Note that these functions are only defined if the `providesPerElementDependencies` capability flag = `true`.
 
 The number of dependencies of a given variable, which may change if <<structuralParameter,`structural parameters`>> are changed, can be retrieved by calling the following function:
 
@@ -1087,15 +1117,25 @@ This function returns the dependency information for a single variable.
 
 - Argument `nDependencies` specifies the number of dependencies that the calling environment allocated space for in the result buffers, and should correspond to the returned by calling <<fmi3GetNumberOfVariableDependencies>>.
 
-- Argument `elementIndexDependent` must point to a buffer of `size_t` values of size `nDependencies` allocated by the calling environment. It is filled in by this function with the element index of the dependent variable that dependency information is provided for. The element indices start with 1. Using the element index 0 means all elements of the variable. (Note: If an array has more than one dimension the indices are serialized in the same order as defined for values).
+- Argument `elementIndexDependent` must point to a buffer of `size_t` values of size `nDependencies` allocated by the calling environment.
+It is filled in by this function with the element index of the dependent variable that dependency information is provided for.
+The element indices start with 1. Using the element index 0 means all elements of the variable.
+(Note: If an array has more than one dimension the indices are serialized in the same order as defined for values).
 
-- Argument `vrIndependent` must point to a buffer of `fmi3ValueReference` values of size `nDependencies` allocated by the calling environment. It is filled in by this function with the value reference of the <<independent>> variable that this dependency entry is dependent upon.
+- Argument `vrIndependent` must point to a buffer of `fmi3ValueReference` values of size `nDependencies` allocated by the calling environment.
+It is filled in by this function with the value reference of the <<independent>> variable that this dependency entry is dependent upon.
 
-- Argument `elementIndexIndependent` must point to a buffer of `size_t` values of size `nDependencies` allocated by the calling environment. It is filled in by this function with the element index of the <<independent>> variable that this dependency entry is dependent upon. The element indices start with 1. Using the element index 0 means all elements of the variable. (Note: If an array has more than one dimension the indices are serialized in the same order as defined for values).
+- Argument `elementIndexIndependent` must point to a buffer of `size_t` values of size `nDependencies` allocated by the calling environment.
+It is filled in by this function with the element index of the <<independent>> variable that this dependency entry is dependent upon.
+The element indices start with 1.
+Using the element index 0 means all elements of the variable.
+(Note: If an array has more than one dimension the indices are serialized in the same order as defined for values).
 
-- Argument `dependencyType` must point to a buffer of `fmi3DependencyKind` values of size `nDependencies` allocated by the calling environment. It is filled in by this function with
-the enumeration value describing the dependency of this dependency entry.
+- Argument `dependencyType` must point to a buffer of `fmi3DependencyKind` values of size `nDependencies` allocated by the calling environment.
+It is filled in by this function with the enumeration value describing the dependency of this dependency entry.
 
 If this function is called before the <<fmi3ExitInitializationMode>> call, it returns the initial dependencies.
 If this function is called after the <<fmi3ExitInitializationMode>> call, it returns the run-time dependencies.
-The retrieved dependency information of one variable becomes invalid as soon as a <<structuralParameter,`structural parameter`>>linked to the variable or to any of its depending variables are set. As a consequence, if you change <<structuralParameter,`structural parameters`>> affecting B or A, the dependency of B becomes invalid. The dependency information must change only if <<structuralParameter,`structural parameters`>> are changed.
+The retrieved dependency information of one variable becomes invalid as soon as a <<structuralParameter,`structural parameter`>> linked to the variable or to any of its depending variables are set.
+As a consequence, if you change <<structuralParameter,`structural parameters`>> affecting B or A, the dependency of B becomes invalid.
+The dependency information must change only if <<structuralParameter,`structural parameters`>> are changed.

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -28,7 +28,7 @@ The types used in the FMI schema files are:
 [cols="1,3,1"]
 |====
 |_XML_
-|Description (http://www.w3.org/TR/xmlschema-2/[http://www.w3.org/TR/XMLschema-2/])
+|Description (http://www.w3.org/TR/xmlschema-2/)
 |_Mapping to C_
 
 |`double`

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1,18 +1,18 @@
 === FMI Description Schema [[fmi-description-schema]]
 
-All static information related to an FMU is stored in the text file `modelDescription.xml`
-in XML format.
+All static information related to an FMU is stored in the text file `modelDescription.xml` in XML format.
 Especially, the FMU variables and their attributes such as name, unit, default <<initial>> value, etc. are stored in this file.
 The structure of this XML file is defined with the schema file `fmiModelDescription.xsd`.
 This schema file utilizes the following helper schema files:
 
-- `fmi3Annotation.xsd` +
-- `fmi3AttributeGroups.xsd` +
-- `fmi3FMUType.xsd` +
-- `fmi3Type.xsd` +
-- `fmi3Variable.xsd` +
-- `fmi3VariableDependency.xsd` +
+- `fmi3Annotation.xsd`
+- `fmi3AttributeGroups.xsd`
+- `fmi3FMUType.xsd`
+- `fmi3Terminal.xsd`
+- `fmi3Type.xsd`
 - `fmi3Unit.xsd`
+- `fmi3Variable.xsd`
+- `fmi3VariableDependency.xsd`
 
 In this section these schema files are discussed.
 The normative definition are the above mentioned schema files footnote:[Note that the screenshots of this section have been generated from the schema files with the tool "Altova XMLSpy" (www.altova.com).
@@ -22,8 +22,8 @@ An efficient open source XML parser is SAX (http://sax.sourceforge.net/, http://
 All data from the XML file is only defined via attributes and not via elements.
 Therefore, only an attribute handler needs to be defined for a SAX parser.].
 Below, optional elements are marked with a dashed box.
-The required data types (like: xs:normalizedString) are defined in the XML-schema standard: http://www.w3.org/TR/XMLschema-2/.
-The types used in the fmi3 schema files are:
+The required data types (like: `xs:normalizedString`) are defined in https://www.w3.org/TR/xmlschema-2/[XML Schema Part 2: Datatypes Second Edition].
+The types used in the FMI schema files are:
 
 [cols="1,3,1"]
 |====
@@ -31,38 +31,38 @@ The types used in the fmi3 schema files are:
 |Description (http://www.w3.org/TR/xmlschema-2/[http://www.w3.org/TR/XMLschema-2/])
 |_Mapping to C_
 
-|xs:double
+|`double`
 |IEEE double-precision 64-bit floating point type _[In order to not loose precision,
-a number of this type should be stored on an XML file with at least *16* significant digits; for example, 2/3 should be stored as `0.6666666666666667`]_
-|double
+a number of this type should be stored on an XML file with at least 16 significant digits; for example, 2/3 should be stored as `0.6666666666666667`]_
+|`double`
 
-|xs:int
+|`int`
 |Integer number with maximum value 2147483647 and minimum value -2147483648 (32 bit Integer)
-|int
+|`int`
 
-|xs:unsignedInt
+|`unsignedInt`
 |Integer number with maximum value 4294967295 and minimum value 0 (unsigned 32 bit Integer)
-|unsigned int
+|`unsigned int`
 
-|xs:boolean
-|Boolean number. Legal literals: `false`, `true`, 0, 1
-|char
+|`boolean`
+|Boolean number. Legal literals: `false`, `true`, `0`, `1`
+|`char`
 
-|xs:string
+|`string`
 |Any number of characters
-|char*
+|`char*`
 
-|xs:normalizedString
+|`normalizedString`
 |String without carriage return, line feed, and tab characters
-|char*
+|`char*`
 
-|xs:hexBinary
+|`hexBinary`
 |Arbitrary hex-encoded binary data
-|char*
+|`char*`
 
-|xs:dateTime
+|`dateTime`
 |Date, time and time zone (for details see the link above).
-Example: 2002-10-23T12:00:00Z (noon on October 23, 2002, Greenwich Mean Time)
+Example: `2002-10-23T12:00:00Z` (noon on October 23, 2002, Greenwich Mean Time)
 |tool specific
 |====
 
@@ -74,15 +74,16 @@ It is required that the encoding scheme is always UTF-8:
 include::examples/co_simulation.xml[lines=1]
 ----
 
-The FMI schema files (*.xsd) are also stored in "UTF-8". +
-_[Note that the definition of an encoding scheme is a prerequisite in order for the XML file to contain letters outside of the 7 bit ANSI ASCII character set, such as German umlauts, or Asian characters. Furthermore, note the FMI calling interface requires that strings are encoded in UTF-8.
-Since the XML files are also required to be encoded in UTF-8, string variables need not to be transformed when reading from the XML files in to C string variables.]._
+The FMI schema files (`fmi3*.xsd`) are also stored in UTF-8. +
+_[Note that the definition of an encoding scheme is a prerequisite in order for the XML file to contain letters outside of the 7 bit ANSI ASCII character set, such as German umlauts, or Asian characters._
+_Furthermore, note the FMI calling interface requires that strings are encoded in UTF-8._
+_Since the XML files are also required to be encoded in UTF-8, string variables need not to be transformed when reading from the XML files in to C string variables.]._
 
-The special values NAN, +INF, -INF for variables values are not allowed in the FMI XML files.
+The special values `NaN`, `+INF`, `-INF` for variables values are not allowed in the FMI XML files.
 
-_[Note that child information items, such as elements in a sequence are ordered lists according to document order, whereas attribute information items are unordered sets (see http://www.w3.org/TR/XML-infoset/#infoitem.element).
-The FMI schema is based on ordered lists in a sequence and therefore parsing must preserve this order.
-For example, the information stored in `ModelVariables.Derivatives` is only correct if this property is fulfilled.]_
+_[Note that child information items, such as elements in a sequence are ordered lists according to document order, whereas attribute information items are unordered sets (see http://www.w3.org/TR/XML-infoset/#infoitem.element)._
+_The FMI schema is based on ordered lists in a sequence and therefore parsing must preserve this order._
+_For example, the information stored in `ModelVariables.Derivatives` is only correct if this property is fulfilled.]_
 
 ==== Definition of an FMU (fmiModelDescription) [[fmiModelDescription]]
 
@@ -151,19 +152,18 @@ image::images/fmiModelDescription_schema_2.png[width=80%, align="center"]
 
 |`fmiVersion`
 |Version of FMI for Model Exchange or FMI for Co-Simulation that was used to generate the XML file.
-The value for this version is "2.0".
-Future minor revisions are denoted as "2.0.1", "2.0.2", ...
+The value for this version is `3.0`.
+Future minor revisions are denoted as `3.0.1`, `3.1`, ...
 
 _[During development prototype FMU implementations can indicate compliance with a certain development version based on the tags available at https://github.com/modelica/fmi-standard/tags._
 _For example the value for the FMI 3.0 Alpha 2 release is `3.0-alpha.2`.]_
 
 |`modelName`
-|The name of the model as used in the modeling environment that generated the XML file, such as "Modelica.Mechanics.Rotational.Examples.CoupledClutches".
+|The name of the model as used in the modeling environment that generated the XML file, such as `Modelica.Mechanics.Rotational.Examples.CoupledClutches`.
 
 |`instantiationToken`
 |The instantiationToken is a string that can be used by the FMU to check that the XML file is compatible with the implementation of the FMU.
 For this purpose the importing tool must pass the instantiationToken from the `modelDescription.xml` to the `fmi3Instantiate` function call.
-
 
 |`description`
 |Optional string with a brief description of the model.
@@ -172,24 +172,21 @@ For this purpose the importing tool must pass the instantiationToken from the `m
 |Optional string with the name and organization of the model author.
 
 |`version`
-|Optional version of the model, for example, "1.0".
+|Optional version of the model _[for example `1.0`]_.
 
 |`copyright`
-|Optional information on the intellectual property copyright for this FMU. +
-_[Example: copyright = "(C) My Company 2011"]_.
+|Optional information on the intellectual property copyright for this FMU _[for example `(C) My Company 2011`]_.
 
 |`license`
 |Optional information on the intellectual property licensing
-for this FMU. +
-_[Example: license = "BSD license <license text or link to license>"]_.
+for this FMU _[for example `BSD license <license text or link to license>`]_.
 
 |`generationTool`
 |Optional name of the tool that generated the XML file.
 
 |`generationDateAndTime`
 |Optional date and time when the XML file was generated.
-The format is a subset of "xs:dateTime" and should be: "YYYY-MM-DDThh:mm:ssZ" (with one `T` between date and time; `Z` characterizes the Zulu time zone, in other words, Greenwich meantime). +
-_[Example: "2009-12-08T14:33:22Z"]_.
+The format is a subset of `dateTime` and should be: `YYYY-MM-DDThh:mm:ssZ` (with one `T` between date and time; `Z` characterizes the Zulu time zone, in other words, Greenwich meantime) _[for example `2009-12-08T14:33:22Z`]_.
 
 |`variableNamingConvention`
 |Defines whether the variable names in `ModelVariables / Variable / name` and in `TypeDefinitions / Type / name` follow a particular convention.
@@ -197,16 +194,11 @@ For the details, see <<variableNamingConvention>>. Currently standardized are:
 
 - `flat`: A list of strings (the default).
 
-- `structured`: Hierarchical names with "." as hierarchy separator,
-and with array elements and derivative characterization.
+- `structured`: Hierarchical names with `.` as hierarchy separator, and with array elements and derivative characterization.
 
 |`numberOfEventIndicators`
-|The (fixed) number of event indicators for an FMU based on FMI for Model Exchange. +
-For Co-Simulation, this value is ignored.
+|The (fixed) number of event indicators for an FMU based on FMI for Model Exchange. For Co-Simulation, this value is ignored.
 |====
-
-_[The attribute `numberOfContinuousStates` available in FMI 1.0 has been removed for FMI 2.0,
-since this information can be deduced from the remaining data in the XML file.]_
 
 ==== Definition of Source Code (BuildConfiguration)
 
@@ -266,16 +258,16 @@ The `PreprocessorDefinition` element defines a preprocessor definition that need
 |Attribute
 |Description
 
-|name
+|`name`
 |Name of the preprocessor definition
 
-|value
+|`value`
 |Value of the preprocessor definition
 
-|optional
+|`optional`
 |Determines wether the definition is optional (default is `false`)
 
-|description
+|`description`
 |Description of the preprocessor definition
 |====
 
@@ -288,10 +280,10 @@ The `Option` element defines a possible value for the `PreprocessorDefinition`. 
 |Attribute
 |Description
 
-|value
+|`value`
 |Value of the preprocessor definition option
 
-|description
+|`description`
 |Description of the preprocessor definition option
 |====
 
@@ -304,7 +296,7 @@ The `IncludeDirectory` element defines the include directories that need to be p
 |Attribute
 |Description
 
-|name
+|`name`
 |Path of the include directory relative to the `sources` directory
 |====
 
@@ -317,18 +309,18 @@ The `Library` element defines a static library required to link the model binary
 |Attribute
 |Description
 
-|name
+|`name`
 |Name of the library
 
-|version
+|`version`
 |Version specifier of the library as defined in https://www.python.org/dev/peps/pep-0440/#version-specifiers[PEP 440].
 The characters `>` (greater-than) and `<` (less-than) must be escaped as `&gt;` and `&lt;`.
  _[For example `2.5`, `>=2.0,<3.0` or `>=1.0,!=1.2`]_.
 
-|external
+|`external`
 |Boolean attribute that determines wether the library is contained in the `binaries/<platform_tuple>` directory (`false`) or if it has to be provided by the environment (`true`). The default is `false`.
 
-|description
+|`description`
 |Description of the library definition option
 |====
 
@@ -348,13 +340,13 @@ include::examples/build_configuration.xml[tags=PlantModel]
 
 ==== Definition of Units (UnitDefinitions)
 
-_[In this section, the units of the variables are (optionally) defined.
-Unit support is important for technical systems since otherwise it is very easy for errors to occur.
-Unit handling is a difficult topic, and there seems to be no method available that is really satisfactory for all applications, such as unit check, unit conversion, unit propagation or dimensional analysis.
-In FMI, a pragmatic approach is used that takes into account that every software system supporting units has potentially its own specific technique to describe and utilize units.
-The approach used here is slightly different than FMI 1.0 to reduce the need for standardized string representations.]_
+_[In this section, the units of the variables are (optionally) defined._
+_Unit support is important for technical systems since otherwise it is very easy for errors to occur._
+_Unit handling is a difficult topic, and there seems to be no method available that is really satisfactory for all applications, such as unit check, unit conversion, unit propagation or dimensional analysis._
+_In FMI, a pragmatic approach is used that takes into account that every software system supporting units has potentially its own specific technique to describe and utilize units._
+_The approach used here is slightly different than FMI 1.0 to reduce the need for standardized string representations.]_
 
-Element "*UnitDefinitions*" of `fmiModelDescription` is defined as:
+Element `UnitDefinitions` of `fmiModelDescription` is defined as:
 
 image::images/UnitDefinitions_schema.png[]
 
@@ -362,20 +354,20 @@ It consists of zero or more `Unit` definitions footnote:[If no units are defined
 If 1 or more units are defined, this element must be present.].
 A `Unit` is defined by its `name` attribute such as `N.m` or `N*m` or `Nm`, which must be unique with respect to all other defined elements of the `UnitDefinitions` list.
 If a variable is associated with a `Unit`, then the value of the variable has to be provided with the `fmi3SetXXX` functions or else is returned by the `fmi3GetXXX` functions with respect to this `Unit`.
-_[The purpose of the name is to uniquely identify a unit and, for example, use it to display the unit in menus or in plots.
-Since there is no standard to represent units in strings, and there are different ways how this is performed in different tools, no specific string representation of the unit is required.]_
+_[The purpose of the name is to uniquely identify a unit and, for example, use it to display the unit in menus or in plots._
+_Since there is no standard to represent units in strings, and there are different ways how this is performed in different tools, no specific string representation of the unit is required.]_
 
 Optionally, a value given in unit `Unit` can be converted to a value with respect to unit `BaseUnit` utilizing the conversion `factor` and `offset` attributes:
 
 image::images/BaseUnit_schema.png[width=50%, align="center"]
 
 Besides `factor` and `offset`, the `BaseUnit` definition consists of the exponents of the 7 SI base units `kg`, `m`, `s`, `A`, `K`, `mol`, `cd`, and of the exponent of the SI derived unit `rad`.
-_[Depending on the analysis/operation carried out, the SI derived unit `rad` is or is not utilized, see discussion below.
-The additional `rad` base unit helps to handle the often occurring quantities in technical systems that depend on an angle.]_
+_[Depending on the analysis/operation carried out, the SI derived unit `rad` is or is not utilized, see discussion below._
+_The additional `rad` base unit helps to handle the often occurring quantities in technical systems that depend on an angle.]_
 
-A value with respect to `Unit` (abbreviated as "Unit_value") is converted with respect to `BaseUnit` (abbreviated as "BaseUnit_value") by the equation:
+A value with respect to `Unit` (abbreviated as `Unit_value`) is converted with respect to `BaseUnit` (abbreviated as `BaseUnit_value`) by the equation:
 
-BaseUnit_value = `factor`* Unit_value + `offset`
+`BaseUnit_value = factor * Unit_value + offset`
 
 _[For example, if_ latexmath:[\color{blue}{p_{bar}}] _is a pressure value in unit `bar`, and_ latexmath:[\color{blue}{p_{Pa}}] _is the pressure value in `BaseUnit`, then_
 
@@ -383,7 +375,7 @@ latexmath:[\color{blue}{p_{Pa} = 10^5 p_{bar}}]
 
 _and therefore, `factor = 1.0e5` and `offset = 0.0`._
 
-_[In the following table several unit examples are given (Note that if in column `exponents` the definition "latexmath:[\color{blue}{kgm^2 / s^2}]" is present, then the attributes of `BaseUnit` are: `kg=1, m=2, s=-2`):_
+_In the following table several unit examples are given (Note that if in column `exponents` the definition "latexmath:[\color{blue}{kgm^2 / s^2}]" is present, then the attributes of `BaseUnit` are: `kg=1, m=2, s=-2`):_
 
 [cols="1,1,1,1,1"]
 |====
@@ -479,26 +471,24 @@ Signal connection check::
 +
 _When two signals v1 and v2 are connected together, and on at least one of the signals no `BaseUnit` element is defined, then the connection equation "v2 = v1" holds (if v1 is an <<output>> of an FMU and v2 is an <<input>> of another FMU, with `fmi3GetXXX` the value of v1 is inquired and used as value for v2 by calling `fmi3SetXXX`)._
 +
-_When two signals v1 and v2 are connected together, and for both of them `BaseUnit` elements are defined, then they must have identical exponents of their `BaseUnit`.
-If `factor` and `offset` are also identical, again the connection equation "v2 = v1" holds.
-If `factor` and `offset` are not identical, the tool may either trigger an error or, if supported, perform a conversion; in other words, use the connection equation (in this case the `relativeQuantity` of the `TypeDefinition`, see below, has to be taken into account in order to determine whether `offset` shall or shall not be utilized):_
+_When two signals v1 and v2 are connected together, and for both of them `BaseUnit` elements are defined, then they must have identical exponents of their `BaseUnit`._
+_If `factor` and `offset` are also identical, again the connection equation `v2 = v1` holds._
+_If `factor` and `offset` are not identical, the tool may either trigger an error or, if supported, perform a conversion; in other words, use the connection equation (in this case the `relativeQuantity` of the `TypeDefinition`, see below, has to be taken into account in order to determine whether `offset` shall or shall not be utilized):_
 +
-`factor(v1)*v1 + offset(v1) = factor(v2)*v2 + offset(v2)`
+`factor(v1) * v1 + offset(v1) = factor(v2) * v2 + offset(v2)`
 +
-_As a result, wrong connections can be detected (for example, connecting a force with an angle signal would trigger an error) and conversions between, say, US and SI units can be either automatically performed or, if not supported, an error is triggered as well.
+_As a result, wrong connections can be detected (for example, connecting a force with an angle signal would trigger an error) and conversions between, say, US and SI units can be either automatically performed or, if not supported, an error is triggered as well._
 +
-_[Note that this approach is not satisfactory for variables belonging to different quantities that have, however, the same `BaseUnit`, such as quantities `Energy` and `Torque`, or `AngularVelocity` and `Frequency`.
-To handle such cases, quantity definitions have to be taken into account (see `TypeDefinitions`) and quantity names need to be standardized.]_
+_[Note that this approach is not satisfactory for variables belonging to different quantities that have, however, the same `BaseUnit`, such as quantities `Energy` and `Torque`, or `AngularVelocity` and `Frequency`._
+_To handle such cases, quantity definitions have to be taken into account (see `TypeDefinitions`) and quantity names need to be standardized.]_
 +
 _This approach allows a general treatment of units, without being forced to standardize the grammar and allowed values for units (for example, in FMI 1.0, a unit could be defined as `N.m` in one FMU and as `N*m` in another FMU, and a tool would have to reject a connection, since the units are not identical. In FMI 2.0, the connection would be accepted, provided both elements have the same `BaseUnit` definition)._
 
 Dimensional analysis of equations::
 +
-_In order to check the validity of equations in a modeling language,
-the defined units can be used for dimensional analysis,
-by using the `BaseUnit` definition of the respective unit.
-For this purpose, the `BaseUnit` `rad` has to be treated as `1`.
-Example:_
+_In order to check the validity of equations in a modeling language, the defined units can be used for dimensional analysis, by using the `BaseUnit` definition of the respective unit._
+_For this purpose, the `BaseUnit` `rad` has to be treated as `1`._
+_Example:_
 +
 [latexmath]
 ++++
@@ -510,19 +500,21 @@ J \cdot \alpha = f \rightarrow [kg.m^2]*[rad/s^2] = [kg.m/s^2] & \quad \text{// 
 
 Unit propagation::
 +
-_If unit definitions are missing for signals, they might be deduced from the equations where the signals are used.
-If no unit computation is needed, `rad` is propagated.
-If a unit computation is needed and one of the involved units has `rad` as a `BaseUnit`, then unit propagation is not possible.
-Examples:_
+_If unit definitions are missing for signals, they might be deduced from the equations where the signals are used._
+_If no unit computation is needed, `rad` is propagated._
+_If a unit computation is needed and one of the involved units has `rad` as a `BaseUnit`, then unit propagation is not possible._
+_Examples:_
 +
 - _a = b + c, and `Unit` of c is provided, but not `Unit` of a and b:_ +
-_The Unit definition of `c` (in other words, `Unit.name`, `BaseUnit`, `DisplayUnit`) is also used for `a` and `b`.
-For example, if BaseUnit(c) = `rad/s`, then BaseUnit(a) = BaseUnit(b) = `rad/s`._
+_The Unit definition of `c` (in other words, `Unit.name`, `BaseUnit`, `DisplayUnit`) is also used for `a` and `b`._
+_For example, if BaseUnit(c) = `rad/s`, then BaseUnit(a) = BaseUnit(b) = `rad/s`._
 +
 - _a = b*c, and `Unit` of a and of c is provided, but not `Unit` of b:_ +
-_If `rad` is either part of the `BaseUnit` of `a` and/or of `c`, then the `BaseUnit` of `b` cannot be deduced (otherwise it can be deduced).
-Example: If `BaseUnit(a) = kg.m/s2` and `BaseUnit(c) = m/s2`, then the `BaseUnit(b) can be deduced to be `kg`.
-In such a case `Unit.name` of b cannot be deduced from the `Unit.name` of `a` and `c`, and a tool would typically construct the `Unit.name` of `b` from the deduced `BaseUnit`.]_
+_If `rad` is either part of the `BaseUnit` of `a` and/or of `c`, then the `BaseUnit` of `b` cannot be deduced (otherwise it can be deduced)._
+_Example: If `BaseUnit(a) = kg.m/s2` and `BaseUnit(c) = m/s2`, then the `BaseUnit(b) can be deduced to be `kg`._
+_In such a case `Unit.name` of b cannot be deduced from the `Unit.name` of `a` and `c`, and a tool would typically construct the `Unit.name` of `b` from the deduced `BaseUnit`._
+
+_]_
 
 Additionally to the unit definition, optionally a set of display units can be defined that can be utilized for <<input>> / <<output>> of a value:
 
@@ -532,12 +524,11 @@ A `DisplayUnit` is defined by `name`, `factor` and `offset`.
 The attribute `name` must be unique with respect to all other `names` of the `DisplayUnit` definitions of the same `Unit` [(different `Unit` elements may have the same `DisplayUnit` names)].
 A value with respect to Unit (abbreviated as `Unit_value`) is converted with respect to `DisplayUnit` (abbreviated as `DisplayUnit_value`) by the equation:
 
-DisplayUnit_value = `factor` * Unit_value + `offset`
+`DisplayUnit_value = factor * Unit_value + offset`
 
 _[`offset` is, for example, needed for temperature units.]_
 
-_[For example, if latexmath:[\color{blue}{T_K}] is the temperature value of `Unit.name` (in `K`) and latexmath:[\color{blue}{T_F}] is the temperature value of `DisplayUnit` (in `&#176;F`),
-then_
+_[For example, if latexmath:[\color{blue}{T_K}] is the temperature value of `Unit.name` (in `K`) and latexmath:[\color{blue}{T_F}] is the temperature value of `DisplayUnit` (in `&#176;F`), then_
 
 [latexmath]
 ++++
@@ -546,8 +537,8 @@ T_F = (9/5) * (T_K - 273.15) + 32
 
 _and therefore, `factor = 1.8 (=9/5)` and `offset = -459.67 (= 32 - 273.15*9/5)`._
 
-_Both the `DisplayUnit.name` definitions as well as the `Unit.name` definitions are used in the `Variable` elements.
-Example of a definition:_
+_Both the `DisplayUnit.name` definitions as well as the `Unit.name` definitions are used in the `Variable` elements._
+_Example of a definition:_
 
 [source, xml]
 ----
@@ -566,8 +557,7 @@ image::images/TypeDefinitions_schema.png[width=90%, align="center"]
 This element consists of a set of `SimpleType` definitions according to schema `fmi3SimpleType` in file `fmi3Type.xsd`.
 One `SimpleType` has a type `name` and `description` as attributes.
 Attribute `name` must be unique with respect to all other elements of the `TypeDefinitions` list.
-Furthermore,
-`name` of a `SimpleType` must be different to all `name` attributes of `Variable`pass:[s] _[if the same names would be used, then this would nearly always give problems when importing the FMU in an environment such as Modelica, where a type name cannot be used as instance name]_.
+Furthermore, `name` of a `SimpleType` must be different to all `name` attributes of `Variable`pass:[s] _[if the same names would be used, then this would nearly always give problems when importing the FMU in an environment such as Modelica, where a type name cannot be used as instance name]_.
 Additionally, one of the elements `Real`, `Integer`, `Boolean`, `String`, `Binary`, `Enumeration` or `Clock` must be present.
 They have the following definitions:
 
@@ -587,47 +577,49 @@ The attributes and elements have the following meaning:
 |_Name_
 |_Description_
 
-|quantity
+|`quantity`
 |Physical quantity of the variable. _[For example, `Angle`, or `Energy`.
 The quantity names are not standardized]_
 
-|unit
-|Unit of the variable defined with `UnitDefinitions.Unit.name` that is used for the model equations. _[For example, `N.m`: in this case a `Unit.name = `N.m` must be present under `UnitDefinitions`.]_
+|`unit`
+|Unit of the variable defined with `UnitDefinitions.Unit.name` that is used for the model equations.
+_[For example, `N.m`: in this case a `Unit.name = `N.m` must be present under `UnitDefinitions`.]_
 
-|displayUnit
+|`displayUnit`
 |Default display unit. The conversion to the `unit` is defined with the element `<fmiModelDescription><UnitDefinitions>`.
 If the corresponding `displayUnit` is not defined under `<UnitDefinitions> <Unit> <DisplayUnit>`, then `displayUnit` is ignored.
 It is an error if `displayUnit` is defined in element `Real`, but `unit` is not, or unit is not defined under `<UnitDefinitions><Unit>`.
 
-|mimeType
+|`mimeType`
 |Indicates the type of data passed as a binary.
-Defaults to `application/octet-stream`, which is unspecific. Implementations can use this information to provide guidance to the user about valid/useful connections.
+Defaults to `application/octet-stream`, which is unspecific.
+Implementations can use this information to provide guidance to the user about valid/useful connections.
 
-|relativeQuantity
+|`relativeQuantity`
 |If this attribute is `true`, then the `offset` of `displayUnit` must be ignored.
 _[For example, 10 degree Celsius = 10 Kelvin if `relativeQuantity = true` and not 283.15 Kelvin.]_
 
-|min
+|`min`
 |Minimum value of variable (variable value &#8805; `min`).
 If not defined, the minimum is the largest negative number that can be represented on the machine.
 The `min` definition is information from the FMU to the environment defining the region in which the FMU is designed to operate, see also comment after this table.
 
-|max
+|`max`
 |Maximum value of variable (variable value &#8804; `max`).
 If not defined, the maximum is the largest positive number that can be represented on the machine.
 The `max` definition is information from the FMU to the environment defining the region in which the FMU is designed to operate, see also comment after this table.
 
-|nominal
+|`nominal`
 |Nominal value of variable.
 If not defined and no other information about the nominal value is available, then nominal = 1 is assumed. +
 _[The nominal value of a variable can be, for example, used to determine the absolute tolerance for this variable as needed by numerical algorithms:_ +
-absoluteTolerance = `nominal` * `tolerance` * 0.01 +
+`absoluteTolerance = nominal * tolerance * 0.01` +
 _where `tolerance` is, for example, the relative tolerance defined in `<DefaultExperiment>`, see <<DefaultExperiment>>.]_
 
-|unbounded
+|`unbounded`
 |If `true`, indicates that during time integration, the variable gets a value much larger than its nominal value `nominal`.
-_[Typical examples are the monotonically increasing rotation angles of crank shafts and the longitudinal position of a vehicle along the track in long distance simulations.
-This information can, for example, be used to increase numerical stability and accuracy by setting the corresponding bound for the relative error to zero (relative tolerance = 0.0), if the corresponding variable or an alias of it is a continuous <<state>> variable.]_
+_[Typical examples are the monotonically increasing rotation angles of crank shafts and the longitudinal position of a vehicle along the track in long distance simulations._
+_This information can, for example, be used to increase numerical stability and accuracy by setting the corresponding bound for the relative error to zero (relative tolerance = 0.0), if the corresponding variable or an alias of it is a continuous <<state>> variable.]_
 
 |Item
 |Items of an enumeration has a sequence of `name` and `value` pairs.
@@ -635,21 +627,20 @@ The values can be any integer number but must be unique within the same enumerat
 An `Enumeration` element must have at least one Item.
 |====
 
-_[Attributes `min` and `max` can be set for variables of type Real, Integer or Enumeration.
-The question is how `fmi3SetReal`, `fmi3SetInteger`, `fmi3GetReal`,
-`fmi3GetInteger` shall utilize this definition.
-There are several conflicting requirements:_ +
+_[Attributes `min` and `max` can be set for variables of type Real, Integer or Enumeration._
+_The question is how `fmi3SetReal`, `fmi3SetInteger`, `fmi3GetReal`, `fmi3GetInteger` shall utilize this definition._
+_There are several conflicting requirements:_ +
 _Avoiding forbidden regions (for example, if `u` is an <<input>> and "sqrt(u)" is computed in the FMU, min=0 on `u` shall guarantee that only values of `u` in the allowed regions are provided)._
-_Numerical algorithms (ODE-solver, optimizers. nonlinear solvers) do not guarantee constraints.
-If a variable is outside of the bounds, the solver tries to bring it back into the bounds.
-As a consequence, calling `fmi3GetReal` during an iteration of such a solver might return values that are not in the defined min/max region.
-After the iteration is finalized, it is only guaranteed that a value is within its bounds up to a certain numerical precision._ +
-_In debug mode checks on min/max should be performed.
-For maximum performance on a real-time system the checks might not be performed._ +
-_The approach in FMI is therefore that min/max definitions are an information from the FMU to the environment defining the region in which the FMU is designed to operate.
-The environment is free to utilize this information (typically, in debug mode of the environment the min/max is checked in the cases as stated above).
-In any case, it is expected that the FMU handles variables appropriately where the region definition is critical.
-For example, dividing by an <<input>> (so the <<input>> should not be in a small range of zero) or taking the square root of an <<input>> (so the <<input>> should not be negative) may either result in `fmi3Error`, or the FMU is able to handle this situation in other ways._
+_Numerical algorithms (ODE-solver, optimizers. nonlinear solvers) do not guarantee constraints._
+_If a variable is outside of the bounds, the solver tries to bring it back into the bounds._
+_As a consequence, calling `fmi3GetReal` during an iteration of such a solver might return values that are not in the defined min/max region._
+_After the iteration is finalized, it is only guaranteed that a value is within its bounds up to a certain numerical precision._ +
+_In debug mode checks on min/max should be performed._
+_For maximum performance on a real-time system the checks might not be performed._ +
+_The approach in FMI is therefore that min/max definitions are an information from the FMU to the environment defining the region in which the FMU is designed to operate._
+_The environment is free to utilize this information (typically, in debug mode of the environment the min/max is checked in the cases as stated above)._
+_In any case, it is expected that the FMU handles variables appropriately where the region definition is critical._
+_For example, dividing by an <<input>> (so the <<input>> should not be in a small range of zero) or taking the square root of an <<input>> (so the <<input>> should not be negative) may either result in `fmi3Error`, or the FMU is able to handle this situation in other ways._
 
 _If the FMU is generated so that min/max shall be checked whenever meaningful (for example, for debug purposes), then the following strategy should be used:_
 
@@ -662,7 +653,6 @@ _If an FMU defines min/max values for Integer and Enumerations (<<local>> and <<
 
 _If an FMU defines min/max values for Reals, then the expected behavior of the FMU is that `fmi3GetReal` returns values at the solution (accepted steps of the integrators) in the defined range with a certain uncertainty related to the tolerances of the numerical algorithms.]_
 
-
 *Clock Type Definition* [[clock-type-definition]]
 
 Clocks are integrated in the element `ModelVariables` of fmiModelDescription as a `Variable` element with the base type `fmi3Clock`.
@@ -673,7 +663,7 @@ The variable sub type `fmi3Clock` provides additional attributes for defining <<
 |_Attribute-Name_
 |_Description_
 
-|clockType
+|`clockType`
 |The type of <<clock,`clocks`>> is defined based on the mandatory attribute `clockType`.
 If the properties of a <<clock>> adhere to synchronous clock theory it is defined with clockType = `STClock`.
 As an additional option for FMI for Co-Simulation discrete parts (that do not necessarily apply to synchronous clock theory) or continuous parts of the FMU can be associated to model partitions via <<clock,`clocks`>> whose ticks define the sampling points (i.e. communication points) for the variables of these model partitions.
@@ -681,7 +671,7 @@ Clocks that are defined for such cases have the clockType attribute value `CPClo
 It is not allowed to include <<clock,`clocks`>> of different `clockType` in one FMU.
 `clockType` is a required attribute.
 
-|priority
+|`priority`
 |The <<clock,`clocks`>> are ordered descending based on their priorities.
 The priority of a <<clock>> has to be defined via the integer attribute `priority` - smaller values have a higher priority.
 It is possible to define multiple <<clock,`clocks`>> with the same priority.
@@ -695,12 +685,12 @@ _[For periodic <<clock,`clocks`>> it is recommended to derive the priorities bas
 
 `priority` is a required attribute.
 
-|periodic
+|`periodic`
 |Clocks can be periodic or non-periodic. If a <<clock>> is periodic the attribute `periodic = true`.
 
 `periodic` is an optional attribute. The default value is `false`.
 
-|strict
+|`strict`
 |If a periodic <<clock>> is strictly periodic, the `strict` attribute is `true`.
 If the optional attribute `strict` is set to `true`, then the FMU and the simulation master have to respect the predefined interval and offset.
 If the optional attribute `strict` is set to `false` another interval or offset can be used, derived from the current simulation setup.
@@ -708,20 +698,20 @@ If the optional attribute `strict` is set to `false` another interval or offset 
 `strict` is an optional attribute. The default value is `false`.
 It is not allowed to set `strict` to `true` if `periodic = false`.
 
-|intervalCounter, shiftCounter, resolution
+|`intervalCounter`, `shiftCounter`, `resolution`
 |The interval of <<output>> or <<input>> periodic <<clock,`clocks`>> is defined with unsignedLong valued `intervalCounter` and `resolution`
 
-interval = `intervalCounter` / `resolution`.
+`interval = intervalCounter / resolution`.
 
 The initial tick of periodic <<clock,`clocks`>> may be delayed by defining a `shiftCounter` (default value 0). This results in the actual
 
-offset = interval * `shiftCounter` / `resolution`.
+`offset = interval * shiftCounter / resolution`.
 
 More information about clock intervals:
  <<additional-clock-properties>>.
 
 The attributes `intervalCounter`, `shiftCounter` and `resolution` are interval <<start>> values for periodic <<clock,`clocks`>> and must not be used together with non-periodic <<clock,`clocks`>>.
-If `strict = true` it is required to provide values for `intervalCounter`, `shiftCounter` and `resolution` in the modelDescription.
+If `strict = true` it is required to provide values for `intervalCounter`, `shiftCounter` and `resolution`.
 
 `intervalCounter` and `resolution` have no default value.
 |====
@@ -771,7 +761,7 @@ If a tool supports one of these log categories and wants to expose it, then an e
 |`logStatusFatal`
 |Log messages when returning `fmi3Fatal` status from any function.
 
-|logAll
+|`logAll`
 |Log all messages.
 |====
 
@@ -780,13 +770,12 @@ _[Typically, this string can be shown by a tool if more details for a log catego
 
 _[This approach to define `LogCategories` has the following advantages:_
 
-. _A simulation environment can present the possible log categories in a menu and the user can select the desired one (in the FMI 1.0 approach, there was no easy way for a user to figure out from a given FMU what log categories could be provided)._
+. _A simulation environment can present the possible log categories in a menu and the user can select the desired one (in the FMI 1.0 approach, there was no easy way for a user to figure out from a given FMU what log categories could be provided)._ +
+_Note that since element `LogCategories` is optional, an FMU does not need to expose its log categories._
 
-_[Note that since element `<LogCategories>` is optional, an FMU does not need to expose its log categories.]_
-
-. _The log output is drastically reduced, because via <<fmi3SetDebugLogging>> exactly the categories are set that shall be logged and therefore the FMU only has to print the messages with the corresponding categories to the <<logMessage>> function.
-In FMI 1.0, it was necessary to provide all log output of the FMU to the <<logMessage>> and then a filter in the <<logMessage>> could select what to show to the end-user.
-The approach introduced in FMI 2.0 is therefore much more efficient.]_
+. _The log output is drastically reduced, because via <<fmi3SetDebugLogging>> exactly the categories are set that shall be logged and therefore the FMU only has to print the messages with the corresponding categories to the <<logMessage>> function._
+_In FMI 1.0, it was necessary to provide all log output of the FMU to the <<logMessage>> and then a filter in the <<logMessage>> could select what to show to the end-user._
+_The approach introduced in FMI 2.0 is therefore much more efficient.]_
 
 ==== Definition of a Default Experiment (DefaultExperiment) [[DefaultExperiment]]
 
@@ -841,7 +830,7 @@ The normalized string attribute `name` of the `Terminal` element is the instance
 The normalized string attribute `matchingRule` describes the rules for variable matching in a connection.
 There are three predefined matching rules: plug, bus, and sequence.
 Other standards may define new matching rules.
-_[It is recommended that vendor specific rules start with "_vendorName" or "_toolName" to avoid namespace clashes.]_
+_[It is recommended that vendor specific rules start with `_vendorName` or `_toolName` to avoid namespace clashes.]_
 
 There is a sequence of terminal member variables, terminal stream member variables, and nested terminals in the `Terminal` element.
 The member variables are the exchanged variables.
@@ -872,10 +861,10 @@ An importing tool should connect terminals only if the number of member variable
 The normalized string `terminalKind` is an optional attribute. Other standards may define terminal kinds.
 It is intended that the `terminalKind` is used to define domain specific member variable sequences, member names and order, or high level restrictions for connections.
 
-_[Other terminal kinds should refer to the predefined matchingRules.
-Vendor specific terminal kinds should start with "_vendorName" or "_toolName" to avoid namespace clashes._
+_[Other terminal kinds should refer to the predefined matchingRules._
+_Vendor specific terminal kinds should start with `_vendorName` or `_toolName` to avoid namespace clashes._
 
-_Examples for terminalKind: StandardXXX_Mechanical_Translational, Modelica.Mechanics.Translational.Interfaces.Flange_a, vendorNameA_customTypeA, _vendorNameB_customLibrary_customTypeB_
+_Examples for `terminalKind`: `StandardXXX_Mechanical_Translational`, `Modelica.Mechanics.Translational.Interfaces.Flange_a`, `vendorNameA_customTypeA`, `_vendorNameB_customLibrary_customTypeB`._
 
 _The structured naming convention of the `ModelVariables` is <<independent>> from the terminal names and member variable names._
 
@@ -901,7 +890,7 @@ One variable can be part of several terminals, which is considered aliasing acco
 
 _[Tools which apply sequence based matching should also provide unique member names, so that all importing tools which use name based matching use the same member names._
 
-_The suggested variable naming scheme for the structured naming convention is: <ModelVariable name> = <terminalName>.<memberName>_
+_The suggested variable naming scheme for the structured naming convention is <ModelVariable name> = <terminalName>.<memberName>_.
 
 _Not all `ModelVariables` which have the prefix "<terminalName>." are a member variable, and there may exist member variables which don't have this prefix._
 
@@ -1054,13 +1043,13 @@ _However, an importing tool might choose to use the factor from the default coor
 _The area defined by the coordinate system suggested to be used as "clickable icon size" in other tools._
 _A `Terminal` might be placed outside of this area, so the visible bounding box has to be determined by the importing tool.]_
 
-The coordinate system default is x1=-100, y1=-100, x2=100, y2=100. This extent is used if the `CoordinateSystem` element is missing.
+The coordinate system default is `x1=-100, y1=-100, x2=100, y2=100`. This extent is used if the `CoordinateSystem` element is missing.
 The default `suggestedScalingFactorTo_mm` is 0.1.
 So the default coordinate system display size should be 20 mm width and 20 mm height.
 
 The FMU icon and all graphical representations provide the position and extent with the attributes `x1`, `y1`, `x2`, `y2`.
 The values of these attributes directly relate to this coordinate system and are not normalized.
-Flipping of the FMU icon or a terminal can be realized by setting its attributes x2 < x1 or y2 < y1 without changing the coordinate system.
+Flipping of the FMU icon or a terminal can be realized by setting its attributes `x2 < x1` or `y2 < y1` without changing the coordinate system.
 
 ===== Icon
 
@@ -1076,18 +1065,20 @@ This enables high quality rendering and printing in importing tools.
 
 image::images/fmiModelDescription_GraphicalRepresentation_Terminal_Schema.png[width=50%, pdfwidth=50%, align="center"]
 
-For `fmi3Terminals` (terminals which are listed in the `Terminals` element) the name of the terminal in the `GraphicalRepresentation` is equal to the name of the terminal in the `Terminals` element (e.g. "port_a").
+For `fmi3Terminals` (terminals which are listed in the `Terminals` element) the name of the terminal in the `GraphicalRepresentation` is equal to the name of the terminal in the `Terminals` element (e.g. `port_a`).
 _[If the graphical representation is used for an <<input>> or <<output>> (e.g. a Real <<input>> `u`), then a `Terminal` has to be added to the `Terminals` element which has one `TerminalMemberVariable`._
 _The name of the `Terminal` and the name of the `TerminalMemberVariable` should be equal to the name of the <<input>> / <<output>>.]_
 
 The `iconSource_PNG` is mandatory for a terminal, optionally an SVG file can be provided.
 The default connection stroke size and color can be provided, to define the intended connection line layout in the importing tool. The stroke size is given relative to the coordinate system extent.
-The stroke color is given in RGB values from 0 to 255. E.g.: "255 255 0".
+The stroke color is given in RGB values from 0 to 255. E.g.: `255 255 0`.
 
 The VendorAnnotations element can be used by vendors to store additional information for the graphical representation.
-_[It is suggested that Modelica tools store the Modelica annotation of the connector under the tool name `Modelica3Annotation` in the attribute `annotation` of an element `connector`. The attribute `name` of the connector element is equal to the `name` attribute of the referenced `fmi3Terminal`.]_
+_[It is suggested that Modelica tools store the Modelica annotation of the connector under the tool name `Modelica3Annotation` in the attribute `annotation` of an element `connector`._
+_The attribute `name` of the connector element is equal to the `name` attribute of the referenced `fmi3Terminal`.]_
 
-_[Only terminals from the `Terminals` element can have a graphical representation. For simple <<input,`inputs`>> / <<output,`outputs`>> a terminal with one member has to be added.]_
+_[Only terminals from the `Terminals` element can have a graphical representation._
+_For simple <<input,`inputs`>> / <<output,`outputs`>> a terminal with one member has to be added.]_
 
 ===== Placement, Extent, and Painting Order of Graphical Items
 
@@ -1212,13 +1203,18 @@ _[The actual value can be inquired with `fmi3GetReal`.]_
 - <<structuralParameter>>: <<independent>> parameter (a data value that is constant during the simulation and is provided by the environment and cannot be used in connections). <<variability>> must be <<fixed>> or <<tunable>>. <<initial>> must be <<exact>> or not present (meaning <<exact>>).
 This <<causality>> requires the `Variable` not to have a `Dimension` element.
 
-_[
-Example:
-<Variable name="spD" valueReference="126" causality="structuralParameter"
-  variability="fixed">
+_[_
+_Example:_
+
+// TODO: include example from XML
+[source, XML]
+----
+<Variable name="spD" valueReference="126" causality="structuralParameter" variability="fixed">
   <Integer start="3"/>
 </Variable>
-]_
+----
+
+_]_
 
 <<structuralParameter,`structural parameters`>> that are referenced in `Dimension` elements may have a `min` attribute with 0 but the <<start>> attribute, which is mandatory for <<structuralParameter,`structural parameters`>>, must have a value larger than 0 for <<structuralParameter,`structural parameters`>> used in `Dimension` elements. [This allows importing tools to ignore <<structuralParameter,`structural parameters`>> because that <<start>> value reflects the internal default setting of that <<structuralParameter,`structural parameter`>>].
 
@@ -1235,16 +1231,16 @@ Only a variable of type `Clock` can have this <<causality>>.
 The default of <<causality>> is <<local>>. +
 A continuous-time <<state>> must have <<causality>> = <<local>> or <<output>>, see also <<ModelStructure>>.
 
-_[<<causality>> = <<calculatedParameter>> and <<causality>> = <<local>> with <<variability>> = <<fixed>> or <<tunable>> are similar.
-The difference is that a <<calculatedParameter>> can be used in another model or slave, whereas a <<local>> variable cannot.
-For example, when importing an FMU in a Modelica environment, a <<calculatedParameter>> should be imported in a `public` section as `final parameter`, whereas a <<local>> variable should be imported in a `protected` section of the model.]_
+_[<<causality>> = <<calculatedParameter>> and <<causality>> = <<local>> with <<variability>> = <<fixed>> or <<tunable>> are similar._
+_The difference is that a <<calculatedParameter>> can be used in another model or slave, whereas a <<local>> variable cannot._
+_For example, when importing an FMU in a Modelica environment, a <<calculatedParameter>> should be imported in a `public` section as `final parameter`, whereas a <<local>> variable should be imported in a `protected` section of the model.]_
 
 |`variability`
 |
 [[variability,`variability`]]
 Enumeration that defines the time dependency of the variable, in other words, it defines the time instants when a variable can change its value.
-_[The purpose of this attribute is to define when a result value needs to be inquired and to be stored.
-For example, <<discrete>> variables change their values only at event instants (Model Exchange) or at a communication point (Co-Simulation) and it is therefore only necessary to inquire them with `fmi3GetXXX` and store them at event times.]_
+_[The purpose of this attribute is to define when a result value needs to be inquired and to be stored._
+_For example, <<discrete>> variables change their values only at event instants (Model Exchange) or at a communication point (Co-Simulation) and it is therefore only necessary to inquire them with `fmi3GetXXX` and store them at event times.]_
 Allowed values of this enumeration:
 
 [[constant,`constant`]]
@@ -1259,9 +1255,8 @@ Whenever a <<parameter>> or <<input>> signal with <<variability>> = <<tunable>> 
 
 [[discrete,`discrete`]]
 - `discrete`: +
-Model Exchange: The value of the variable is constant between external and internal events (= time,
-state, step events defined implicitly in the FMU). +
-Co-Simulation: By convention, the variable is from a `real` sampled data system and its value is only changed at communication points (also inside the slave).
+Model Exchange: The value of the variable is constant between external and internal events (= time, state, step events defined implicitly in the FMU). +
+Co-Simulation: By convention, the variable is from a real sampled data system and its value is only changed at communication points (also inside the slave).
 
 [[continuous,`continuous`]]
 - `continuous`: Only a variable of `type = Real` can be <<continuous>>. +
@@ -1300,7 +1295,9 @@ Examples: (a) automatic tests of FMUs are performed, and the FMU is tested by pr
 (b) For a Model Exchange FMU, the FMU might be part of an algebraic loop.
 If the <<input>> variable is iteration variable of this algebraic loop, then initialization starts with its <<start>> value.]_
 
-If <<causality>> = <<input>> the value for <<initial>> has to be set to <<exact>> and it is required to provide a <<start>> value for describing the expected initial contidion of master <<clock,`clocks`>> for that FMU. If an <<inputClock>> has `fmi3True` as an <<start>> value the master should activate the <<clock>> the first time it enters event mode. The master can nevertheless choose different <<start>> values if it is not possible to fulfill the conditions in a simulation setup.
+If <<causality>> = <<input>> the value for <<initial>> has to be set to <<exact>> and it is required to provide a <<start>> value for describing the expected initial contidion of master <<clock,`clocks`>> for that FMU.
+If an <<inputClock>> has `fmi3True` as an <<start>> value the master should activate the <<clock>> the first time it enters event mode.
+The master can nevertheless choose different <<start>> values if it is not possible to fulfill the conditions in a simulation setup.
 
 If <<causality>> = <<output>> the <<initial>> attribute value is set to <<calculated>> and no <<start>> value is provided.
 
@@ -1314,10 +1311,9 @@ If both Model Exchange and Co-Simulation FMU, this attribute is ignored for Co-S
 Only for variables with <<variability>> = <<input>> : +
 If present with value equals `false`, then only one `fmi3SetXXX` call is allowed at one super dense time instant (model evaluation) on this variable.
 That is, this <<input>> is not allowed to appear in a (real) algebraic loop requiring multiple calls of `fmi3SetXXX` on this variable _[for example, due to a Newton iteration]_. +
-_[This flag must be set by FMUs where (internal) discrete-time <<state,`states`>> are directly updated when assigned (xd := f(xd) instead of xd = f(previous(xd)),
-and at least one <<output>> depends on this <<input>> and on discrete <<state,`states`>>._ +
-_It is strongly recommended that such an FMU checks the fulfillment of the requirement by itself during run-time, because an environment might not be able to check it; usually, there is a generic mechanism to import an FMU in an environment, but the mechanism to connect FMUs together is unrelated to the import mechanism.
-For example, there is no mechanism in the Modelica language to formulate connection restrictions for C functions (the FMU) called in a Modelica model.]_
+_[This flag must be set by FMUs where (internal) discrete-time <<state,`states`>> are directly updated when assigned (xd := f(xd) instead of xd = f(previous(xd)), and at least one <<output>> depends on this <<input>> and on discrete <<state,`states`>>._ +
+_It is strongly recommended that such an FMU checks the fulfillment of the requirement by itself during run-time, because an environment might not be able to check it; usually, there is a generic mechanism to import an FMU in an environment, but the mechanism to connect FMUs together is unrelated to the import mechanism._
+_For example, there is no mechanism in the Modelica language to formulate connection restrictions for C functions (the FMU) called in a Modelica model.]_
 
 
 |`clockReference`
@@ -1331,7 +1327,8 @@ Clock (`clockType = STClock`): If present, the variable is a clocked variable as
 It is not possible to associate more than one <<clock>> to a variable.
 
 Communication Point Clock (`clockType = CPClock`): If present, the variable is associated with the <<clock>> referenced by <<valueReference>> and defined in element `ModelVariables`.
-It is possible to associate multiple <<clock,`clocks`>> to a variable. Variables that are assigned to a Communication Point Clock are not necessarily `clocked` in the sense of synchronous time clock theory. Such variables can also be continuous-time or discrete-time variables.
+It is possible to associate multiple <<clock,`clocks`>> to a variable.
+Variables that are assigned to a Communication Point Clock are not necessarily `clocked` in the sense of synchronous time clock theory. Such variables can also be continuous-time or discrete-time variables.
 
 If <<outputClock,`output clocks`>> and <<inputClock,`input clocks`>> of `clockType = CPClock` are defined in the `modelDescription.xml` it is possible to define a tick relationship from a <<outputClock>> to an aperiodic <<inputClock>> based on <<clockReference>> (<<clock-relationships-for-communication-point-clocks>>).
 This is done for aperiodic <<inputClock,`input clocks`>> that have the clockType = `CPClock` via providing a list of <<valueReference>> of <<outputClock,`output clocks`>> of the same FMU.
@@ -1353,9 +1350,9 @@ _[For example, if there are 10 Variables and <<previous>> equals 3 for Variable 
 [[intermediateAccess,`intermediateAccess`]]
 If this boolean attribute is `true`, the variable can be accessed during a communication step.
 Variables with <<causality>> <<parameter>> must not be marked with <<intermediateAccess>> = `true`.
-#[TODO link to see math-intermediate-variable-access)]#
+// TODO: link to see math-intermediate-variable-access)
 This attribute is only used for Co-Simulation. The default value of this attribute is `false`.
-#[TODO: default false is not defined in the xsd (yet?)]#
+// TODO: default false is not defined in the xsd (yet?)
 |====
 
 *fmi3SetXXX* can be called on any variable with <<variability>> &#8800; <<constant>> *before initialization* (before calling <<fmi3EnterInitializationMode>>)
@@ -1381,9 +1378,8 @@ _[in order to provide new values for <<input,`inputs`>> during continuous integr
 
 If <<initial>> is not present, its value is defined by the following tables based on the values of <<causality>> and <<variability>>:
 
-//TODO <<previous>> variable must have <<initial>> = <<exact>>
-*TODO* include <<previous>> attribute information in table or below table
-
+// TODO: <<previous>> variable must have <<initial>> = <<exact>>
+// TODO: include <<previous>> attribute information in table or below table
 
 [cols="1,1,1,1,1,1,1,1,1,1,1,1"]
 |====
@@ -1512,9 +1508,9 @@ with
 |[brown]#calculated#
 |====
 
-_[Note: (1) If <<causality>> = <<independent>>, it is neither allowed to define a value for <<initial>> nor a value for start.
-(2) If <<causality>> = <<input>>, it is not allowed to define a value for <<initial>> and a value for <<start>> must be defined.
-(3) If \(C) and <<initial>> = <<exact>>, then the variable is explicitly defined by its <<start>> value in Initialization Mode (so directly after calling <<fmi3ExitInitializationMode>>, the value of the variable is either the <<start>> value stored in element `<Variable><XXX start=YYY/>` or the value provided by `fmi3SetXXX`, if this function was called on this variable).]_
+_[Note: (1) If <<causality>> = <<independent>>, it is neither allowed to define a value for <<initial>> nor a value for start._
+_(2) If <<causality>> = <<input>>, it is not allowed to define a value for <<initial>> and a value for <<start>> must be defined._
+_(3) If \(C) and <<initial>> = <<exact>>, then the variable is explicitly defined by its <<start>> value in Initialization Mode (so directly after calling <<fmi3ExitInitializationMode>>, the value of the variable is either the <<start>> value stored in element `<Variable><XXX start=YYY/>` or the value provided by `fmi3SetXXX`, if this function was called on this variable).]_
 
 The following combinations of <<variability>>/<<causality>> settings are allowed:
 
@@ -1603,7 +1599,7 @@ The following combinations of <<variability>>/<<causality>> settings are allowed
 ^|[red]#18#
 |====
 
-_Discussion of the combinations that are not allowed_:
+_[Discussion of the combinations that are not allowed:_
 
 [cols="1,10"]
 |====
@@ -1620,12 +1616,12 @@ _Discussion of the combinations that are not allowed_:
 |_For an <<independent>> variable only <<variability>> = <<continuous>> makes sense._
 
 ^|_[red]#(d)#_
-|_A <<fixed>> or <<tunable>> <<input>> has exactly the same properties as a <<fixed>> or <<tunable>> <<parameter>>.
-For simplicity, only <<fixed>> and <<tunable>> <<parameter,`parameters`>> shall be defined._
+|_A <<fixed>> or <<tunable>> <<input>> has exactly the same properties as a <<fixed>> or <<tunable>> <<parameter>>._
+_For simplicity, only <<fixed>> and <<tunable>> <<parameter,`parameters`>> shall be defined._
 
 ^|_[red]#(e)#_
-|_A <<fixed>> or <<tunable>> <<output>> has exactly the same properties as a <<fixed>> or <<tunable>> <<calculatedParameter>>.
-For simplicity, only <<fixed>> and <<tunable>> <<calculatedParameter,`calculatedParameters`>> shall be defined._
+|_A <<fixed>> or <<tunable>> <<output>> has exactly the same properties as a <<fixed>> or <<tunable>> <<calculatedParameter>>._
+_For simplicity, only <<fixed>> and <<tunable>> <<calculatedParameter,`calculatedParameters`>> shall be defined._
 |====
 
 _Discussion of the combinations that are allowed_:
@@ -1666,8 +1662,8 @@ _Discussion of the combinations that are allowed_:
 
 >|_[green]#(8)#_
 |_<<discrete>> <<output>>_
-|_<<discrete,`Discrete`>> variable that is computed in the FMU.
-Can be used in another model._
+|_<<discrete,`Discrete`>> variable that is computed in the FMU._
+_Can be used in another model._
 
 >|_[green]#(9)#_
 |_<<continuous>> <<output>>_
@@ -1675,20 +1671,20 @@ Can be used in another model._
 
 >|_[green]#(10)#_
 |_<<constant>> <<local>>_
-|_Variable where the value never changes.
-Cannot be used in another model._
+|_Variable where the value never changes._
+_Cannot be used in another model._
 
 >|_[green]#(11)#_
 |_<<fixed>> <<local>>_
-|_Local variable that depends on <<fixed>> <<parameter,`parameters`>> only and is computed in the FMU.
-Cannot be used in another model.
-After initialization, the value of this <<local>> variable cannot change._
+|_Local variable that depends on <<fixed>> <<parameter,`parameters`>> only and is computed in the FMU._
+_Cannot be used in another model._
+_After initialization, the value of this <<local>> variable cannot change._
 
 >|_[green]#(12)#_
 |_<<tunable>> <<local>>_
-|_Local variable that depends on <<tunable>> <<parameter,`parameters`>> only and is computed in the FMU.
-Cannot be used in another model.
-The value of this <<local>> variable can only change during initialization and at event instants, provided a <<tunable>> <<parameter>> was changed._
+|_Local variable that depends on <<tunable>> <<parameter,`parameters`>> only and is computed in the FMU._
+_Cannot be used in another model._
+_The value of this <<local>> variable can only change during initialization and at event instants, provided a <<tunable>> <<parameter>> was changed._
 
 >|_[green]#(13)#_
 |_<<discrete>> <<local>>_
@@ -1700,8 +1696,8 @@ The value of this <<local>> variable can only change during initialization and a
 
 >|_[green]#(15)#_
 |_<<continuous>> <<independent>>_
-|_All variables are a function of the continuous-time variable marked as <<independent>>.
-Usually, this is `time`_
+|_All variables are a function of the continuous-time variable marked as <<independent>>._
+_Usually, this is `time`_
 
 >|_[green]#(16)#_
 |_<<fixed>> structual <<parameter>>_
@@ -1718,14 +1714,14 @@ Usually, this is `time`_
 
 _How to treat <<tunable>> variables:_
 
-_A <<parameter>> p is a variable that does not change its value during simulation, in other words, dp/dt = 0.
-If the <<parameter>> p is changing, then Dirac impulses are introduced since dp/dt of a discontinuous <<constant>> variable `p` is a Dirac impulse.
-Even if this Dirac impulse would be modeled correctly by the modeling environment, it would introduce unwanted `vibrations`.
-Furthermore, in many cases the model equations are derived under the assumption of a <<constant>> value (like mass or capacity), and the model equations would be different if `p` would be time varying._
+_A <<parameter>> p is a variable that does not change its value during simulation, in other words, dp/dt = 0._
+_If the <<parameter>> p is changing, then Dirac impulses are introduced since dp/dt of a discontinuous <<constant>> variable `p` is a Dirac impulse._
+_Even if this Dirac impulse would be modeled correctly by the modeling environment, it would introduce unwanted `vibrations`._
+_Furthermore, in many cases the model equations are derived under the assumption of a <<constant>> value (like mass or capacity), and the model equations would be different if `p` would be time varying._
 
 _FMI for Model Exchange:_ +
-_Therefore, "tuning a (structural) <<parameter>>" during simulation does not mean to "change the parameter online" during simulation.
-Instead, this is a short hand notation for:_
+_Therefore, "tuning a (structural) <<parameter>>" during simulation does not mean to "change the parameter online" during simulation._
+_Instead, this is a short hand notation for:_
 
 . _Stop the simulation at an event instant (usually, a step event, in other words, after a successful integration step)._
 
@@ -1735,12 +1731,12 @@ Instead, this is a short hand notation for:_
 
 . _Newly start the simulation using as initial values the current values of all <<previous>> variables and the new values of the <<parameter,`parameters`>>._
 
-_Basically this means that a new simulation run is started from the previous FMU state with changed <<parameter>> values.
-With this interpretation, changing <<parameter,`parameters`>> online is "clean", as long as these changes appear at an event instant._
+_Basically this means that a new simulation run is started from the previous FMU state with changed <<parameter>> values._
+_With this interpretation, changing <<parameter,`parameters`>> online is "clean", as long as these changes appear at an event instant._
 
 _FMI for Co-Simulation:_
-_Changing of <<tunable>> <<parameter,`parameters`>> is allowed before an <<fmi3DoStep>> call (so, whenever an <<input>> can be set with `fmi3SetXXX`) and before <<fmi3ExitInitializationMode>> is called (that is before and during Initialization Mode).
-The FMU internally carries out event handling if necessary.]_
+_Changing of <<tunable>> <<parameter,`parameters`>> is allowed before an <<fmi3DoStep>> call (so, whenever an <<input>> can be set with `fmi3SetXXX`) and before <<fmi3ExitInitializationMode>> is called (that is before and during Initialization Mode)._
+_The FMU internally carries out event handling if necessary.]_
 
 ===== Aliasing of Variables [[aliasing-of-variables]]
 
@@ -1749,12 +1745,11 @@ The main purpose of alias variables is to enhance efficiency.
 If two variables `a` and `b` are alias variables, then this is only allowed if the behavior of the FMU would be exactly the same if `a` and `b` were not treated as alias variables (that is, had different <<valueReference>>pass:[s]).
 This requirement leads naturally to the following restrictions:
 
-. Variables `a` and `b` that can both be set with `fmi3SetXXX`, or variable `a` that can be set with `fmi3SetXXX` and variable `b` that is defined with <<causality>> = <<independent>>, cannot be alias variables [since these variables are <<independent>> variables and alias means that there is a constraint equation between variables (= the values are the same), these variables are no longer <<independent>>. +
-For example, if variables `a` and `b` have <<causality>> = <<parameter>>, then the value references of `a` and `b` must be different.
-However, if variable a has <<causality>> = <<parameter>> and `b` has <<causality>> = <<calculatedParameter>> and `b := a`, then `a` and `b` can have the same value reference.].
+. Variables `a` and `b` that can both be set with `fmi3SetXXX`, or variable `a` that can be set with `fmi3SetXXX` and variable `b` that is defined with <<causality>> = <<independent>>, cannot be alias variables _[since these variables are <<independent>> variables and alias means that there is a constraint equation between variables (= the values are the same), these variables are no longer <<independent>>._ +
+_For example, if variables `a` and `b` have <<causality>> = <<parameter>>, then the value references of `a` and `b` must be different._
+_However, if variable a has <<causality>> = <<parameter>> and `b` has <<causality>> = <<calculatedParameter>> and `b := a`, then `a` and `b` can have the same value reference.]_
 
-. At most one variable of the same alias set of variables with <<variability>> = <<constant>> can have a <<start>> attribute.
-[Since <<start>> variables are independent initial values.]
+. At most one variable of the same alias set of variables with <<variability>> = <<constant>> can have a <<start>> attribute _[since <<start>> variables are independent initial values.]_
 
 . A variable with <<variability>> = <<constant>> can only be aliased to another variable with <<variability>> = <<constant>>.
 It is then required that the <<start>> values of all aliased (constant) variables are identical.
@@ -1765,9 +1760,9 @@ The aliasing of variables only means that the `value` of the variables is always
 However, aliased variables may have different attributes, such as `min/max/nominal` values or description texts.
 _[For example, if v1, v2 are two alias variables with `v1=v2` and `v1.max=10` and `v2.max=5`, then the FMU will trigger an error if either `v1` or `v2` becomes larger than 5.]_
 
-_[The dependency definition in `fmiModelDescription.ModelStructure` is completely unrelated to the alias definition.
-In particular, the "direct dependency" definition can be a superset of the "real" direct dependency definition, even if the alias information shows that this is too conservative.
-For example, if it is stated that the <<output>> `y1` depends on <<input>> `u1` and the <<output>> `y2` depends on <<input>> `u2`, and `y1` is an alias to `y2`, then this definition is fine, although it can be deduced that in reality neither `y1` nor `y2` depend on any <<input>>.]._
+_[The dependency definition in `fmiModelDescription.ModelStructure` is completely unrelated to the alias definition._
+_In particular, the "direct dependency" definition can be a superset of the "real" direct dependency definition, even if the alias information shows that this is too conservative._
+_For example, if it is stated that the <<output>> `y1` depends on <<input>> `u1` and the <<output>> `y2` depends on <<input>> `u2`, and `y1` is an alias to `y2`, then this definition is fine, although it can be deduced that in reality neither `y1` nor `y2` depend on any <<input>>.]._
 
 Type specific properties are defined in the required choice element, where exactly one of `Real`, `Integer`, `Boolean`, `String`, `Enumeration` must be present in the XML file:
 
@@ -1804,8 +1799,8 @@ Initial or guess value of variable.
 _[Therefore, calling_ `fmi3SetXXX` _to set <<start>> values is only necessary, if a different value as stored in the XML file is desired.]_ The interpretation of <<start>> is defined by `Variable` / <<initial>>.
 A different <<start>> value can be provided with an `fmi3SetXXX` function before <<fmi3ExitInitializationMode>> is called (but not for variables with <<variability>> = <<constant>>).
 
-_[The standard approach is to set the <<start>> value before <<fmi3EnterInitializationMode>>.
-However, if the initialization shall be modified in the calling environment (for example, changing from initialization of states to steady-state initialization), it is also possible to use the <<start>> value as iteration variable of an algebraic loop: using an additional condition in the environment, such as_ latexmath:[\color{blue}{\dot{x} = 0}] _, the actual <<start>> value is determined.]_
+_[The standard approach is to set the <<start>> value before <<fmi3EnterInitializationMode>>._
+_However, if the initialization shall be modified in the calling environment (for example, changing from initialization of states to steady-state initialization), it is also possible to use the <<start>> value as iteration variable of an algebraic loop: using an additional condition in the environment, such as_ latexmath:[\color{blue}{\dot{x} = 0}] _, the actual <<start>> value is determined.]_
 
 If <<initial>> = <<exact>> or <<approx>> or <<causality>> = <<input>>, a <<start>> value must be provided.
 
@@ -1825,9 +1820,8 @@ Variables with <<causality>> = <<parameter>> or <<input>>, as well as variables 
 |
 [[derivative,`derivative`]]
 If present, this variable is the derivative of variable with `Variable` value reference `derivative`.
-_[For example,
-if there are 10 `Variable`pass:[s] and `derivative = 3` for `Variable` 8, then `Variable` 8 is the derivative of `Variable` 3 with respect to the <<independent>> variable (usually time).
-This information might be especially used if an <<input>> or an <<output>> is the derivative of another <<input>> or <<output>>, or to define the <<state,`states`>>.]_
+_[For example, if there are 10 `Variable`pass:[s] and `derivative = 3` for `Variable` 8, then `Variable` 8 is the derivative of `Variable` 3 with respect to the <<independent>> variable (usually time)._
+_This information might be especially used if an <<input>> or an <<output>> is the derivative of another <<input>> or <<output>>, or to define the <<state,`states`>>.]_
 
 The <<state>> <<derivative,`derivatives`>> of an FMU are listed under element `<ModelStructure><Derivatives>`.
 All `Variable`pass:[s] listed in this element must have attribute `derivative` (in order that the continuous-time <<state,`states`>> are uniquely defined).
@@ -1857,10 +1851,10 @@ _[Typically, additional data is defined here how to build up the menu for the va
 
 The structure of the model is defined in element `ModelStructure` within `fmiModelDescription`.
 This structure is with respect to the underlying model equations, independently how these model equations are solved.
-_[For example, when exporting a model both in Model Exchange and Co-Simulation format; then the model structure is identical in both cases.
-The Co-Simulation FMU has either an integrator included that solves the model equations, or the discretization formula of the integrator and the model equations are solved together ("inline integration").
-In both cases the model has the same continuous-time <<state,`states`>>.
-In the second case the internal implementation is a discrete-time system, but from the outside this is still a continuous-time model that is solved with an integration method.]_
+_[For example, when exporting a model both in Model Exchange and Co-Simulation format; then the model structure is identical in both cases._
+_The Co-Simulation FMU has either an integrator included that solves the model equations, or the discretization formula of the integrator and the model equations are solved together ("inline integration")._
+_In both cases the model has the same continuous-time <<state,`states`>>._
+_In the second case the internal implementation is a discrete-time system, but from the outside this is still a continuous-time model that is solved with an integration method.]_
 
 The required part defines an ordering of the <<output,`outputs`>> and of the (exposed) <<derivative,`derivatives`>>, and defines the unknowns that are available during Initialization _[Therefore, when linearizing an FMU, every tool will use the same ordering for the <<output,`outputs`>>, <<state,`states`>>, and <<derivative,`derivatives`>> for the linearized model.
 The ordering of the <<input,`inputs`>> should be performed in this case according to the ordering in `ModelVariables`.]_
@@ -1896,46 +1890,45 @@ ModelStructure consists of the following elements (see also figures above; the s
 |_Description_
 
 |`Outputs`
-|Ordered list of all outputs,
-in other words, a list of `Variable` value references where every corresponding `Variable` must have <<causality>> = <<output>> (and *every variable with <<causality>> = <<output>> must be listed here*).
-_[Note that all <<output>> variables are listed here, especially <<discrete>> and <<continuous>> <<output,`outputs`>>.
-The ordering of the variables in this list is defined by the exporting tool.
-Usually, it is best to order according to the declaration order in the source model, since then the `Outputs` list does not change if the declaration order of <<output,`outputs`>> in the source model is not changed.
-This is for example, important for linearization, in order that the interpretation of the output vector does not change for a re-exported FMU.]_
+|Ordered list of all outputs, in other words, a list of `Variable` value references where every corresponding `Variable` must have <<causality>> = <<output>> (and *every variable with <<causality>> = <<output>> must be listed here*).
+_[Note that all <<output>> variables are listed here, especially <<discrete>> and <<continuous>> <<output,`outputs`>>._
+_The ordering of the variables in this list is defined by the exporting tool._
+_Usually, it is best to order according to the declaration order in the source model, since then the `Outputs` list does not change if the declaration order of <<output,`outputs`>> in the source model is not changed._
+_This is for example, important for linearization, in order that the interpretation of the output vector does not change for a re-exported FMU.]_
 Attribute <<dependencies>> defines the dependencies of the <<output,`outputs`>> from the knowns at the current super dense time instant in Event and in Continuous-Time Mode (Model Exchange) and at the current communication point (Co-Simulation).
 The functional dependency is defined as (dependencies of variables that are fixed in Event and Continuous-Time Mode and at communication points are not shown): +
 [blue]#latexmath:[\color{blue}{(\mathbf{y}_c, \mathbf{y}_d) := \mathbf{f}_{output}(\mathbf{x}_c, \mathbf{u}_c, \mathbf{u}_d, t, \mathbf{p}_{tune})}]#
 
 |`Derivatives`
 |Ordered list of all state derivatives, in other words, a list of `Variable` value references where every corresponding `Variable` must be a state derivative.
-_[Note that only <<continuous>> Real variables are listed here.
-If a <<state>> or a <<derivative>> of a <<state>> shall not be exposed from the FMU, or if states are not statically associated with a variable (due to dynamic state selection), then dummy `Variable`pass:[s] have to be introduced, for example, `x[4]`, or `xDynamicStateSet2[5]`.
-The ordering of the variables in this list is defined by the exporting tool.
-Usually, it is best to order according to the declaration order of the <<state,`states`>> in the source model, since then the <Derivatives> list does not change if the declaration order of states in the source model is not changed.
-This is for example, important for linearization, in order that the interpretation of the state vector does not change for a re-exported FMU._].
+_[Note that only <<continuous>> Real variables are listed here._
+_If a <<state>> or a <<derivative>> of a <<state>> shall not be exposed from the FMU, or if states are not statically associated with a variable (due to dynamic state selection), then dummy `Variable`pass:[s] have to be introduced, for example, `x[4]`, or `xDynamicStateSet2[5]`._
+_The ordering of the variables in this list is defined by the exporting tool._
+_Usually, it is best to order according to the declaration order of the <<state,`states`>> in the source model, since then the <Derivatives> list does not change if the declaration order of states in the source model is not changed._
+_This is for example, important for linearization, in order that the interpretation of the state vector does not change for a re-exported FMU.]_
 The corresponding continuous-time <<state,`states`>> are defined by attribute <<derivative>> of the corresponding `Variable` state derivative element.
-_[Note that higher order derivatives must be mapped to first order derivatives but the mapping definition can be preserved due to attribute <<derivative>>.
-Example: if_ latexmath:[\color{blue}{\frac{\text{ds}}{\text{dt}} = v,\ \frac{\text{dv}}{\text{dt}} =f(..)}] _,then_ latexmath:[\color{blue}{\left\{ v,\ \frac{\text{dv}}{\text{dt}} \right\}}] _ is the vector of state derivatives and attribute <<derivative>> of_ latexmath:[\color{blue}{v}] _references_ latexmath:[\color{blue}{s}] _,
-and attribute <<derivative>> of_ latexmath:[\color{blue}{\frac{\text{dv}}{\text{dt}}}] _references_ latexmath:[\color{blue}{v}] _.]_ +
-For Co-Simulation, element `Derivatives` is ignored if capability flag `providesDirectionalDerivative` has a value of `false`, in other words, it cannot be computed. _[This is the default.
-If an FMU supports both Model Exchange and Co-Simulation, then the `Derivatives` element might be present, since it is needed for Model Exchange.
-If the above flag is set to `false` for the Co-Simulation case, then the `Derivatives` element is ignored for Co-Simulation.
-If "inline integration" is used for a Co-Simulation slave, then the model still has continuous-time <<state,`states`>> and just a special solver is used (internally the implementation results in a discrete-time system, but from the outside, it is still a continuous-time system).]_ +
+_[Note that higher order derivatives must be mapped to first order derivatives but the mapping definition can be preserved due to attribute <<derivative>>._
+_Example: if_ latexmath:[\color{blue}{\frac{\text{ds}}{\text{dt}} = v,\ \frac{\text{dv}}{\text{dt}} =f(..)}] _,then_ latexmath:[\color{blue}{\left\{ v,\ \frac{\text{dv}}{\text{dt}} \right\}}] _is the vector of state derivatives and attribute <<derivative>> of_ latexmath:[\color{blue}{v}] _references_ latexmath:[\color{blue}{s}] _, and attribute <<derivative>> of_ latexmath:[\color{blue}{\frac{\text{dv}}{\text{dt}}}] _references_ latexmath:[\color{blue}{v}] _.]_ +
+For Co-Simulation, element `Derivatives` is ignored if capability flag `providesDirectionalDerivative` has a value of `false`, in other words, it cannot be computed.
+_[This is the default._
+_If an FMU supports both Model Exchange and Co-Simulation, then the `Derivatives` element might be present, since it is needed for Model Exchange._
+_If the above flag is set to `false` for the Co-Simulation case, then the `Derivatives` element is ignored for Co-Simulation._
+_If "inline integration" is used for a Co-Simulation slave, then the model still has continuous-time <<state,`states`>> and just a special solver is used (internally the implementation results in a discrete-time system, but from the outside, it is still a continuous-time system).]_ +
 Attribute <<dependencies>> defines the dependencies of the state derivatives from the knowns at the current super dense time instant in Event and in Continuous-Time Mode (Model Exchange) and at the current communication point (Co-Simulation).
 The functional dependency is defined as (dependencies of variables that are fixed in Event and Continuous-Time Mode and at communication points are not shown): +
 [blue]#latexmath:[\color{blue}{\dot{\mathbf{x}_c} := \mathbf{f}_{der}(\mathbf{x}_c, \mathbf{u}_c, \mathbf{u}_d, t, \mathbf{p}_{tune})}]#
 
 |`InitialUnknowns`
-|
+a|
 [[InitialUnknowns,`InitialUnknowns`]]
 Ordered list of all exposed <<Unknown,`Unknowns`>> in Initialization Mode.
 This list consists of all variables with
 
-1. <<causality>> = <<output>> and (<<initial>> = <<approx>> or <<calculated>>), and
+. <<causality>> = <<output>> and (<<initial>> = <<approx>> or <<calculated>>), and
 
-2. <<causality>> = <<calculatedParameter>> and
+. <<causality>> = <<calculatedParameter>> and
 
-3. all continuous-time <<state,`states`>> and all state derivatives (defined with element `<Derivatives>` from `<ModelStructure>`) with <<initial>> = <<approx>> or <<calculated>> _[if a Co-Simulation FMU does not define the <Derivatives> element, (3) cannot be present]_.
+. all continuous-time <<state,`states`>> and all state derivatives (defined with element `<Derivatives>` from `<ModelStructure>`) with <<initial>> = <<approx>> or <<calculated>> _[if a Co-Simulation FMU does not define the <Derivatives> element, (3) cannot be present]_.
 
 The resulting list is not allowed to have duplicates (for example, if a <<state>> is also an <<output>>, it is included only once in the list). +
 Attribute <<dependencies>> defines the dependencies of the <<Unknown,`Unknowns`>> from the `Knowns` in Initialization Mode at the initial time.
@@ -1943,8 +1936,7 @@ The functional dependency is defined as:
 
 [blue]#latexmath:[\color{blue}{\dot{\mathbf{v}}_{initialUnknowns} := \mathbf{f}_{init}(\mathbf{u}_c, \mathbf{u}_d, t_0, \mathbf{v}_{initial=exact})}]#
 
-Since, <<output,`outputs`>>, continuous-time <<state,`states`>> and state derivatives are either present as `Knowns` (if <<initial>> = <<exact>>) or as <<Unknown,`Unknowns`>> (if <<initial>> = <<approx>> or <<calculated>>),
-they can be inquired with `fmi3GetXXX` in InitializationMode.
+Since, <<output,`outputs`>>, continuous-time <<state,`states`>> and state derivatives are either present as `Knowns` (if <<initial>> = <<exact>>) or as <<Unknown,`Unknowns`>> (if <<initial>> = <<approx>> or <<calculated>>), they can be inquired with `fmi3GetXXX` in InitializationMode.
 
 _[Example: Assume an FMU is defined in the following way:_
 
@@ -1952,8 +1944,8 @@ latexmath:[\color{blue}{(\mathbf{y}_{c+d}, \dot{\mathbf{x}}_c) := \mathbf{f}_{in
 
 latexmath:[\color{blue}{(\mathbf{y}_{c+d}, \dot{\mathbf{x}}_c) := \mathbf{f}_{sim}(\mathbf{x}_c, \mathbf{u}_{c+d}, t_i, \mathbf{p})}] +
 
-_Therefore, the initial state latexmath:[\color{blue}{\mathbf{x}_c(t_0)}] has <<initial>> = <<exact>> and the initial state derivative latexmath:[\color{blue}{\dot{\mathbf{x}}_c(t_0)}] has <<initial>> = <<calculated>>.
-The environment can still initialize this FMU in steady-state, by using latexmath:[\color{blue}{\mathbf{x}_c(t_0)}] as iteration variables and adding the equations latexmath:[\color{blue}{\mathbf{x}_c(t_0) = \mathbf{0}}] in the environment.]_
+_Therefore, the initial state latexmath:[\color{blue}{\mathbf{x}_c(t_0)}] has <<initial>> = <<exact>> and the initial state derivative latexmath:[\color{blue}{\dot{\mathbf{x}}_c(t_0)}] has <<initial>> = <<calculated>>._
+_The environment can still initialize this FMU in steady-state, by using latexmath:[\color{blue}{\mathbf{x}_c(t_0)}] as iteration variables and adding the equations latexmath:[\color{blue}{\mathbf{x}_c(t_0) = \mathbf{0}}] in the environment.]_
 
 |`Unknown`
 |
@@ -1975,18 +1967,18 @@ Attribute <<dependencies>> of <<Unknown>> defines the dependency of latexmath:[\
 _[If, for example, a continuous-time <<output>>_ latexmath:[\color{blue}{y_{2}}] _is a function of the continuous-time <<input,`inputs`>>_ latexmath:[\color{blue}{u_{3}}] _and_ latexmath:[\color{blue}{u_{5}}], _and these <<input,`inputs`>> have changed, then_ `fmi3SetXXX` _on_ latexmath:[\color{blue}{u_{3}}] _and_ latexmath:[\color{blue}{u_{5}}] _must always be called before calling_ `fmi3GetXXX` _on_ latexmath:[\color{blue}{y_{2}}] _.]_
 
 |`DiscreteStates`
-|Ordered list of all exposed discrete <<state,`states`>>, in other words a list of Variable indices. Every corresponding Variable may have attribute <<previous>> defined. Discrete <<state,`states`>> must have a <<clockReference>> attribute.
-//TODO unclear why this is not solved or updated yet
-----------*TODO*-------------
-[There are three cases:
-(1) discrete states are not exposed, like in FMI 2.0,
-(2) discrete states are exposed through modelDescription with <<previous>> values,
-(3) discrete states are exposed without <<previous>> values.
-It could be a combination of all three in one FMU. Discussion and conclusion:
-Introduce a flag `hasInternalState`, see also #148.]
- [Need to clarify causality of discrete states (<<local>>, <<output>>?) and if `fmi3SetReal` is allowed for continuous states, see #243.]
-Attribute <<dependencies>> defines the dependencies of the discrete states from the known <<input,`inputs`>>, continuous-time states and previous discrete-time states.
-----------*TODO*-------------
+|Ordered list of all exposed discrete <<state,`states`>>, in other words a list of Variable indices.
+Every corresponding Variable may have attribute <<previous>> defined. Discrete <<state,`states`>> must have a <<clockReference>> attribute.
+// TODO: unclear why this is not solved or updated yet
+//
+// [There are three cases:
+// (1) discrete states are not exposed, like in FMI 2.0,
+// (2) discrete states are exposed through modelDescription with <<previous>> values,
+// (3) discrete states are exposed without <<previous>> values.
+// It could be a combination of all three in one FMU. Discussion and conclusion:
+// Introduce a flag `hasInternalState`, see also #148.]
+//  [Need to clarify causality of discrete states (<<local>>, <<output>>?) and if `fmi3SetReal` is allowed for continuous states, see #243.]
+// Attribute <<dependencies>> defines the dependencies of the discrete states from the known <<input,`inputs`>>, continuous-time states and previous discrete-time states.
 |====
 
 Element <<Unknown>> in `Outputs`, `Derivatives` and <<InitialUnknowns>> has the following attributes:
@@ -2029,8 +2021,8 @@ If an <<independent>> variable is not explicitly defined under `Variable`pass:[s
 For Co-Simulation, <<dependencies>> does not list the dependency on continuous-time, if the capability flag `providesDirectionalDerivative` has a value of `false`.
 In other words, the respective partial derivatives cannot be computed.
 
-//TODO should be discussed after Karl's return
-*TODO* is it helpful to include also <<clock>> dependencies here --> i.e. changing this variable will lead to a <<outputClock>> tick.*TODO*
+// TODO: should be discussed after Karl's return
+// TODO: is it helpful to include also <<clock>> dependencies here --> i.e. changing this variable will lead to a <<outputClock>> tick.
 
 |`dependenciesKind`
 |
@@ -2044,8 +2036,7 @@ If <<dependenciesKind>> is present, <<dependencies>> must be present and must ha
 
 Only for Real unknowns latexmath:[\color{blue}{v_{\text{unknown}}}]:
 
-`=` <<constant>>: constant factor,
-latexmath:[\color{blue}{c \cdot v_{known,i}}] where latexmath:[\color{blue}{c}] is an expression that is evaluated before <<fmi3EnterInitializationMode>> is called.
+`=` <<constant>>: constant factor, latexmath:[\color{blue}{c \cdot v_{known,i}}] where latexmath:[\color{blue}{c}] is an expression that is evaluated before <<fmi3EnterInitializationMode>> is called.
 
 Only for Real unknowns latexmath:[\color{blue}{v_{\text{unknown}}}] in Event and Continuous-Time Mode (Model Exchange) and at communication points (Co-Simulation), and not for <<InitialUnknowns>> for Initialization Mode:
 
@@ -2087,8 +2078,8 @@ y &= g_1(x_2, x_3)
 \end{align*},
 ++++
 
-_where_ latexmath:[\color{blue}{u_{1}}] _is a continuous-time <<input>> (<<variability>> = <<continuous>>),_ latexmath:[\color{blue}{u_{2}}] _is any type of <<input>>,_ latexmath:[\color{blue}{u_{3}}] _is a Real discrete-time <<input>> (<<variability>> = "discrete"`), and_ latexmath:[\color{blue}{p}] _is a <<fixed>> <<parameter>> (<<variability>> = <<fixed>>).
-The initialization is defined by:_
+_where_ latexmath:[\color{blue}{u_{1}}] _is a continuous-time <<input>> (<<variability>> = <<continuous>>),_ latexmath:[\color{blue}{u_{2}}] _is any type of <<input>>,_ latexmath:[\color{blue}{u_{3}}] _is a Real discrete-time <<input>> (<<variability>> = "discrete"`), and_ latexmath:[\color{blue}{p}] _is a <<fixed>> <<parameter>> (<<variability>> = <<fixed>>)._
+_The initialization is defined by:_
 
 [latexmath]
 ++++
@@ -2123,16 +2114,16 @@ y = \left\{ \begin{matrix}
 \end{matrix}\right.
 ++++
 
-_where_ latexmath:[\color{blue}{u}] _is a continuous-time <<input>> with <<valueReference>> = `1` and_ latexmath:[\color{blue}{y}] _is a continuous-time <<output>> with <<valueReference>> = `2`.
-The definition of the model structure is then:_
+_where_ latexmath:[\color{blue}{u}] _is a continuous-time <<input>> with <<valueReference>> = `1` and_ latexmath:[\color{blue}{y}] _is a continuous-time <<output>> with <<valueReference>> = `2`._
+_The definition of the model structure is then:_
 
 [source, xml]
 ----
 include::examples/model_structure_example2.xml[tags=ModelStructure]
 ----
 
-_[Note that_ latexmath:[\color{blue}{y = d \cdot u}] _where_ latexmath:[\color{blue}{d}] __changes only during Event Mode (__latexmath:[\color{blue}{d = 2 \cdot u}] _or_ latexmath:[\color{blue}{3 \cdot u\ }] _depending on relation_ latexmath:[\color{blue}{u > 0}] _that changes only at Event Mode).
-Therefore <<dependenciesKind>> = <<discrete>>.]_
+_[Note that_ latexmath:[\color{blue}{y = d \cdot u}] _where_ latexmath:[\color{blue}{d}] __changes only during Event Mode (__latexmath:[\color{blue}{d = 2 \cdot u}] _or_ latexmath:[\color{blue}{3 \cdot u\ }] _depending on relation_ latexmath:[\color{blue}{u > 0}] _that changes only at Event Mode)._
+_Therefore <<dependenciesKind>> = <<discrete>>.]_
 
 _Example 3:_
 
@@ -2144,28 +2135,28 @@ y = \left\{ \begin{matrix}
 \end{matrix}\right.
 ++++
 
-_where_ latexmath:[\color{blue}{u}] _is a continuous-time <<input>> with <<valueReference>> = `1` and_ latexmath:[\color{blue}{y}] _is a continuous-time <<output>> with <<valueReference>> = `2`.
-The definition of the model structure is then:_
+_where_ latexmath:[\color{blue}{u}] _is a continuous-time <<input>> with <<valueReference>> = `1` and_ latexmath:[\color{blue}{y}] _is a continuous-time <<output>> with <<valueReference>> = `2`._
+_The definition of the model structure is then:_
 
 [source, xml]
 ----
 include::examples/model_structure_example3.xml[tags=ModelStructure]
 ----
 
-_[Note that_ latexmath:[\color{blue}{y = c}] _where_ latexmath:[\color{blue}{c}] __changes only during Event Mode (__latexmath:[\color{blue}{c = 2}] _or_ latexmath:[\color{blue}{3\ }]__depending on relation__ latexmath:[\color{blue}{u > 0}] _that changes only at Event Mode).
-Therefore <<dependenciesKind>> = <<dependenciesKind,`dependent`>> because it is not a linear relationship on_ latexmath:[\color{blue}{u}].]_
+_[Note that_ latexmath:[\color{blue}{y = c}] _where_ latexmath:[\color{blue}{c}] __changes only during Event Mode (__latexmath:[\color{blue}{c = 2}] _or_ latexmath:[\color{blue}{3\ }]__depending on relation__ latexmath:[\color{blue}{u > 0}] _that changes only at Event Mode)._
+_Therefore <<dependenciesKind>> = <<dependenciesKind,`dependent`>> because it is not a linear relationship on_ latexmath:[\color{blue}{u}]. _]_
 
 _Defining FMU features with the_ <<dependencies>> _list:_
 
-_[Note that via the <<dependencies>> list the supported features of the FMU can be defined.
-Examples:_
+_[Note that via the <<dependencies>> list the supported features of the FMU can be defined._
+_Examples:_
 
-- _If a state derivative `der_x` is a function of a <<parameter>> p (so of a <<start>> value of a variable with <<causality>> = <<parameter>> and <<variability>> = <<fixed>>), and the FMU does not support an iteration over `p` during `InitializationMode` (for example, to iterate over p such that the state derivative `der_x` is zero), then the <<dependencies>> list of `der_x` should not include `p`.
-If an FMU is imported in an environment and such an iteration is set up, then the tool can figure out that the resulting algebraic system of equations is structurally singular and therefore can reject such a definition._
+- _If a state derivative `der_x` is a function of a <<parameter>> p (so of a <<start>> value of a variable with <<causality>> = <<parameter>> and <<variability>> = <<fixed>>), and the FMU does not support an iteration over `p` during `InitializationMode` (for example, to iterate over p such that the state derivative `der_x` is zero), then the <<dependencies>> list of `der_x` should not include `p`._
+_If an FMU is imported in an environment and such an iteration is set up, then the tool can figure out that the resulting algebraic system of equations is structurally singular and therefore can reject such a definition._
 
-- _For standard Co-Simulation FMUs, it is common that no algebraic loops over the <<input>> / <<output>> variables nor over start-values is supported.
-In such a case, all <<dependencies>> lists for <<output>> variables under the <<InitialUnknowns>> element should be defined as empty lists defining that the setting of <<input,`inputs`>> and/or of <<start>> values does not influence the <<output,`outputs`>>.
-As a result, it is not possible to formulate algebraic loops of connected FMUs during InitializationMode.]_
+- _For standard Co-Simulation FMUs, it is common that no algebraic loops over the <<input>> / <<output>> variables nor over start-values is supported._
+_In such a case, all <<dependencies>> lists for <<output>> variables under the <<InitialUnknowns>> element should be defined as empty lists defining that the setting of <<input,`inputs`>> and/or of <<start>> values does not influence the <<output,`outputs`>>._
+_As a result, it is not possible to formulate algebraic loops of connected FMUs during InitializationMode.]_
 
 ==== Variable Naming Conventions (variableNamingConvention) [[variableNamingConvention]]
 
@@ -2262,9 +2253,7 @@ robot.arm1.centerOfMass[2]
 robot.arm1.centerOfMass[3]
 ----
 
-_For example,
-a table T[4,3,2] (first dimension 4 entries, second dimension 3 entries,
-third dimension 2 entries) is mapped to the following `Variable`pass:[s]:_
+_For example, a table `T[4,3,2]` (first dimension 4 entries, second dimension 3 entries, third dimension 2 entries) is mapped to the following `Variable`pass:[s]:_
 
 ----
 T[1,1,1]

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -2122,7 +2122,7 @@ _The definition of the model structure is then:_
 include::examples/model_structure_example2.xml[tags=ModelStructure]
 ----
 
-_[Note that_ latexmath:[\color{blue}{y = d \cdot u}] _where_ latexmath:[\color{blue}{d}] __changes only during Event Mode (__latexmath:[\color{blue}{d = 2 \cdot u}] _or_ latexmath:[\color{blue}{3 \cdot u\ }] _depending on relation_ latexmath:[\color{blue}{u > 0}] _that changes only at Event Mode)._
+_[Note that_ latexmath:[\color{blue}{y = d \cdot u}] _where_ latexmath:[\color{blue}{d}] _changes only during Event Mode (_ latexmath:[\color{blue}{d = 2 \cdot u}] _or_ latexmath:[\color{blue}{3 \cdot u\ }] _depending on relation_ latexmath:[\color{blue}{u > 0}] _that changes only at Event Mode)._
 _Therefore <<dependenciesKind>> = <<discrete>>.]_
 
 _Example 3:_
@@ -2143,7 +2143,7 @@ _The definition of the model structure is then:_
 include::examples/model_structure_example3.xml[tags=ModelStructure]
 ----
 
-_[Note that_ latexmath:[\color{blue}{y = c}] _where_ latexmath:[\color{blue}{c}] __changes only during Event Mode (__latexmath:[\color{blue}{c = 2}] _or_ latexmath:[\color{blue}{3\ }]__depending on relation__ latexmath:[\color{blue}{u > 0}] _that changes only at Event Mode)._
+_[Note that_ latexmath:[\color{blue}{y = c}] _where_ latexmath:[\color{blue}{c}] _changes only during Event Mode (_ latexmath:[\color{blue}{c = 2}] _or_ latexmath:[\color{blue}{3\ }] _depending on relation_ latexmath:[\color{blue}{u > 0}] _that changes only at Event Mode)._
 _Therefore <<dependenciesKind>> = <<dependenciesKind,`dependent`>> because it is not a linear relationship on_ latexmath:[\color{blue}{u}]. _]_
 
 _Defining FMU features with the_ <<dependencies>> _list:_

--- a/docs/2_3_fmu_distribution.adoc
+++ b/docs/2_3_fmu_distribution.adoc
@@ -6,7 +6,7 @@ All relevant files are stored in a ZIP file with a pre-defined structure.
 The implementation must either implement all the functions of FMI for Model Exchange or all the functions of FMI for Co-Simulation or both.
 Specifically it is required that all functions specified for Model Exchange and/or Co-Simulation are present, even if they are only needed for capabilities that the FMU does not support.
 The behavior of those functions is unspecified, so while calling environments can rely on the functions being present, they cannot rely on any particular behavior for functions only needed for capabilities the FMU does not support.
-The extension of the ZIP file must be "**.fmu**", for example, `HybridVehicle.fmu`.
+The extension of the ZIP file must be `.fmu` _[, for example, `HybridVehicle.fmu`]_.
 The compression method used for the ZIP file must be `deflate` _[(most free tools, such as zlib, offer only the common compression method `deflate`)]_.
 
 Every FMU is distributed with its own ZIP file.
@@ -49,13 +49,13 @@ extra                         // Additional (meta-)data of the FMU (optional)
 ----
 
 An FMU has to implement all common functions (according to tables in <<state-machine-model-exchange>> and <<state-machine-co-simulation>>).
-Model Exchange FMUs have to provide additionally the respective Model Exchange function, CoSimulation FMUs the Co-Simulation functions.
+Model Exchange FMUs have to provide additionally the respective Model Exchange function, Co-Simulation FMUs the Co-Simulation functions.
 
 The FMU must be distributed with at least one implementation, in other words, either sources or one of the binaries for a particular machine.
 It is also possible to provide the sources and binaries for different target machines together in one ZIP file.
 The names of the binary directories are standardized by the "platform tuple".
 Further names can be introduced by vendors.
-Dynamic link libraries must include all referenced resources that are not available on a standard target machine _[for example, DLLs on Windows machines must be built with option "MT" to include the run-time environment of VisualStudio in the DLL, and not use the option "MD" where this is not the case]_.
+Dynamic link libraries must include all referenced resources that are not available on a standard target machine _[for example, DLLs on Windows that are built  with Visual Studio should be compiled with the `/MT` option to include the required symbols from the Visual C runtime in the DLL, and not use the option `/MD` where this is not the case]_.
 When compiling a shared object on Linux, `RPATH="$ORIGIN"` has to be set when generating the shared object in order that shared objects used from it, can be dynamically loaded.
 
 The binaries must be placed in the respective <platformTuple> directory with the general format `<arch>-<sys>{-<abi>{<abi_ver>}{<abi_sub>}}`.
@@ -212,21 +212,22 @@ _[As template makefile, CMake (http://www.cmake.org), a cross- platform, open-so
 In directory `resources`, additional data can be provided in FMU specific formats, typically for tables and maps used in the FMU.
 This data must be read into the model at the latest during initialization (that is, before <<fmi3ExitInitializationMode>> is called).
 The actual file names in the ZIP file to access the data files can either be hard-coded in the generated FMU functions, or the file names can be provided as string parameters via the `fmi3SetString` function.
-_[Note that the absolute file name of the resource directory is provided by the initialization functions]_.
+_[Note that the absolute file name of the resource directory is provided by the initialization functions.]_
 In the case of a Co-Simulation implementation of `needsExecutionTool = true` type, the `resources` directory can contain the model file in the tool specific file format.
 
 _[Note that the header files `fmi3PlatformTypes.h` and `fmi3FunctionTypes.h/fmi3Functions.h` are not included in the FMU due to the following reasons:_
 
-_pass:[]`fmi3PlatformTypes.h` makes no sense in the `sources` directory, because if sources are provided, then the target simulator defines this header file and not the FMU. +
-This header file is not included in the `binaries` directory, because it is implicitly defined by the platform directory (for example, i686-windows for a 32-bit machine or x86_64-linux for a 64-bit machine)._
+_pass:[]`fmi3PlatformTypes.h` makes no sense in the `sources` directory, because if sources are provided, then the target simulator defines this header file and not the FMU._ +
+_This header file is not included in the `binaries` directory, because it is implicitly defined by the platform directory (for example, `i686-windows` for a 32-bit machine or `x86_64-linux` for a 64-bit machine)._
 
-_pass:[]`fmi3FunctionTypes.h` / `fmi3Functions.h` are not needed in the `sources` directory, because they are implicitly defined by attribute `fmiVersion` in file `modelDescription.xml`.
-Furthermore, in order that the C compiler can check for consistent function arguments, the header file from the target simulator should be used when compiling the C sources.
-It would therefore be counter-productive (unsafe) if this header file was present. +
-These header files are not included in the `binaries` directory, since they are already utilized to build the target simulator executable.
-The version number of the header file used to construct the FMU can be deduced via attribute `fmiVersion` in file `modelDescription.xml` or via function call <<fmi3GetVersion>>.]_
+_pass:[]`fmi3FunctionTypes.h` / `fmi3Functions.h` are not needed in the `sources` directory, because they are implicitly defined by attribute `fmiVersion` in file `modelDescription.xml`._
+_Furthermore, in order that the C compiler can check for consistent function arguments, the header file from the target simulator should be used when compiling the C sources._
+_It would therefore be counter-productive (unsafe) if this header file was present._ +
+_These header files are not included in the `binaries` directory, since they are already utilized to build the target simulator executable._
+_The version number of the header file used to construct the FMU can be deduced via attribute `fmiVersion` in file `modelDescription.xml` or via function call <<fmi3GetVersion>>.]_
 
 The ZIP archive may contain additional entries with the prefix `extra/` that can be used to store additional data and meta-data.
 In order to avoid ambiguities the extra files should be provided in subdirectories using a reverse domain name notation of a domain that is controlled by the entity defining the semantics and content of the additional entries _[(for example `extra/com.example/SimTool/meta.xml` or `extra/org.example.stdname/data.asd`)]_.
 The use of subdirectories beginning with `org.modelica` and `org.fmi-standard` is explicitly reserved for use by MAP FMI-defined layered standards, i.e. other uses must not use subdirectory names beginning with these prefixes.
-It is explicitly allowed for tools and users other than the original creator of an FMU to modify, add or delete entries in the `extra/` directory without affecting the validity of the FMU in all other aspects. Specifically all validation or digital signature schemes used to protect the content of the FMU should take the variability of extra file content into account _[(for example by having seperate checksums or signatures for FMU core content and extra content, or not having signatures at all for extra content)]_.
+It is explicitly allowed for tools and users other than the original creator of an FMU to modify, add or delete entries in the `extra/` directory without affecting the validity of the FMU in all other aspects.
+Specifically all validation or digital signature schemes used to protect the content of the FMU should take the variability of extra file content into account _[(for example by having seperate checksums or signatures for FMU core content and extra content, or not having signatures at all for extra content)]_.

--- a/docs/2___common_concepts.adoc
+++ b/docs/2___common_concepts.adoc
@@ -5,5 +5,5 @@ In both cases, FMI defines an input/output block of a dynamic model where the di
 The definitions that are specific to the particular cases are defined in <<fmi-for-model-exchange>> and <<fmi-for-co-simulation>>.
 .
 
-Below, the term __FMU__ (Functional Mock-up Unit) will be used as common term for a model in the FMI for Model Exchange format, or a co-simulation slave in the FMI for Co-Simulation format.
+Below, the term _FMU_ (Functional Mock-up Unit) will be used as common term for a model in the FMI for Model Exchange format, or a co-simulation slave in the FMI for Co-Simulation format.
 Note that the interface supports several instances of one FMU.

--- a/docs/3_1_model_exchange_math.adoc
+++ b/docs/3_1_model_exchange_math.adoc
@@ -54,8 +54,8 @@ latexmath:[t_{Imax}] is the largest occurring Integer index of super dense time
 |<<previous>> value (= either left limit or value from the previous event)
 |====
 
-_[Assume that an FMU has an event at latexmath:[t_R=2.1s] and here a signal changes discontinuously.
-If no event iteration occurs, the time instant when the event occurs is defined as (2.1, 0), and the time instant whenthe integration is restarted is defined as (2.1, 1).]_
+_[Assume that an FMU has an event at latexmath:[t_R=2.1s] and here a signal changes discontinuously._
+_If no event iteration occurs, the time instant when the event occurs is defined as (2.1, 0), and the time instant when the integration is restarted is defined as (2.1, 1).]_
 
 The hybrid ODEs supported by FMI are described as piecewise continuous-time systems.
 Discontinuities can occur at time instants latexmath:[t_0, t_1, \ldots, t_n] where latexmath:[t_i < t_{i+1}].
@@ -63,7 +63,7 @@ These time instants are called `events`.
 Events can be known before hand (= time event), or are defined implicitly (= state and step events), see below.
 Between events, variables are either <<continuous>> or do not change their value.
 A variable is called discrete-time, if it changes its value only at an event instant.
-Otherwise the variable is called continuoustime.
+Otherwise the variable is called continuous-time.
 Only real variables can be continuous-time.
 The following variable indices are used to describe the timing behavior of the corresponding variable (for example, latexmath:[v_d] is a discrete-time variable).
 
@@ -77,19 +77,16 @@ The following variable indices are used to describe the timing behavior of the c
 is a continuous function of time inside each interval latexmath:[t_i^+ < \ ^-t_{i+1}]
 
 |m
-|A piece-wise <<constant>> variable latexmath:[m(t)],
-is constant inside each interval latexmath:[t_i^+ < \ ^-t_{i+1}] .
+|A piece-wise <<constant>> variable latexmath:[m(t)], is constant inside each interval latexmath:[t_i^+ < \ ^-t_{i+1}].
 
 |c
-| A *Clock* variable latexmath:[c(t)],
-is active only at particular time instants
+| A *Clock* variable latexmath:[c(t)], is active only at particular time instants.
 
 |r
-|A *Clocked* variable latexmath:[r(t)],
-is a variable of type Real, Integer, Boolean, String or Enumeration associated to a <<clock>> latexmath:[c(t)] and therefore active only at particular time instants
+|A *Clocked* variable latexmath:[r(t)], is a variable of type Real, Integer, Boolean, String or Enumeration associated to a <<clock>> latexmath:[c(t)] and therefore active only at particular time instants.
 
 |====
-//EDITQ: which variables can be actually be associated with a clock?
+// TODO: which variables can be actually be associated with a clock?
 At every event instant latexmath:[t_i], variables might be discontinuous (see <<figure-piecwise-continuous-variables>>).
 
 .Piecewise-continuous variables of an FMU: continuous-time (latexmath:[v_c]) and discrete-time (latexmath:[v_d]).
@@ -100,9 +97,9 @@ An event instant latexmath:[t_i] is defined by one of the following conditions t
 
 . The environment of the FMU triggers an event at the current time instant because at least one discrete-time <<input>> changes its value, a continuous-time <<input>> has a discontinuous change, or a <<tunable>> <<parameter>> changes its value.
 Such an event is called external event.
- _[Note that if an FMU A is connected to an FMU B, and an event is triggered for A, then potentially all <<output,`outputs`>> of A will be discontinuous at this time instant.
- It is therefore adviceable to trigger an external event for B at this time instant too, if an <<output>> of A is connected to B.
- This means to call <<fmi3EnterEventMode>> on B.]_ +
+_[Note that if an FMU A is connected to an FMU B, and an event is triggered for A, then potentially all <<output,`outputs`>> of A will be discontinuous at this time instant._
+_It is therefore adviceable to trigger an external event for B at this time instant too, if an <<output>> of A is connected to B._
+_This means to call <<fmi3EnterEventMode>> on B.]_ +
 All the following events are internal events.
 
 . At a predefined time instant latexmath:[t_i=(T_{next}(t_{i-1}, 0)] that was defined at the previous event instant ti-1 by the FMU.
@@ -136,8 +133,7 @@ An FMI Model-Exchange model is described by the following variables:
 (Variable defined with <<causality>> = <<independent>>).
 
 ^|latexmath:[v]
-|A vector of all exposed variables (all variables defined in element `<ModelVariables>`,
-see <<definition-of-model-variables>>).
+|A vector of all exposed variables (all variables defined in element `<ModelVariables>`, see <<definition-of-model-variables>>).
 A subset of the variables is selected via a subscript.
 Example: latexmath:[\mathbf{v}_{initial=exact}] are variables defined with attribute <<initial>> = <<exact>> (see <<definition-of-model-variables>>).
 These are <<independent>> <<parameter,`parameters`>> and start values of other variables, such as initial values for <<state,`states`>>, state derivatives or <<output,`outputs`>>.
@@ -169,16 +165,14 @@ Variables of this type are defined with attribute <<causality>> = <<local>>, see
 
 ^|latexmath:[\mathbf{x}_c(t)]
 |A vector of real continuous-time variables representing the continuous-time <<state,`states`>>.
-For notational convenience,
-a continuous-time <<state>> is conceptually treated as a different type of variable as an <<output>> or a <<local>> variable for the mathematical description below.
+For notational convenience, a continuous-time <<state>> is conceptually treated as a different type of variable as an <<output>> or a <<local>> variable for the mathematical description below.
 In reality, a continuous-time <<state>> is however part of the <<output,`outputs`>> latexmath:[\mathbf{y}] or the <<local>> variables latexmath:[\mathbf{w}] of an FMU.
 
 ^|latexmath:[\mathbf{x}_d(t)] +
 latexmath:[^{\bullet}\mathbf{x}_d(t)]
 |latexmath:[\mathbf{x}_d(t)] is a vector of (internal) discrete-time variables (of any type) representing the discrete <<state,`states`>>. +
 latexmath:[{}^{\bullet}\mathbf{x}_d(t)] a is the value of latexmath:[\mathbf{x}_d(t)] at the previous super dense time instant, so latexmath:[{}^{\bullet}\mathbf{x}_d(t)=\mathbf{x}_d({}^{\bullet}t)].
-Given the <<previous>> values of the discrete-time <<state,`states`>>,
-latexmath:[{}^{\bullet}\mathbf{x}_d(t)], at the actual time instant latexmath:[t], all other discrete-time variables, especially the discrete <<state,`states`>> latexmath:[\mathbf{x}_d(t)], can be computed. +
+Given the <<previous>> values of the discrete-time <<state,`states`>>, latexmath:[{}^{\bullet}\mathbf{x}_d(t)], at the actual time instant latexmath:[t], all other discrete-time variables, especially the discrete <<state,`states`>> latexmath:[\mathbf{x}_d(t)], can be computed. +
 Discrete <<state,`states`>> are not visible in the interface of an FMU and are only introduced here to clarify the mathematical description.
 Formally, a discrete <<state>> is part of the <<output,`outputs`>> latexmath:[\mathbf{y}] or the <<local>> variables latexmath:[\mathbf{w}] of an FMU.
 
@@ -200,8 +194,7 @@ Computing the solution of an FMI model means to split the solution process in di
 The phases can be categorized according to the following modes:
 
 Initialization Mode::
-This mode is used to compute at the start time stem[t_0] initial values for continuous-time <<state,`states`>>, latexmath:[\mathbf{x}_c(t_0)],
-and for the <<previous>> (internal) discrete-time <<state,`states`>>, latexmath:[\mathbf{x}_d(t_0)], by utilizing extra equations not present in the other modes (for example, equations to define the <<start>> value for a <<state>> or for the derivative of a <<state>>).
+This mode is used to compute at the start time stem[t_0] initial values for continuous-time <<state,`states`>>, latexmath:[\mathbf{x}_c(t_0)], and for the <<previous>> (internal) discrete-time <<state,`states`>>, latexmath:[\mathbf{x}_d(t_0)], by utilizing extra equations not present in the other modes (for example, equations to define the <<start>> value for a <<state>> or for the derivative of a <<state>>).
 
 Continuous-Time Mode::
 This mode is used to compute the values of all (real) continuous-time variables between events by numerically solving ordinary differential and algebraic equations.
@@ -224,14 +217,14 @@ _[Example: In <<figure-connected-fmus>> two different types of connected FMUs ar
 [#figure-connected-fmus]
 image::images/ArtificialAlgebraicLoop.svg[width=80%, align="center"]
 
-_In the upper diagram, FMU1 and FMU2 are connected in such a way that by an appropriate sequence of `fmi3SetXXX` and `fmi3GetXXX` calls, the FMU variables can be computed.
-In the lower diagram, FMU3 and FMU4 are connected in such a way that a real algebraic loop is present.
-This loop might be solved iteratively with a Newton method.
-In every iteration the iteration variable latexmath:[u_4] is provided by the solver, and via the shown sequence of `fmi3SetXXX` and `fmi3GetXXX` calls, the residue is computed and is provided back to the solver.
-Based on the residue a new value of latexmath:[u_4] is provided.
-The iteration is terminated when the residue is close to zero.
-These types of artifical or real algebraic loops can occur in all the different modes, such as Initialization Mode, Event Mode, and Continuous-Time Mode.
-Since different variables are computed in every Mode and the causality of variable computation can be different in Initialization Mode as with respect to the other two Modes, it might be necessary to solve different kinds of loops in the different Modes.]_
+_In the upper diagram, FMU1 and FMU2 are connected in such a way that by an appropriate sequence of `fmi3SetXXX` and `fmi3GetXXX` calls, the FMU variables can be computed._
+_In the lower diagram, FMU3 and FMU4 are connected in such a way that a real algebraic loop is present._
+_This loop might be solved iteratively with a Newton method._
+_In every iteration the iteration variable latexmath:[u_4] is provided by the solver, and via the shown sequence of `fmi3SetXXX` and `fmi3GetXXX` calls, the residue is computed and is provided back to the solver._
+_Based on the residue a new value of latexmath:[u_4] is provided._
+_The iteration is terminated when the residue is close to zero._
+_These types of artifical or real algebraic loops can occur in all the different modes, such as Initialization Mode, Event Mode, and Continuous-Time Mode._
+_Since different variables are computed in every Mode and the causality of variable computation can be different in Initialization Mode as with respect to the other two Modes, it might be necessary to solve different kinds of loops in the different Modes.]_
 
 In <<table-math-model-exchange>> the equations are defined that can be evaluated in the respective Mode.
 The following color coding is used in the table:
@@ -245,9 +238,9 @@ For an output argument, calling `fmi3GetXXX` on such a variable returns always t
 Function `fmi3SetXXX` is an abbreviation for functions `fmi3SetReal`, `fmi3SetBoolean`, `fmi3SetInteger` and `fmi3SetString` respectively.
 Function `fmi3GetXXX` is an abbreviation for functions `fmi3GetReal`, `fmi3GetBoolean`, `fmi3GetInteger` and `fmi3GetString` respectively.
 
-_[In the following table the setting of the super dense time, (latexmath:[t_R], latexmath:[t_I]), is precisely described.
-Tools will usually not have such a representation of time.
-However, super-dense time defines precisely when a new "model evaluation" starts and therefore which variable values belong to the same "model evaluation" at the same (super dense) time instant and should be stored together.]_
+_[In the following table the setting of the super dense time, (latexmath:[t_R], latexmath:[t_I]), is precisely described._
+_Tools will usually not have such a representation of time._
+_However, super-dense time defines precisely when a new "model evaluation" starts and therefore which variable values belong to the same "model evaluation" at the same (super dense) time instant and should be stored together.]_
 
 .Mathematical description of an FMU for Model Exchange.
 [#table-math-model-exchange]
@@ -332,77 +325,81 @@ latexmath:[\mathbf{f}_{init}, \mathbf{f}_{sim} \in C^0] (=continuous functions w
 
 _[Remark 1 - Calling Sequences:_
 
-_In the table above, for notational convenience in every Mode one function call is defined to compute all output arguments from all inputs arguments.
-In reality, every scalar output argument is computed by one `fmi3GetXXX` function call.
-Additionally, the output argument need not be a function of all input arguments, but of only a subset from it, as defined in the XML file under_ `<ModelStructure>`.
-_This is essential when FMUs are connected in a loop, as shown in <<figure-connected-fmus>>. For example, since_ latexmath:[y_{2a}] _depends only on_
-latexmath:[u_{1a}] _, but not on_ latexmath:[u_{1b}]_, it is possible to call_ `fmi3SetXXX` _to set_ latexmath:[u_{1a}] _, and then inquire_ latexmath:[y_{2a}] _with_ `fmi3GetXXX` _without setting_ latexmath:[u_{1b}] _beforehand._
+_In the table above, for notational convenience in every Mode one function call is defined to compute all output arguments from all inputs arguments._
+_In reality, every scalar output argument is computed by one `fmi3GetXXX` function call._
+_Additionally, the output argument need not be a function of all input arguments, but of only a subset from it, as defined in the XML file under `<ModelStructure>`._
+_This is essential when FMUs are connected in a loop, as shown in <<figure-connected-fmus>>. For example, since_ latexmath:[y_{2a}] _depends only on_ latexmath:[u_{1a}] _, but not on_ latexmath:[u_{1b}]_, it is possible to call_ `fmi3SetXXX` _to set_ latexmath:[u_{1a}] _, and then inquire_ latexmath:[y_{2a}] _with_ `fmi3GetXXX` _without setting_ latexmath:[u_{1b}] _beforehand._
 
-_It is non-trivial to provide code for `fmi3SetXXX`, `fmi3GetXXX`, if the environment can call_ `fmi3SetXXX` _on the <<input,`inputs`>> in quite different orders.
-A simple remedy is to provide the dependency information, not according to the real functional dependency, but according to the sorted equations in the generated code.
-Example:_
+_It is non-trivial to provide code for `fmi3SetXXX`, `fmi3GetXXX`, if the environment can call_ `fmi3SetXXX` _on the <<input,`inputs`>> in quite different orders._
+_A simple remedy is to provide the dependency information, not according to the real functional dependency, but according to the sorted equations in the generated code._
+_Example:_
 
-Assume an FMU is described by the following equations (`u1`, `u2` are <<input,`inputs`>>, `y1`, `y2` are <<output,`outputs`>>,`w1`, `w2` are internal variables):
+_Assume an FMU is described by the following equations (`u1`, `u2` are <<input,`inputs`>>, `y1`, `y2` are <<output,`outputs`>>,`w1`, `w2` are internal variables):_
+
 -----
 w1 = w2 + u1
 w2 = u2
 y1 = w1
 y2 = w2
 -----
-Sorting of the equations might result in (this ordering is not unique):
------
-w2 := u2
-y2 := w2
-w1 := w2 + u1
-y1 := w1
------
-With this ordering, the dependency should be defined as `y2 = f(u2), y1 = f(u1,u2)`.
-When `y2` is called first with `fmi3GetXXX`, then only `u2` must be set first (since `y2 = f(u2)`), and the first two equations are evaluated.
-If later `y1` is inquired as well, then the first two equations are not evaluated again and only the last two equations are evaluated.
-On the other hand, if `y1` is inquired first, then `u1` and `u2` must be set first (since `y1 = f(u1,u2)`) and then all equations are computed.
-When `y2` is inquired afterwards, the cached value is returned.
 
-If sorting of the equations in this example would instead result in the following code:
+_Sorting of the equations might result in (this ordering is not unique):_
+
+-----
+w2 := u2
+y2 := w2
+w1 := w2 + u1
+y1 := w1
+-----
+
+_With this ordering, the dependency should be defined as `y2 = f(u2), y1 = f(u1,u2)`._
+_When `y2` is called first with `fmi3GetXXX`, then only `u2` must be set first (since `y2 = f(u2)`), and the first two equations are evaluated._
+_If later `y1` is inquired as well, then the first two equations are not evaluated again and only the last two equations are evaluated._
+_On the other hand, if `y1` is inquired first, then `u1` and `u2` must be set first (since `y1 = f(u1,u2)`) and then all equations are computed._
+_When `y2` is inquired afterwards, the cached value is returned._
+
+_If sorting of the equations in this example would instead result in the following code:_
+
 ----
 w2 := u2
 w1 := w2 + u1
 y1 := w1
 y2 := w2
 ----
-then the dependency should be defined as `y2 = f(u1,u2)`, `y1 = f(u1,u2)`, because `u1` and `u2` must be first set, before `y2` can be inquired with `fmi3GetXXX` when executing this code.
+
+_then the dependency should be defined as `y2 = f(u1,u2)`, `y1 = f(u1,u2)`, because `u1` and `u2` must be first set, before `y2` can be inquired with `fmi3GetXXX` when executing this code._
 
 _Remark 2 - Mathematical Model of Discrete-Time FMUs:_
 
-_There are many different ways discrete-time systems are described.
-For FMI, the following basic mathematical model for discrete-time systems is used (other description forms must be mapped, as sketched below):_
+_There are many different ways discrete-time systems are described._
+_For FMI, the following basic mathematical model for discrete-time systems is used (other description forms must be mapped, as sketched below):_
 
 image::images/remark_2_source.png[width=70%]
 
-_At an event instant, the discrete system is described by algebraic equations as function of the <<previous>> (internal) discrete-time <<state,`states`>>_ latexmath:[_{}^{\bullet}\mathbf{x}_{d}] _and the discrete-time <<input,`inputs`>>_ latexmath:[\mathbf{u}_{d}]__.
-If FMUs are connected in a loop, these algebraic equations are called iteratively, until the solution is found.
-If the actual discrete-time <<state,`states`>>__ latexmath:[\mathbf{x}_{d}] __and the <<previous>> discrete-time <<state,`states`>>__ latexmath:[_{}^{\bullet}\mathbf{x}_{d}] _are not identical, the discrete-time <<state,`states`>> are updated, the Integer part of the time is incremented and a new event iteration is performed.
-Other discrete-time models must be mapped to this description form.
-Examples:_
+_At an event instant, the discrete system is described by algebraic equations as function of the <<previous>> (internal) discrete-time <<state,`states`>>_ latexmath:[_{}^{\bullet}\mathbf{x}_{d}] _and the discrete-time <<input,`inputs`>>_ latexmath:[\mathbf{u}_{d}].
+_If FMUs are connected in a loop, these algebraic equations are called iteratively, until the solution is found._
+_If the actual discrete-time <<state,`states`>>__ latexmath:[\mathbf{x}_{d}] __and the <<previous>> discrete-time <<state,`states`>>_ latexmath:[_{}^{\bullet}\mathbf{x}_{d}] _are not identical, the discrete-time <<state,`states`>> are updated, the Integer part of the time is incremented and a new event iteration is performed._
+_Other discrete-time models must be mapped to this description form._
+_Examples:_
 
 Synchronous systems::
-_A synchronous system,
-such as Lucid Synchrone (Pouzet 2006) or Modelica 3.3 (Modelica 2012), is called periodically, and at every sample instant the discrete-time equations are evaluated exactly once.
-An FMU of this type can be implemented by activating the model equations only at the first event iteration and returning always `newDiscreteStatesNeeded = false` from <<fmi3NewDiscreteStates>>.
-Furthermore, the discrete-time <<state,`states`>> are not updated by <<fmi3NewDiscreteStates>>, but as first action before the discrete-time equations are evaluated, in order that_ latexmath:[^{\bullet}\mathbf{x}_d] _(= value at the previous <<clock>> tick) and_ latexmath:[\mathbf{x}_d] _(value at the latest <<clock>> tick) have reasonable values between <<clock>> ticks._
+_A synchronous system, such as Lucid Synchrone (Pouzet 2006) or Modelica 3.3 (Modelica 2012), is called periodically, and at every sample instant the discrete-time equations are evaluated exactly once._
+_An FMU of this type can be implemented by activating the model equations only at the first event iteration and returning always `newDiscreteStatesNeeded = false` from <<fmi3NewDiscreteStates>>._
+_Furthermore, the discrete-time <<state,`states`>> are not updated by <<fmi3NewDiscreteStates>>, but as first action before the discrete-time equations are evaluated, in order that_ latexmath:[^{\bullet}\mathbf{x}_d] _(= value at the previous <<clock>> tick) and_ latexmath:[\mathbf{x}_d] _(value at the latest <<clock>> tick) have reasonable values between <<clock>> ticks._
 
 State machines with one memory location for a state::
-_In such a system there is only one memory location for a discrete-time <<state>> and not two, and therefore a discrete-time <<state>> is updated in the statement where it is assigned (and not in <<fmi3NewDiscreteStates>>).
-As a result, <<fmi3NewDiscreteStates>> is basically just used to start a new (super dense) time instant.
-This is unproblematic, as long as no algebraic loops occur.
-FMUs of this type can therefore not be used in real algebraic loops if the involved variables depend on a discrete-time <<state>>.
-This restriction is communicated to the environment of the FMU by the `ScalarVariable` definition of the corresponding <<input>> with flag <<canHandleMultipleSetPerTimeInstant>> `= false` (so an <<input>> with this flag is not allowed to be called in an algebraic loop)._
+_In such a system there is only one memory location for a discrete-time <<state>> and not two, and therefore a discrete-time <<state>> is updated in the statement where it is assigned (and not in <<fmi3NewDiscreteStates>>)._
+_As a result, <<fmi3NewDiscreteStates>> is basically just used to start a new (super dense) time instant._
+_This is unproblematic, as long as no algebraic loops occur._
+_FMUs of this type can therefore not be used in real algebraic loops if the involved variables depend on a discrete-time <<state>>._
+_This restriction is communicated to the environment of the FMU by the `ScalarVariable` definition of the corresponding <<input>> with flag <<canHandleMultipleSetPerTimeInstant>> `= false` (so an <<input>> with this flag is not allowed to be called in an algebraic loop)._
 
 _Remark 3 - Event Indicators / Freezing Relations:_
 
 _In the above table, vector_ *r* _is used to collect all relations together that are utilized in the event indicators_ **z** _.
-In Continuous-Time Mode all these relations are `frozen` and do not change during the evaluations in the respective Mode.
-This is indicated in the table above by computing__ *r* _when entering the Continuous-Time Mode and providing_ *r* _as (internal) input argument to the evaluation functions.
-Example:_
+_In Continuous-Time Mode all these relations are `frozen` and do not change during the evaluations in the respective Mode._
+_This is indicated in the table above by computing__ *r* _when entering the Continuous-Time Mode and providing_ *r* _as (internal) input argument to the evaluation functions._
+_Example:_
 
 _An equation of the form_
 
@@ -422,8 +419,8 @@ end if;
 y = if r1 or r2 then +1 else -1
 ----
 
-_Therefore, the original if-clause is evaluated in this form only during Initialization and Event Mode.
-In Continuous-Time Mode this equation is evaluated as:_
+_Therefore, the original if-clause is evaluated in this form only during Initialization and Event Mode._
+_In Continuous-Time Mode this equation is evaluated as:_
 
 ----
 z1 = x1 - x2;
@@ -446,15 +443,12 @@ _An actual implementation will pack the code in an impure function, say Greater(
 y = if Greater(x1-x2,...) or Greater(x3-x1,...) then +1 else -1;
 ----
 
-_Furthermore, a hysteresis should be added for the event indicators.
-For more details see the companion document FunctionalMockupInterface-ImplementationHints.docx._
+_Furthermore, a hysteresis should be added for the event indicators._
+_For more details see the companion document FunctionalMockupInterface-ImplementationHints.docx._
 
 _Remark 4 - Pure Discrete-Time FMUs:_
 
-_If an FMU has only discrete-time equations (and no variables with <<variability>> = <<continuous>>),
-then the environment need not to call <<fmi3EnterContinuousTimeMode>> but can directly call
-<<fmi3SetTime>> to set the value of the next event instant,
-before <<fmi3EnterEventMode>> is called.]_
+_If an FMU has only discrete-time equations (and no variables with <<variability>> = <<continuous>>), then the environment need not to call <<fmi3EnterContinuousTimeMode>> but can directly call <<fmi3SetTime>> to set the value of the next event instant, before <<fmi3EnterEventMode>> is called.]_
 
 An FMU is initialized in Initialization Mode with latexmath:[\mathbf{f}_{init}(\ldots)].
 The input arguments to this function consist of the <<input>> variables (= variables with <<causality>> = <<input>>), of the <<independent>> variable (= variable with <<causality>> = <<independent>>; usually the default value `time`), and of all variables that have a <<start>> value with (explicitly or implicitly) <<initial>> = <<exact>> in order to compute the continuous-time <<state,`states`>> and the output variables at the initial time latexmath:[t_0].
@@ -481,9 +475,8 @@ The function calls in the table above describe precisely which input arguments a
 There is no 1:1 mapping of these mathematical functions to C functions.
 Instead, all input arguments are set with `fmi3SetXXX` C function calls, and then the result argument(s) can be determined with the C functions defined in the right column of the above table.
 This technique is discussed in detail in <<providing-independent-variables-and-re-initialization>>.
-_[In short:
-For efficiency reasons, all equations from the table above will usually be available in one (internal) C function.
-With the C functions described in the next sections, input arguments are copied into the internal model data structure only when their value has changed in the environment.
-With the C functions in the right column of the table above, the internal function is called in such a way that only the minimum needed equations are evaluated.
-Hereby, variable values calculated from previous calls can be reused.
-This technique is called "caching" and can significantly enhance the simulation efficiency of real-world models.]_
+_[In short: For efficiency reasons, all equations from the table above will usually be available in one (internal) C function._
+_With the C functions described in the next sections, input arguments are copied into the internal model data structure only when their value has changed in the environment._
+_With the C functions in the right column of the table above, the internal function is called in such a way that only the minimum needed equations are evaluated._
+_Hereby, variable values calculated from previous calls can be reused._
+_This technique is called "caching" and can significantly enhance the simulation efficiency of real-world models.]_

--- a/docs/3_1_model_exchange_math.adoc
+++ b/docs/3_1_model_exchange_math.adoc
@@ -378,7 +378,7 @@ image::images/remark_2_source.png[width=70%]
 
 _At an event instant, the discrete system is described by algebraic equations as function of the <<previous>> (internal) discrete-time <<state,`states`>>_ latexmath:[_{}^{\bullet}\mathbf{x}_{d}] _and the discrete-time <<input,`inputs`>>_ latexmath:[\mathbf{u}_{d}].
 _If FMUs are connected in a loop, these algebraic equations are called iteratively, until the solution is found._
-_If the actual discrete-time <<state,`states`>>__ latexmath:[\mathbf{x}_{d}] __and the <<previous>> discrete-time <<state,`states`>>_ latexmath:[_{}^{\bullet}\mathbf{x}_{d}] _are not identical, the discrete-time <<state,`states`>> are updated, the Integer part of the time is incremented and a new event iteration is performed._
+_If the actual discrete-time <<state,`states`>>_ latexmath:[\mathbf{x}_{d}] _and the <<previous>> discrete-time <<state,`states`>>_ latexmath:[_{}^{\bullet}\mathbf{x}_{d}] _are not identical, the discrete-time <<state,`states`>> are updated, the Integer part of the time is incremented and a new event iteration is performed._
 _Other discrete-time models must be mapped to this description form._
 _Examples:_
 
@@ -398,7 +398,7 @@ _Remark 3 - Event Indicators / Freezing Relations:_
 
 _In the above table, vector_ *r* _is used to collect all relations together that are utilized in the event indicators_ **z** _.
 _In Continuous-Time Mode all these relations are `frozen` and do not change during the evaluations in the respective Mode._
-_This is indicated in the table above by computing__ *r* _when entering the Continuous-Time Mode and providing_ *r* _as (internal) input argument to the evaluation functions._
+_This is indicated in the table above by computing_ *r* _when entering the Continuous-Time Mode and providing_ *r* _as (internal) input argument to the evaluation functions._
 _Example:_
 
 _An equation of the form_

--- a/docs/3_1_model_exchange_math.adoc
+++ b/docs/3_1_model_exchange_math.adoc
@@ -12,7 +12,7 @@ The real part latexmath:[t_R] of this tuple is the <<independent>> variable of t
 In this phase latexmath:[t_I = 0].
 The integer part latexmath:[t_I] of this tuple is a counter to enumerate (and therefore distinguish) the events at the same continuous-time instant latexmath:[t_R].
 This time definition is also called "super dense time" in literature, see, for example, <<LZ07>>.
-An ordering is defined on latexmath:[\mathbb{\text{T}}] leading to the following notation footnote:[The notation latexmath:[^{\bullet}t] is from <<BCP10>> adapted from non-standard analysis to super-dense time, in order to precisely define the value from the previous event iteration.]:
+An ordering is defined on latexmath:[\mathbb{\text{T}}] leading to the following notation footnote:[The notation latexmath:[^{\bullet}t] is from <<BCP10,BCP10>> adapted from non-standard analysis to super-dense time, in order to precisely define the value from the previous event iteration.]:
 
 [cols="1,7,4"]
 |====

--- a/docs/3_1_model_exchange_math.adoc
+++ b/docs/3_1_model_exchange_math.adoc
@@ -11,8 +11,8 @@ The <<independent>> variable time latexmath:[t \in \mathbb{T}] is a tuple latexm
 The real part latexmath:[t_R] of this tuple is the <<independent>> variable of the FMU for describing the continuous-time behavior of the model between events.
 In this phase latexmath:[t_I = 0].
 The integer part latexmath:[t_I] of this tuple is a counter to enumerate (and therefore distinguish) the events at the same continuous-time instant latexmath:[t_R].
-This time definition is also called "super dense time" in literature, see, for example, (Lee and Zheng 2007).
-An ordering is defined on latexmath:[\mathbb{\text{T}}] leading to the following notation footnote:[The notation latexmath:[^{\bullet}t] is from (_Benveniste et.al. 2010_) adapted from non-standard analysis to super-dense time, in order to precisely define the value from the previous event iteration.]:
+This time definition is also called "super dense time" in literature, see, for example, <<LZ07>>.
+An ordering is defined on latexmath:[\mathbb{\text{T}}] leading to the following notation footnote:[The notation latexmath:[^{\bullet}t] is from <<BCP10>> adapted from non-standard analysis to super-dense time, in order to precisely define the value from the previous event iteration.]:
 
 [cols="1,7,4"]
 |====
@@ -383,7 +383,7 @@ _Other discrete-time models must be mapped to this description form._
 _Examples:_
 
 Synchronous systems::
-_A synchronous system, such as Lucid Synchrone (Pouzet 2006) or Modelica 3.3 (Modelica 2012), is called periodically, and at every sample instant the discrete-time equations are evaluated exactly once._
+_A synchronous system, such as Lucid Synchrone <<PZ06>> or Modelica 3.3 <<MLS12>>, is called periodically, and at every sample instant the discrete-time equations are evaluated exactly once._
 _An FMU of this type can be implemented by activating the model equations only at the first event iteration and returning always `newDiscreteStatesNeeded = false` from <<fmi3NewDiscreteStates>>._
 _Furthermore, the discrete-time <<state,`states`>> are not updated by <<fmi3NewDiscreteStates>>, but as first action before the discrete-time equations are evaluated, in order that_ latexmath:[^{\bullet}\mathbf{x}_d] _(= value at the previous <<clock>> tick) and_ latexmath:[\mathbf{x}_d] _(value at the latest <<clock>> tick) have reasonable values between <<clock>> ticks._
 

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -44,16 +44,14 @@ fmi3Status fmi3SetXXX(..);
 Set new values for (<<independent>>) <<parameter,`parameters`>>, <<start>> values and <<input,`inputs`>> and re-initialize caching of variables that depend on these variables.
 The details of these functions are defined in <<get-and-set-variable-values>>.
 
-_[The functions above have the slight drawback that values must always be copied.
-For example, a call to_ <<fmi3SetContinuousStates>> _will provide the actual states in a vector, and this function has to copy the values in to the internal model data structure "_ `c` _" so that subsequent evaluation calls can utilize these values.
-If this turns out to be an efficiency issue, a future release of FMI might provide additional functions to provide the address of a memory area where the variable values are present.]_
+_[The functions above have the slight drawback that values must always be copied._
+_For example, a call to_ <<fmi3SetContinuousStates>> _will provide the actual states in a vector, and this function has to copy the values in to the internal model data structure "_ `c` _" so that subsequent evaluation calls can utilize these values._
+_If this turns out to be an efficiency issue, a future release of FMI might provide additional functions to provide the address of a memory area where the variable values are present.]_
 
 ==== Evaluation of Model Equations [[evaluation-of-model-equations]]
 
 This section contains the core functions to evaluate the model equations.
-Before one of these functions can be called,
-the appropriate functions from the previous section have to be used,
-to set the input arguments to the current model evaluation.
+Before one of these functions can be called, the appropriate functions from the previous section have to be used, to set the input arguments to the current model evaluation.
 
 [[fmi3EnterEventMode,`fmi3EnterEventMode`]]
 [source, C]
@@ -66,18 +64,18 @@ The model enters *Event Mode* from the *Continuous-Time Mode* and discrete-time 
 The followings arguments can be set to `fmi3True` to inform the FMU why *Event Mode* was entered.
 _[These arguments are not mutually exclusive and may all be `fmi3False` if the caller cannot provide this information.]_
 
-`inputEvent`:: an input event occurred
+`inputEvent`:: An input event occurred.
 
-`stepEvent`:: a step event occurred
+`stepEvent`:: A step event occurred.
 
-`rootsFound`:: array of length `nEventIndicators`. For `i = 1, ..., nEventIndicators, rootsFound[i]` latexmath:[\neq] `0` if the event indicator latexmath:[z_i] has a root, and `rootsFound[i] == 0` if not.
+`rootsFound`:: Array of length `nEventIndicators`. For `i = 1, ..., nEventIndicators, rootsFound[i]` latexmath:[\neq] `0` if the event indicator latexmath:[z_i] has a root, and `rootsFound[i] == 0` if not.
 For the components latexmath:[z_i] for which a root was found, the sign of `rootsFound[i]` indicates the direction of the zero-crossing.
 A value of `+1` indicates that latexmath:[z_i] is increasing, while a value of `-1` indicates a decreasing latexmath:[z_i].
 If `nEventIndicators == 0` the value of `rootsFound` is not defined.
 
-`nEventIndicators`:: the number of event indicators or `0` if the caller cannot provide this information.
+`nEventIndicators`:: The number of event indicators or `0` if the caller cannot provide this information.
 
-`timeEvent`:: a time event occurred
+`timeEvent`:: A time event occurred.
 
 [[fmi3NewDiscreteStates,`fmi3NewDiscreteStates`]]
 [source, C]
@@ -139,8 +137,7 @@ The function returns `enterEventMode` to signal to the environment if the FMU sh
 If `enterEventMode = fmi3False` and `terminateSimulation = fmi3False` the FMU stays in *Continuous-Time Mode* without calling <<fmi3EnterContinuousTimeMode>> again.
 When the integrator step is completed and the <<state,`states`>> are modified by the integrator afterwards (for example, correction by a BDF method),
 then <<fmi3SetContinuousStates>> has to be called with the updated states before <<fmi3CompletedIntegratorStep>> is called. +
-When the integrator step is completed and one or more event indicators change sign (with respect to the previously completed integrator step),
-then the integrator or the environment has to determine the time instant of the sign change that is closest to the previous completed step up to a certain precision (usually a small multiple of the machine epsilon).
+When the integrator step is completed and one or more event indicators change sign (with respect to the previously completed integrator step), then the integrator or the environment has to determine the time instant of the sign change that is closest to the previous completed step up to a certain precision (usually a small multiple of the machine epsilon).
 This is usually performed by an iteration where time is varied and <<state>> variables needed during the iteration are determined by interpolation.
 Function <<fmi3CompletedIntegratorStep>> must be called after this state event location procedure and not after the successful computation of the time step by the integration algorithm.
 The intended purpose of the function call is to indicate to the FMU that at this stage all <<input,`inputs`>> and <<state>> variables have valid (accepted) values.
@@ -149,17 +146,16 @@ However, it is not allowed to go back in time over the previous <<fmi3CompletedI
 
 _[This function might be used, for example, for the following purposes:_
 
-. _Delays:_ +
+_Delays:_ +
 _All variables that are used in a "delay(..)" operator are stored in an appropriate buffer and the function returns with `enterEventMode = fmi3False`, and `terminateSimulation = fmi3False`._
 
-. _Dynamic state selection: +
-It is checked whether the dynamically selected states are still numerically appropriate.
-If yes, the function returns with `enterEventMode = fmi3False`  otherwise with `enterEventMode = fmi3True`._
+. _Dynamic state selection:_ +
+_It is checked whether the dynamically selected states are still numerically appropriate._
+_If yes, the function returns with `enterEventMode = fmi3False`  otherwise with `enterEventMode = fmi3True`._
 _In the latter case, <<fmi3EnterEventMode>> has to be called and the states are dynamically changed by a subsequent <<fmi3NewDiscreteStates>>._
 
-_Note that this function is not used to detect time or state events, for example, by comparing event indicators of the previous with the current call of <<fmi3CompletedIntegratorStep>>.
-These types of events are detected in the environment, and the environment has to call <<fmi3EnterEventMode>> independently in these cases,
-whether the return argument `enterEventMode` of <<fmi3CompletedIntegratorStep>> is `fmi3True` or `fmi3False`.]_
+_Note that this function is not used to detect time or state events, for example, by comparing event indicators of the previous with the current call of <<fmi3CompletedIntegratorStep>>._
+_These types of events are detected in the environment, and the environment has to call <<fmi3EnterEventMode>> independently in these cases, whether the return argument `enterEventMode` of <<fmi3CompletedIntegratorStep>> is `fmi3True` or `fmi3False`.]_
 
 [[fmi3GetDerivatives,`fmi3GetDerivatives`]]
 [source, C]
@@ -202,9 +198,9 @@ Return the nominal values of the continuous <<state,`states`>>.
 This function should always be called after calling function <<fmi3NewDiscreteStates>> if it returns with `eventInfo->nominalsOfContinuousStatesChanged = fmi3True`, since then the nominal values of the continuous <<state,`states`>> have changed _[for example, because the association of the continuous <<state,`states`>> to variables has changed due to internal dynamic state selection]_.
 If the FMU does not have information about the nominal value of a continuous <<state>> i, a nominal value `x_nominal[i] = 1.0` should be returned.
 Note that it is required that `x_nominal[i] > 0.0`.
-_[Typically, the nominal values of the continuous <<state,`states`>> are used to compute the absolute tolerance required by the integrator.
-Example: +
-`absoluteTolerance[i] = 0.01*tolerance*x_nominal[i];`]_
+_[Typically, the nominal values of the continuous <<state,`states`>> are used to compute the absolute tolerance required by the integrator._
+_Example:_ +
+`absoluteTolerance[i] = 0.01 * tolerance * x_nominal[i];` _]_
 
 ==== State Machine of Calling Sequence [[state-machine-model-exchange]]
 
@@ -259,9 +255,9 @@ Note that simulation backward in time is only allowed over continuous time inter
 As soon as an event occurred (<<fmi3EnterEventMode>> was called), going back in time is forbidden, because <<fmi3EnterEventMode>> / <<fmi3NewDiscreteStates>> can only compute the next discrete state, not the previous one.
 
 Note that during *Initialization*, *Event*, and *Continuous-Time Mode* <<input>> variables can be set with `fmi3SetXXX` and output variables can be retrieved with `fmi3GetXXX` interchangeably according to the model structure defined under element `<ModelStructure>` in the XML file.
-_[For example, if one <<output>> `y1` depends on two <<input,`inputs`>> `u1`, `u2`, then these two <<input,`inputs`>> must be set, before `y1` can be retrieved.
-If additionally an <<output>> `y2` depends on an <<input>> `u3`, then `u3` can be set and `y2` can be retrieved afterwards.
-As a result, artificial or `real` algebraic loops over connected FMUs in any of these three modes can be handled by using appropriate numerical algorithms.]_
+_[For example, if one <<output>> `y1` depends on two <<input,`inputs`>> `u1`, `u2`, then these two <<input,`inputs`>> must be set, before `y1` can be retrieved._
+_If additionally an <<output>> `y2` depends on an <<input>> `u3`, then `u3` can be set and `y2` can be retrieved afterwards._
+_As a result, artificial or `real` algebraic loops over connected FMUs in any of these three modes can be handled by using appropriate numerical algorithms.]_
 
 The allowed function calls in the respective states are summarized in the following table (functions marked in "[yellow-background]#yellow#" are only available for Model Exchange, the other functions are available both for Model Exchange and Co-Simulation):
 
@@ -381,6 +377,6 @@ Before a new loop iteration is started, the environment must activate the <<cloc
 Leave event mode::
 The function <<fmi3NewDiscreteStates>> evaluates the discrete-time equations, provided the corresponding <<clock>> is active and the discrete-time equations have not already been evaluated with calls to `fmi3GetXXX` functions.
 Clocks are automatically deactivated by <<fmi3NewDiscreteStates>> and by <<fmi3Reset>>.
-_[This handling of discrete <<state,`states`>> and time events is forward compatible with FMI 2.0 for any model that could be treated with FMI 2.0 and is exported again using the new features.
-The environment may ignore the new functions <<fmi3SetClock>>, <<fmi3GetClock>>, <<fmi3SetIntervalDecimal>>, <<fmi3SetIntervalFraction>>, <<fmi3GetIntervalDecimal>> and <<fmi3GetIntervalFraction>>.
-The new functions are needed for FMUs with input sample times and to set discrete-time <<state,`states`>> in model-based control applications or if algebraic loops are present among discrete-time equations of multiple connected FMUs.]_
+_[This handling of discrete <<state,`states`>> and time events is forward compatible with FMI 2.0 for any model that could be treated with FMI 2.0 and is exported again using the new features._
+_The environment may ignore the new functions <<fmi3SetClock>>, <<fmi3GetClock>>, <<fmi3SetIntervalDecimal>>, <<fmi3SetIntervalFraction>>, <<fmi3GetIntervalDecimal>> and <<fmi3GetIntervalFraction>>._
+_The new functions are needed for FMUs with input sample times and to set discrete-time <<state,`states`>> in model-based control applications or if algebraic loops are present among discrete-time equations of multiple connected FMUs.]_

--- a/docs/3_3_model_exchange_schema.adoc
+++ b/docs/3_3_model_exchange_schema.adoc
@@ -1,6 +1,6 @@
 === FMI Description Schema
 
-This is defined in 2.2.
+This is defined in <<fmi-description-schema>>.
 Additionally, the Model Exchange-specific element `ModelExchange` is defined in the next section.
 
 ==== Model Exchange FMU (ModelExchange) [[ModelExchange]]
@@ -20,16 +20,16 @@ The following attributes are defined (all of them are optional, with exception o
 |_Description_
 
 |`modelIdentifier`
-|Short class name according to C syntax, for example, "A_B_C".
+|Short class name according to C syntax, for example, `A_B_C`.
 Used as prefix for FMI functions if the functions are provided in C source code or in static libraries, but not if the functions are provided by a DLL/SharedObject.
 `modelIdentifier` is also used as name of the static library or DLL/SharedObject.
 See also <<header-files-and-naming-of-functions>>.
 
 |`needsExecutionTool`
 |If `true`, a tool is needed to execute the model and the FMU just contains the communication to this tool.
-_[Typically, this information is only utilized for information purposes.
-For example, when loading an FMU with `needsExecutionTool = true`, the environment can inform the user that a tool has to be available on the computer where the model is instantiated.
-The name of the tool can be taken from attribute generationTool of fmiModelDescription.]_
+_[Typically, this information is only utilized for information purposes._
+_For example, when loading an FMU with `needsExecutionTool = true`, the environment can inform the user that a tool has to be available on the computer where the model is instantiated._
+_The name of the tool can be taken from attribute generationTool of fmiModelDescription.]_
 
 |`completedIntegratorStepNotNeeded`
 |If `true`, function <<fmi3CompletedIntegratorStep>> need not be called (this gives a slightly more efficient integration).

--- a/docs/3___model_exchange.adoc
+++ b/docs/3___model_exchange.adoc
@@ -1,4 +1,5 @@
 == FMI for Model Exchange [[fmi-for-model-exchange]]
+
 This chapter contains the interface description to access the equations of a dynamic system from a C program.
 A schematic view of a model in FMI for Model Exchange format is shown in <<figure-model-exchange-data-flow>>:
 

--- a/docs/4_1_co-simulation_math.adoc
+++ b/docs/4_1_co-simulation_math.adoc
@@ -12,7 +12,7 @@ The term "communication point" in FMI for Co-Simulation refers to the communicat
 
 FMI for Co-Simulation provides an interface standard for the solution of time-dependent coupled systems consisting of subsystems that are continuous in time (model components that are described by instationary differential equations) or time-discrete (model components that are described by difference equations such as discrete controllers).
 In a block representation of the coupled system, the subsystems are represented by blocks with (internal) <<state>> variables latexmath:[x(t)] that are connected to other subsystems (blocks) of the coupled problem by _subsystem <<input,`inputs`>>_ latexmath:[u(t)] and _subsystem <<output,`outputs`>>_ latexmath:[y(t)].
-In this framework, the physical connections between subsystems are represented by mathematical coupling conditions between the inputs latexmath:[u(t)] and the <<output,`outputs`>> latexmath:[y(t)] of all subsystems, _K&#252;bler and Schiehlen (2000)_.
+In this framework, the physical connections between subsystems are represented by mathematical coupling conditions between the inputs latexmath:[u(t)] and the <<output,`outputs`>> latexmath:[y(t)] of all subsystems, <<KS00>>.
 
 .Data flow at communication points.
 image::images/co-simulation-data-flow.svg[width=80%, align="center"]
@@ -204,7 +204,7 @@ O(hc_i^{2}).
 
 _]_
 
-Definition <<equation-co-simulation-evaluations>> is consistent with the definition of co-simulation by (K&#252;bler, Schiehlen 2000).
+Definition <<equation-co-simulation-evaluations>> is consistent with the definition of co-simulation by <<KS00>>.
 
 * At the communication points, the master provides generalized inputs to the slave, which can be:
 

--- a/docs/4_1_co-simulation_math.adoc
+++ b/docs/4_1_co-simulation_math.adoc
@@ -1,5 +1,7 @@
 === Mathematical Description
+
 ==== Co-Simulation [[math-co-simulation]]
+
 ===== Basics Co-Simulation
 
 Co-simulation exploits the modular structure of coupled problems in all stages of the simulation process beginning with the separate model setup and preprocessing for the individual subsystems in different simulation tools (which can be powerful simulators as well as simple C programs).
@@ -9,7 +11,7 @@ In different contexts, the communication points latexmath:[tc_i], the communicat
 The term "communication point" in FMI for Co-Simulation refers to the communication between subsystems in a co-simulation environment and should not be mixed with the output points for saving simulation results to file.
 
 FMI for Co-Simulation provides an interface standard for the solution of time-dependent coupled systems consisting of subsystems that are continuous in time (model components that are described by instationary differential equations) or time-discrete (model components that are described by difference equations such as discrete controllers).
-In a block representation of the coupled system, the subsystems are represented by blocks with (internal) <<state>> variables latexmath:[x(t)] that are connected to other subsystems (blocks) of the coupled problem by _subsystem <<input,`inputs`>>_ latexmath:[u(t)] and _subsystem <<output,`outputs`>>_  latexmath:[y(t)].
+In a block representation of the coupled system, the subsystems are represented by blocks with (internal) <<state>> variables latexmath:[x(t)] that are connected to other subsystems (blocks) of the coupled problem by _subsystem <<input,`inputs`>>_ latexmath:[u(t)] and _subsystem <<output,`outputs`>>_ latexmath:[y(t)].
 In this framework, the physical connections between subsystems are represented by mathematical coupling conditions between the inputs latexmath:[u(t)] and the <<output,`outputs`>> latexmath:[y(t)] of all subsystems, _K&#252;bler and Schiehlen (2000)_.
 
 .Data flow at communication points.
@@ -22,7 +24,7 @@ For Co-Simulation two basic groups of functions have to be implemented:
 . functions for algorithmic issues to synchronize the simulation of all subsystems and to proceed in communication steps latexmath:[tc_i \rightarrow tc_{i+1}] from initial time latexmath:[tc_0 := t_{start}] to end time latexmath:[tc_N := t_{stop}]
 
 In FMI for Co-Simulation, both functions are implemented in one software component, the Co-Simulation master.
-The data exchange between the subsystems (_slaves_) is handled via the master only.
+The data exchange between the subsystems (slaves) is handled via the master only.
 There is no direct communication between the slaves.
 The master functionality can be implemented by a special software tool (a separate simulation backplane) or by one of the involved simulation tools.
 In its most general form, the coupled system may be simulated in nested co-simulation environments and FMI for Co-Simulation applies to each level of the hierarchy.
@@ -70,10 +72,10 @@ The details of the flow are given in the state machine of the calling sequences 
 
 ===== Mathematical Model Co-Simulation
 
-_[Function `fmi3Set{VariableType}` used in the document, is an abbreviation for functions `fmi3SetFloat64`, `fmi3SetInt8`, `fmi3SetInt16`, `fmi3SetString` and for other base variable types respectively - with the exception of <<clock,`clocks`>>.
-Function `fmi3Get{VariableType}` is an abbreviation for functions `fmi3SetFloat64`, `fmi3SetInt8`, `fmi3SetInt16`, `fmi3SetString` and for other base variable types respectively - with the exception of <<clock,`clocks`>>.
-]_
-#TODO: Move to better place of function abbreviation definition in document#
+_[Function `fmi3Set{VariableType}` used in the document, is an abbreviation for functions `fmi3SetFloat64`, `fmi3SetInt8`, `fmi3SetInt16`, `fmi3SetString` and for other base variable types respectively - with the exception of <<clock,`clocks`>>._
+_Function `fmi3Get{VariableType}` is an abbreviation for functions `fmi3SetFloat64`, `fmi3SetInt8`, `fmi3SetInt16`, `fmi3SetString` and for other base variable types respectively - with the exception of <<clock,`clocks`>>.]_
+
+// TODO: Move to better place of function abbreviation definition in document
 
 This section contains a formal mathematical model of a Co-Simulation FMU.
 The following fundamental assumptions are made:
@@ -95,38 +97,46 @@ An FMI Co-Simulation model is described by the following variables:
 
 [options="header", cols="^1,7"]
 |====
-|_Variable_ |_Description_
+|Variable
+|Description
 
-|latexmath:[t] |Independent variable time latexmath:[\in \mathbb{R}].
+|latexmath:[t]
+|Independent variable time latexmath:[\in \mathbb{R}].
 (Variable defined with <<causality>> = <<independent>>). +
 The i-th communication point is denoted as latexmath:[t = tc_i] +
 The communication step size is denoted as latexmath:[hc_i = tc_{i+1} - tc_i]
 
-|latexmath:[\mathbf{v}] | A vector of all exposed variables (all variables defined in element `<ModelVariables>`, see <<definition-of-model-variables>>).
+|latexmath:[\mathbf{v}]
+| A vector of all exposed variables (all variables defined in element `<ModelVariables>`, see <<definition-of-model-variables>>).
 A subset of the variables is selected via a subscript.
 Example: +
 latexmath:[\mathbf{v}_{initial=exact}] are variables defined with attribute <<initial>> = <<exact>>, see <<definition-of-model-variables>>.
 These are <<independent>> <<parameter,`parameters`>> and <<start>> values of other variables, such as initial values for <<state,`states`>>, state derivatives or <<output,outputs>>.
 
-|latexmath:[\mathbf{p}] |Parameters that are constant during simulation.
+|latexmath:[\mathbf{p}]
+|Parameters that are constant during simulation.
 The symbol without a subscript references <<independent>> <<parameter,`parameters`>> (variables with <<causality>> = <<parameter>>).
 Dependent <<parameter,`parameters`>> (variables with <<causality>> = <<calculatedParameter>>) are denoted as latexmath:[\mathbf{p}_{calculated}] and <<tunable>> <<parameter,`parameters`>> (variables with <<causality>> = <<parameter>> and <<variability>> = <<tunable>>) are denoted as latexmath:[\mathbf{p}_{tune}].
 
-|latexmath:[\mathbf{u}(tc_i)] |Input variables.
+|latexmath:[\mathbf{u}(tc_i)]
+|Input variables.
 The values of these variables are defined outside of the model.
 Variables of this type are defined with attribute <<causality>> = <<input>>.
 Whether the <<input>> is a discrete-time or continuous-time variable is defined via attribute <<variability>> = <<discrete>> or <<continuous>> (see <<definition-of-model-variables>>).
 
-|latexmath:[\mathbf{y}(tc_i)] |Output variables.
+|latexmath:[\mathbf{y}(tc_i)]
+|Output variables.
 The values of these variables are computed in the FMU and they are designed to be used in a model connection.
 So output variables might be used in the environment as input values to other FMUs or other submodels.
 Variables of this type are defined with attribute <<causality>> = <<output>>.
 Via attribute <<variability>> = <<discrete>> or <<continuous>> it is defined whether the <<output>> is a discrete-time or continuous-time variable, see <<definition-of-model-variables>>.
 
-|latexmath:[\mathbf{w}(tc_i)] |Local variables of the FMU that cannot be used for FMU connections.
+|latexmath:[\mathbf{w}(tc_i)]
+|Local variables of the FMU that cannot be used for FMU connections.
 Variables of this type are defined with attribute <<causality>> = <<local>> (see <<definition-of-model-variables>>).
 
-|latexmath:[\mathbf{x}_c(t)] |A vector of real continuous-time variables representing the continuous-time <<state,`states`>>.
+|latexmath:[\mathbf{x}_c(t)]
+|A vector of real continuous-time variables representing the continuous-time <<state,`states`>>.
 For notational convenience, a continuous-time <<state>> is conceptually treated as a different type of variable as an <<output>> or a <<local>> variable for the mathematical description below.
 However, at a communication point, a continuous-time <<state>> is part of the <<output,`outputs`>> or the <<local>> variables latexmath:[\mathbf{w}] of an FMU.
 
@@ -141,7 +151,8 @@ Formally, a discrete <<state>> is part of the <<output,`outputs`>> latexmath:[\m
 
 When the transient simulation of the coupled system through Co-Simulation is completed, the sequence of evaluations is the following (here latexmath:[\mathbf{x} = {\lbrack \mathbf{x}_c; \mathbf{x}_d \rbrack}^T] is the combined vector of continuous-time and discrete-time <<state,states>>, and latexmath:[\mathbf{y} = {\lbrack \mathbf{y}_c; \mathbf{y}_d \rbrack}^T]) is the combined vector of continuous-time and discrete-time <<output,`outputs`>>):
 
-.(4.1)
+.Sequence of Co-Simulation evaluations
+[[equation-co-simulation-evaluations,Sequence of Co-Simulation evaluations]]
 [latexmath]
 ++++
 \mathrm{\text{for}}\ i = 0, \cdots, n-1
@@ -179,8 +190,8 @@ _In this case, the following relationship should hold (note the use of_ latexmat
 \mathbf{p}_{tune,i}  \right)
 ++++
 
-_This relation is in practice inexact due to using finite precision on machines and stopping iterations early.
-The slave simulators are responsible for implementing_ latexmath:[\mathbf{\Phi}_i] and latexmath:[\mathbf{\Gamma}_i] _; for example, to handle stiff differential equations as:_
+_This relation is in practice inexact due to using finite precision on machines and stopping iterations early._
+_The slave simulators are responsible for implementing_ latexmath:[\mathbf{\Phi}_i] and latexmath:[\mathbf{\Gamma}_i] _; for example, to handle stiff differential equations as:_
 
 [latexmath]
 ++++
@@ -193,7 +204,7 @@ O(hc_i^{2}).
 
 _]_
 
-Definition (4.1) is consistent with the definition of co-simulation by (K&#252;bler, Schiehlen 2000).
+Definition <<equation-co-simulation-evaluations>> is consistent with the definition of co-simulation by (K&#252;bler, Schiehlen 2000).
 
 * At the communication points, the master provides generalized inputs to the slave, which can be:
 
@@ -210,8 +221,7 @@ Definition (4.1) is consistent with the definition of co-simulation by (K&#252;b
 * Initialization: The slave being a sampled-data system, its internal states (which can be either continuous-time or discrete-time) need to be initialized at latexmath:[t = tc_0].
 This is performed through an auxiliary function _[this relationship is defined in the XML file under `<ModelStructure><InitialUnknowns>`]_:
 
-Computing the solution of an FMI Co-Simulation model means to split the solution process in two phases and in every phase different equations
-and solution methods are utilized.
+Computing the solution of an FMI Co-Simulation model means to split the solution process in two phases and in every phase different equations and solution methods are utilized.
 The phases can be categorized according to the following modes:
 
 Initialization Mode::
@@ -295,11 +305,11 @@ latexmath:[\mathbf{f}_{init}, \mathbf{f}_{out} \in C^0] (=continuous functions w
 
 _[Remark - Calling Sequences:_
 
-_In the table above, for notational convenience in Initialization Mode one function call is defined to compute all output arguments from all inputs arguments.
-In reality, every scalar output argument is computed by one_ `fmi3Get{VariableType}` _function call._
+_In the table above, for notational convenience in Initialization Mode one function call is defined to compute all output arguments from all inputs arguments._
+_In reality, every scalar output argument is computed by one_ `fmi3Get{VariableType}` _function call._
 
-_In_ _Step Mode the input arguments to_ latexmath:[\mathbf{f}_{doStep}] _are defined by calls to_ `fmi3Set{VariableType}` _and_ `fmi3SetRealInputDerivatives` _functions.
-The variables computed by_ latexmath:[\mathbf{f}_{doStep}] _can be inquired by_  `fmi3Get{VariableType}` _function calls.]_
+_In Step Mode the input arguments to_ latexmath:[\mathbf{f}_{doStep}] _are defined by calls to_ `fmi3Set{VariableType}` _and_ `fmi3SetRealInputDerivatives` _functions._
+_The variables computed by_ latexmath:[\mathbf{f}_{doStep}] _can be inquired by_  `fmi3Get{VariableType}` _function calls.]_
 
 ==== Early Return from Current Communication Step
 :DOSTEP: fmi3DoStep()
@@ -308,7 +318,8 @@ The variables computed by_ latexmath:[\mathbf{f}_{doStep}] _can be inquired by_ 
 
 //=== Improving efficiency in multi-FMU environment when asynchronous mode is used
 
-In the particular context of multi-FMU architectures, significant co-simulation speed-up may be obtained if the master can avoid waiting until the end of the slowest FMU step integration. If an FMU prematurely stops its current step integration computation due to an unpredictable internal event before the normal end of the step calculation, all other concurrently running FMUs may be stopped as soon as possible in order to minimize the time needed for the Co-Simulation master to resynchronize all the FMUs at the same event time.
+In the particular context of multi-FMU architectures, significant co-simulation speed-up may be obtained if the master can avoid waiting until the end of the slowest FMU step integration.
+If an FMU prematurely stops its current step integration computation due to an unpredictable internal event before the normal end of the step calculation, all other concurrently running FMUs may be stopped as soon as possible in order to minimize the time needed for the Co-Simulation master to resynchronize all the FMUs at the same event time.
 
 In this context based on parallel multi-FMU calculations, the following figure illustrates different possibilities to synchronize FMUs at the same event time.
 
@@ -344,13 +355,12 @@ At these communication points, the FMU is pushed to the Event mode and <<inputCl
 
 <<outputClock,`Output clocks`>>, on the other hand, are detected by the FMU.
 The FMU detects an <<outputClock>> and informs the master by invoking a callback in which the event time and the event type is communicated to the master.
-Then FMU stops the current Co-Simulation step and returns back from Dostep.
+Then FMU stops the current Co-Simulation step and returns back from <<fmi3DoStep>>.
 Then the FMU is pushed to the Event mode and the event is handled.
 Note that, since output events time instants are not known in advance, at output event time instants, new communication steps are created.
 
 
 ==== Scheduled Execution Simulation Support [[math-scheduled-execution-simulation]]
-:stem: latexmath
 
 The Scheduled Execution Simulation mode has a different timing concept compared to the other Co-Simulation modes.
 This is required to cover <<clock>> ticks for aperiodic <<inputClock,`input clocks`>> which may tick at time instances that are not predictable in advance for the simulation master.
@@ -361,7 +371,7 @@ A Co-Simulation master's call for computing a model partition will compute the r
 The result values will be computed for the current <<clock>> tick time (activation time) latexmath:[t_i] from the assigned <<inputClock>> (which is known to the Co-Simulation master).
 Refer to the <<clock>> time progress definition (<<clock-types-for-evaluation-of-clocked-model-partitions>>) for periodic <<clock,`clocks`>>.
 
-If required, the FMU can internally derive the <<clock>> interval stem:[\Delta T_i] based on the last <<clock>> tick time stem:[t_{i-1}] i.e. last activation time for this model partition.
+If required, the FMU can internally derive the <<clock>> interval latexmath:[\Delta T_i] based on the last <<clock>> tick time latexmath:[t_{i-1}] i.e. last activation time for this model partition.
 
 A model partition can only be activated once per activation time point latexmath:[t_i].
 
@@ -372,24 +382,18 @@ The activation of such a <<outputClock>> is not directly controlled by the Co-Si
 
 Intermediate variable access has three main uses:
 
-1. *An FMU is able to produce valid output variables at intermediate points
-during a communication interval.* This is typically the result of an internal
-solver taking multiple integration steps at each communication interval.
-The FMU exposes intermediate output variables for the master whenever they are
-available. These can be used for e.g. extrapolation, interpolation, filtering
-or asynchronous co-simulation.
+. *An FMU is able to produce valid output variables at intermediate points during a communication interval.*
+This is typically the result of an internal solver taking multiple integration steps at each communication interval.
+The FMU exposes intermediate output variables for the master whenever they are available.
+These can be used for e.g. extrapolation, interpolation, filtering or asynchronous co-simulation.
 
-2. *Intermediate <<input>> variables for an FMU is available in the Co-Simulation
-master.* The FMU requests updated intermediate <<input>> variables every time they
-are required by the internal solver. This can be either at temporary solver
-states or after successful integration steps.
+. *Intermediate <<input>> variables for an FMU is available in the Co-Simulation master.*
+The FMU requests updated intermediate <<input>> variables every time they are required by the internal solver.
+This can be either at temporary solver states or after successful integration steps.
 
-3. *Intermediate <<input>> variables for the FMU can be computed by the
-Co-Simulation master.* The computation requires intermediate output
-variables from the FMU. Whenever the internal solver in the FMU needs
-updated intermediate <<input>> variables, it provides the intermediate
-output variables for and requests the intermediate <<input>> variables from
-the master.
+. *Intermediate <<input>> variables for the FMU can be computed by the Co-Simulation master.*
+The computation requires intermediate output variables from the FMU.
+Whenever the internal solver in the FMU needs updated intermediate <<input>> variables, it provides the intermediate output variables for and requests the intermediate <<input>> variables from the master.
 
 Combinations of the above methods are also allowed.
 

--- a/docs/4_2_co-simulation_api.adoc
+++ b/docs/4_2_co-simulation_api.adoc
@@ -112,7 +112,7 @@ The following state machine defines the supported calling sequences.
 [#figure-co-simulation-state-machine]
 image::images/calling-sequence-co-simulation.svg[width=80%, align="center"]
 
-In this Co-Simulation mode the following functions must not be called: `fmi3ActivateModelPartition`, <<fmi3NewDiscreteStates>>, <<fmi3EnterEventMode>>, <<fmi3SetClock>>, <<fmi3GetClock>>, <<fmi3SetIntervalFraction>>, <<fmi3GetIntervalFraction>>, <<fmi3SetIntervalDecimal>>, <<fmi3GetIntervalDecimal>> including all functions that are specific to fmuType `fmi3ModelExchange`.
+In this Co-Simulation mode the following functions must not be called: <<fmi3ActivateModelPartition>>, <<fmi3NewDiscreteStates>>, <<fmi3EnterEventMode>>, <<fmi3SetClock>>, <<fmi3GetClock>>, <<fmi3SetIntervalFraction>>, <<fmi3GetIntervalFraction>>, <<fmi3SetIntervalDecimal>>, <<fmi3GetIntervalDecimal>> including all functions that are specific to fmuType `fmi3ModelExchange`.
 
 ====== State: slaveSetableFMUstate [[state-slave-setable-fmu-state-co-simulation]]
 
@@ -598,7 +598,7 @@ The following state machine defines the supported calling sequences.
 image::images/calling-sequence-hybrid-co-simulation.svg[width=80%, align="center"]
 [#figure-hybrid-co-simulation-state-machine]
 
-In this Co-Simulation mode the following functions must not be called: `fmi3ActivateModelPartition` including all functions that are specific to fmuType `fmi3ModelExchange`.
+In this Co-Simulation mode the following functions must not be called: <<fmi3ActivateModelPartition>> including all functions that are specific to fmuType `fmi3ModelExchange`.
 
 Unlike the state machine in section <<state-machine-co-simulation>> the entry state after *Initialization Mode* is the *Event Mode* in order to allow the FMU to handle the very first discrete event.
 Each state of the state machine corresponds to a certain phase of a simulation as follows:
@@ -790,12 +790,12 @@ In case of `fmi3Discard` or `fmi3Error` no repetition of the step is possible, t
 The simulation master sets and gets variable values as defined in section <<get-and-set-variable-values>>.
 
 Before scheduling a model partition it is allowed to set all variables assigned to that model partition via its associated <<clock>> (including all global variables that are not associated to a <<clock>>) via `fmi3Set{VariableType}`.
-After the computation of a model partition (call of `fmi3ActivateModelPartition` with the <<clockReference>> of the <<clock>> that is associated to the model partition) all variables that are assigned to this model partition (including all global variables that are not associated to a <<clock>>) can be retrieved via `fmi3Get{VariableType}`.
+After the computation of a model partition (call of <<fmi3ActivateModelPartition>> with the <<clockReference>> of the <<clock>> that is associated to the model partition) all variables that are assigned to this model partition (including all global variables that are not associated to a <<clock>>) can be retrieved via `fmi3Get{VariableType}`.
 Set/get operations have to be atomic for a single variable.
 
 _[The value of global variables can be influenced by more than one model partition if multiple model partitions are active at the same time.]_
 
-The computational effort has to be predictable, thus all computationally expensive operations needed to calculate a model partition have to be contained within the `fmi3ActivateModelPartition` function.
+The computational effort has to be predictable, thus all computationally expensive operations needed to calculate a model partition have to be contained within the <<fmi3ActivateModelPartition>> function.
 The simulation master can assume that `fmi3Get{VariableType} and fmi3Set{VariableType}` operations are not computationally expensive.
 In mode `fmi3ModeScheduledExecutionSimulation` the handling of <<fmi3CallbackIntermediateUpdate>> callbacks is the same as in section <<clocked-co-simulation>>.
 The only difference is that an early return has no meaning in this mode and  no additional event handling based on <<fmi3NewDiscreteStates>> is conducted.
@@ -807,15 +807,15 @@ _[In this mode it is recommended to restrict such updates by the FMU to <<output
 If this mode is set, the master has to directly control the time of computation of model partitions associated to <<inputClock,`input clocks`>>.
 The activation states of <<outputClock,`output clocks`>> are transported via <<fmi3CallbackIntermediateUpdate>> and <<fmi3GetClock>>.
 
-[[fmi3ActivateModelPartition]]
-Each `fmi3ActivateModelPartition` call is now associated to the computation of a (publicly disclosed, externally controlled) model partition of the model and therefore to a single defined <<inputClock>>.
+[[fmi3ActivateModelPartition, `fmi3ActivateModelPartition`]]
+Each <<fmi3ActivateModelPartition>> call is now associated to the computation of a (publicly disclosed, externally controlled) model partition of the model and therefore to a single defined <<inputClock>>.
 
 [source, C]
 ----
 include::../headers/fmi3FunctionTypes.h[tag=ActivateModelPartition]
 ----
 
-The `fmi3ActivateModelPartition` function has the following parameters:
+The <<fmi3ActivateModelPartition>> function has the following parameters:
 
 - `fmi3Instance instance`: same meaning as for other `fmi3*` functions
 
@@ -823,26 +823,26 @@ The `fmi3ActivateModelPartition` function has the following parameters:
 
 - `fmi3Float64 activationTime`: simulation (i.e. virtual) time of the <<clock>> tick
 
-Scheduling of `fmi3ActivateModelPartition` calls for each FMU is done by the simulation master.
+Scheduling of <<fmi3ActivateModelPartition>> calls for each FMU is done by the simulation master.
 Calls are based on ticks of periodic or aperiodic <<inputClock,`input clocks`>>.
 These <<inputClock>> ticks can be based on <<clock>> ticks from FMU external sources (e.g. <<outputClock,`output clocks`>> of other FMUs) or other external <<clock,`clocks`>>/events/interrupts assigned via the simulation master configuration (such external events can be based on a potentially unpredictable process or can be just simulation time based events e.g. the planned communication point).
-The `fmi3ActivateModelPartition` function is not called for <<outputClock,`output clocks`>> of an FMU.
+The <<fmi3ActivateModelPartition>> function is not called for <<outputClock,`output clocks`>> of an FMU.
 
 The <<fmi3DoStep>>, <<fmi3SetClock>>, <<fmi3SetIntervalDecimal>>, <<fmi3SetIntervalFraction>>, <<fmi3DoEarlyReturn>>, <<fmi3EnterEventMode>>, <<fmi3EnterStepMode>> functions must not be called in this Co-Simulation mode.
 
-The value for the `fmi3ActivateModelPartition` parameter `activationTime` is the <<clock>> tick time latexmath:[t_i] from the  assigned <<inputClock>> (which is known to the Co-Simulation master).
+The value for the <<fmi3ActivateModelPartition>> parameter `activationTime` is the <<clock>> tick time latexmath:[t_i] from the  assigned <<inputClock>> (which is known to the Co-Simulation master).
 
 Refer to <<math-scheduled-execution-simulation>> and <<clock-types-for-evaluation-of-clocked-model-partitions>>.
 
 This is a different timing concept compared to <<fmi3DoStep>> calls.
-A `fmi3ActivateModelPartition` call will compute the results of the model partition defined by <<clockReference>> (i.e. <<valueReference>> of the variable that defines a <<clock>>) for the current <<clock>> tick latexmath:[t_i].
+A <<fmi3ActivateModelPartition>> call will compute the results of the model partition defined by <<clockReference>> (i.e. <<valueReference>> of the variable that defines a <<clock>>) for the current <<clock>> tick latexmath:[t_i].
 
-The value for the `fmi3ActivateModelPartition` parameter `activationTime` is the <<clock>> tick time latexmath:[t_i] from the assigned <<inputClock>> (which is known to the Co-Simulation master).
+The value for the <<fmi3ActivateModelPartition>> parameter `activationTime` is the <<clock>> tick time latexmath:[t_i] from the assigned <<inputClock>> (which is known to the Co-Simulation master).
 Refer to the <<clock>> time progress definition (<<clock-types-for-evaluation-of-clocked-model-partitions>>) for periodic <<clock,`clocks`>>.
 
-If required, the FMU can internally derive the <<clock>> interval latexmath:[\Delta T_i] based on the last <<clock>> tick time latexmath:[t_{i-1}] i.e. last activationTime for this <<clockReference>> (based on last `fmi3ActivateModelPartition` call).
+If required, the FMU can internally derive the <<clock>> interval latexmath:[\Delta T_i] based on the last <<clock>> tick time latexmath:[t_{i-1}] i.e. last activationTime for this <<clockReference>> (based on last <<fmi3ActivateModelPartition>> call).
 
-It is not allowed to call `fmi3ActivateModelPartition` for a <<clockReference>> (i.e. <<valueReference>> of <<clock>> variable) more than once for the same activationTime latexmath:[t_i].
+It is not allowed to call <<fmi3ActivateModelPartition>> for a <<clockReference>> (i.e. <<valueReference>> of <<clock>> variable) more than once for the same activationTime latexmath:[t_i].
 
 ===== State Machine for fmi3ModeScheduledExecutionSimulation
 
@@ -878,19 +878,19 @@ After <<fmi3Terminate>> has been called no new tasks can be started (e.g. relate
 ====== State: Clock Activation Mode
 
 The FMU enters this state when the master calls <<fmi3ExitInitializationMode>> in state `Initialization Mode` or <<fmi3ExitConfigurationMode>> in state *Reconfiguration Mode*.
-In this state the master can create multiple concurrent tasks related to an FMU and in each task the master can activate one or multiple <<inputClock,`input clocks`>> of an FMU based on the defined <<clock>> properties via a `fmi3ActivateModelPartition` call for each <<clock>>.
+In this state the master can create multiple concurrent tasks related to an FMU and in each task the master can activate one or multiple <<inputClock,`input clocks`>> of an FMU based on the defined <<clock>> properties via a <<fmi3ActivateModelPartition>> call for each <<clock>>.
 
 Allowed Function Calls::
 
-`fmi3ActivateModelPartition`::
+<<fmi3ActivateModelPartition>>::
 If the function returns with `fmi3OK` or `fmi3Warning` the FMU stays in this state.
 In case of `fmi3Fatal` the master can prematurely end all tasks related to the computation of model partitions of this FMU.
 In case of `fmi3Discard` or `fmi3Error` the master must wait until all other tasks related to the computation of model partitions of this FMU have ended, but no new tasks can be started (e.g. related to <<outputClock>> tick) and all other function calls for this FMU must also return `fmi3Discard` or `fmi3Error` until the state *Terminated* is reached.
 +
-It is recommended to call `fmi3Set{VariableType}` and `fmi3Get{VariableType}` in the same task as `fmi3ActivateModelPartition` for setting and retrieving variable values associated to a <<clock>> activation.
+It is recommended to call `fmi3Set{VariableType}` and `fmi3Get{VariableType}` in the same task as <<fmi3ActivateModelPartition>> for setting and retrieving variable values associated to a <<clock>> activation.
 
 <<get-and-set-variable-values,fmi3Set{VariableType}>>, `fmi3SetRealInputDerivatives`::
-Is called before the start of the computation of a model partition (i.e. before call of `fmi3ActivateModelPartition`) and only for global variables and variables associated to the <<inputClock>> assigned to the model partition.
+Is called before the start of the computation of a model partition (i.e. before call of <<fmi3ActivateModelPartition>>) and only for global variables and variables associated to the <<inputClock>> assigned to the model partition.
 +
 The restrictions related to variable <<causality>> and <<variability>> defined for `Step Mode` in mode `fmi3ModeCoSimulation` apply.
 +
@@ -899,7 +899,7 @@ In case the function returns `fmi3Fatal` the master can prematurely end all task
 In case the function returns `fmi3Discard` or `fmi3Error` the master must wait until all other tasks related to the computation of the model partitions of this FMU have ended, but new tasks must not be started (e.g. related to <<outputClock>> ticks) and all other function calls for this FMU must also return `fmi3Discard` or `fmi3Error` until the state *Terminated* is reached.
 
 <<get-and-set-variable-values,fmi3Get{VariableType}>>, `fmi3GetRealOutputDerivatives`, <<fmi3GetDirectionalDerivative>>`::
-Is called after the end of the computation of a model partition (i.e. after return of `fmi3ActivateModelPartition`) and only for global variables and variables associated to the <<inputClock>> assigned to the model partition.
+Is called after the end of the computation of a model partition (i.e. after return of <<fmi3ActivateModelPartition>>) and only for global variables and variables associated to the <<inputClock>> assigned to the model partition.
 +
 The restrictions related to variable <<causality>> and <<variability>> defined for `Step Mode` in mode `fmi3ModeCoSimulation` apply.
 +
@@ -907,7 +907,7 @@ If the function returns with `fmi3OK` or `fmi3Warning` the FMU stays in this sta
 In case the function returns `fmi3Fatal` the master can prematurely end all tasks related to the computation of model partitions of this FMU.
 In case the function returns `fmi3Discard` or `fmi3Error` the master must wait until all other tasks related to the computation of model partitions of this FMU have ended, but new tasks must not be started (e.g. related to <<outputClock>> ticks) and all other function calls for this FMU have to also return `fmi3Discard` or `fmi3Error` until the state *Terminated* is reached.
 
-It is not allowed to call `fmi3Get{VariableType}` functions after `fmi3Set{VariableType}` functions without an `fmi3ActivateModelPartition` call in between.
+It is not allowed to call `fmi3Get{VariableType}` functions after `fmi3Set{VariableType}` functions without an <<fmi3ActivateModelPartition>> call in between.
 
 _[The reason is to avoid different interpretations of the caching, since contrary to FMI for Model Exchange, <<fmi3DoStep>> will perform the actual calculation instead of `fmi3Get{VariableType}`, and therefore, dummy algebraic loops at communication points cannot be handled by an appropriate sequence of `fmi3Get{VariableType}` and, `fmi3Set{VariableType}` calls as for Model Exchange._
 
@@ -936,7 +936,7 @@ _]_
 
 <<fmi3CallbackIntermediateUpdate>>::
 Only in this state the FMU is allowed to call the callback <<fmi3CallbackIntermediateUpdate>>.
-The callback may be called from concurrent tasks within `fmi3ActivateModelPartition`.
+The callback may be called from concurrent tasks within <<fmi3ActivateModelPartition>>.
 The function must not return `fmi3Discard`.
 
 <<fmi3EnterConfigurationMode>>::
@@ -961,13 +961,13 @@ Additionally to the generally forbidden functions in this Co-Simulation mode as 
 In this state the master can retrieve information from the FMU between communication points.
 Functions called in this state must not return `fmi3Discard`.
 
-The FMU enters this state by calling <<fmi3CallbackIntermediateUpdate>>  within `fmi3ActivateModelPartition` and leaves the state towards state `Clock Activation Mode` if the function returns `fmi3OK` or `fmi3Warning`.
+The FMU enters this state by calling <<fmi3CallbackIntermediateUpdate>>  within <<fmi3ActivateModelPartition>> and leaves the state towards state `Clock Activation Mode` if the function returns `fmi3OK` or `fmi3Warning`.
 If the function returns `fmi3Error` the FMU enters state *Terminated*.
 If the function returns `fmi3Fatal` the FMU enters state *Fatal*.
 
 
 Forbidden Function Calls::
-The same functions which are not allowed to be called in `Clock Activation Mode` must not be called in this state. Additionally the following functions must not be called `fmi3ActivateModelPartition`, <<fmi3EnterConfigurationMode>>, <<fmi3Terminate>>.
+The same functions which are not allowed to be called in `Clock Activation Mode` must not be called in this state. Additionally the following functions must not be called <<fmi3ActivateModelPartition>>, <<fmi3EnterConfigurationMode>>, <<fmi3Terminate>>.
 
 Allowed Function Calls::
 For a <<outputClock>> only the first call of `fmi3GetClock` for a specific activation of this <<clock>> signals `fmi3True`.
@@ -989,27 +989,27 @@ Allowed Function Calls::
 - `fmi3Set{VariableTypes}`: Only for variables with <<causality>> = <<structuralParameter>> and <<variability>> = <<tunable>>.
 
 Forbidden Function Calls::
-Additionally to the generally forbidden functions in this Co-Simulation mode listed above the following functions must not be called in this state: <<fmi3EnterConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3GetDoStepDiscardedStatus>>, `fmi3ActivateModelPartition`,`fmi3SetRealInputDerivatives`, <<fmi3GetDirectionalDerivative>>, `fmi3GetRealOutputDerivatives`, `fmi3Get{VariableTypes}`, <<fmi3DoEarlyReturn>>
+Additionally to the generally forbidden functions in this Co-Simulation mode listed above the following functions must not be called in this state: <<fmi3EnterConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3GetDoStepDiscardedStatus>>, <<fmi3ActivateModelPartition>>,`fmi3SetRealInputDerivatives`, <<fmi3GetDirectionalDerivative>>, `fmi3GetRealOutputDerivatives`, `fmi3Get{VariableTypes}`, <<fmi3DoEarlyReturn>>
 
 // TODO: add non-normative table of states and function calls
 
 ===== Preemption Support [[preemption-support]]
 
-For real-time applications the simulation time equals the real wall <<clock>> time, thus each `fmi3ActivateModelPartition` computation step has to be finished in real-time within its current period time length (computation time is not only defined by the runtime of `fmi3ActivateModelPartition` but also by the time for setting and getting variables and related operations).
-Usually a preemptive scheduling of the `fmi3ActivateModelPartition`, `fmi3Get{VariableType}`, `fmi3Set{VariableType}` calls is required for respecting this constraint.
+For real-time applications the simulation time equals the real wall <<clock>> time, thus each <<fmi3ActivateModelPartition>> computation step has to be finished in real-time within its current period time length (computation time is not only defined by the runtime of <<fmi3ActivateModelPartition>> but also by the time for setting and getting variables and related operations).
+Usually a preemptive scheduling of the <<fmi3ActivateModelPartition>>, `fmi3Get{VariableType}`, `fmi3Set{VariableType}` calls is required for respecting this constraint.
 
-The FMU's code has to be prepared for being able to correctly handle preemptive calls of `fmi3ActivateModelPartition`, `fmi3Get{VariableType}`, `fmi3Set{VariableType}`.
+The FMU's code has to be prepared for being able to correctly handle preemptive calls of <<fmi3ActivateModelPartition>>, `fmi3Get{VariableType}`, `fmi3Set{VariableType}`.
 That requires a secured internal and external access to global states and variable values.
 Thus in this Co-Simulation mode a support for a correct handling of the preemption of model partition computations is required.
 That also requires that the FMU reports the active state of a <<outputClock>> only with the first call of <<fmi3GetClock>> for a specific activation of this <<clock>> and sets the reported activation state immediately back to `false` for the following <<fmi3GetClock>> calls for that <<clock>> until this <<outputClock>> is internally activated again.
 
 If a preemptive multitasking regime is intended an individual task (or thread -- task and thread are used synonymously here) for each model partition (associated to an <<inputClock>>) has to be created.
-The task for computing each `fmi3ActivateModelPartition` is created and controlled by the simulation master, not by the FMU.
+The task for computing each <<fmi3ActivateModelPartition>> is created and controlled by the simulation master, not by the FMU.
 So the FMU exporting tool does not need to take care for that (except for preparing its code to support preemption).
 
-_[If only one single model partition (<<inputClock>>) is available via the interface of an FMU, preemptive calls of the related `fmi3ActivateModelPartition` function are possible by default since there are no external cross dependencies within one model partition between communication points.]_
+_[If only one single model partition (<<inputClock>>) is available via the interface of an FMU, preemptive calls of the related <<fmi3ActivateModelPartition>> function are possible by default since there are no external cross dependencies within one model partition between communication points.]_
 
-Based on the <<inputClock>> settings defined in the XML the master calls `fmi3Set{VariableType}`, `fmi3ActivateModelPartition`, `fmi3Get{VariableType}` calls.
+Based on the <<inputClock>> settings defined in the XML the master calls `fmi3Set{VariableType}`, <<fmi3ActivateModelPartition>>, `fmi3Get{VariableType}` calls.
 Set/get calls for each task are only allowed for variables that are associated to the <<inputClock>> associated to that task or - here preemption issues become important - to variables that are associated to no <<clock,`clocks`>> (global variables), based on the XML information (see 4.4.3).
 
 _[The recommendation is to avoid global variable associations as much as possible in the XML._
@@ -1017,7 +1017,7 @@ _It is also recommended to reduce dependencies (defined in XML model structure) 
 
 The Co-Simulation master has no knowledge about the FMU internal communication between the model partitions of a single FMU and does not handle it.
 
-The simulation master schedules the `fmi3ActivateModelPartition` (as well as related `fmi3Get{VariableType}` and `fmi3Set{VariableType}`) calls based on given priorities for <<inputClock,`input clocks`>> defined in the `modelDescription.xml`.
+The simulation master schedules the <<fmi3ActivateModelPartition>> (as well as related `fmi3Get{VariableType}` and `fmi3Set{VariableType}`) calls based on given priorities for <<inputClock,`input clocks`>> defined in the `modelDescription.xml`.
 
 Priority (see <<clock-type-definition>>):
 

--- a/docs/4_2_co-simulation_api.adoc
+++ b/docs/4_2_co-simulation_api.adoc
@@ -1,4 +1,4 @@
-<<fmi3DoEarlyReturn>>=== FMI Application Programming Interface
+=== FMI Application Programming Interface
 
 ==== Mode fmi3ModeCoSimulation
 
@@ -12,7 +12,7 @@ In order to enable the slave to interpolate the <<continuous>> real <<input,`inp
 Also, higher <<derivative,`derivatives`>> can be set to allow higher order interpolation.
 Whether the slave is able to handle the <<derivative,`derivatives`>> of <<input,`inputs`>> is given by the unsigned integer capability flag `MaxInputDerivativeOrder`. It delivers the maximum order of the input <<derivative>>.
 
-[[fmi3SetInputDerivatives,`fmi3SetInputDerivatives()`]]
+[[fmi3SetInputDerivatives,`fmi3SetInputDerivatives`]]
 [source, C]
 ----
 include::../headers/fmi3FunctionTypes.h[tags=SetInputDerivatives]
@@ -36,7 +36,7 @@ _[Example: If the internal polynomial is of order 1 and the master inquires the 
 
 The <<derivative,`derivatives`>> can be retrieved by:
 
-[[fmi3GetOutputDerivatives,`fmi3GetOutputDerivatives()`]]
+[[fmi3GetOutputDerivatives,`fmi3GetOutputDerivatives`]]
 [source, C]
 ----
 include::../headers/fmi3FunctionTypes.h[tags=GetOutputDerivatives]
@@ -65,24 +65,24 @@ The computation of a time step is started. +
 Argument `currentCommunicationPoint` is the current communication point of the master (latexmath:[tc_i]) and argument `communicationStepSize` is the communication step size (latexmath:[hc_i]).
 The latter must be latexmath:[> 0.0].
 The slave must integrate until time instant latexmath:[tc_{i+1} = tc_i + hc_i].
-_[The calling environment defines the communication points and <<fmi3DoStep>> must synchronize to these points by always integrating exactly to latexmath:[tc_i + hc_i].
+_[The calling environment defines the communication points and <<fmi3DoStep>> must synchronize to these points by always integrating exactly to latexmath:[tc_i + hc_i]._
 
-It is up to <<fmi3DoStep>> how to achieve this.]_
+_It is up to <<fmi3DoStep>> how to achieve this.]_
 At the first call to <<fmi3DoStep>> after <<fmi3ExitInitializationMode>> was called `currentCommunicationPoint` must be equal to `startTime` as set with <<fmi3SetupExperiment>>.
-_[Formally, argument `currentCommunicationPoint` is not needed.
-It is present in order to handle a mismatch between the master and the FMU state of the slave: The `currentCommunicationPoint` and the FMU state of the slaves defined by former_ <<fmi3DoStep>> or `fmi3SetFMUState` _calls have to be consistent with respect to each other.
-For example, if the slave does not use the update formula for the <<independent>> variable as required above,_ latexmath:[tc_{i+1} = tc_i + hc_i] _(using argument_ latexmath:[tc_i] = `currentCommunicationPoint` of <<fmi3DoStep>>) _but uses internally an own update formula, such as_ latexmath:[tc_{s,i+1} = tc_{s,i} + hc_{s,i}] _then the slave could use as time increment_ latexmath:[\text{hc}_{s,i} := (tc_i - tc_{s,i}) + hc_i] _(instead of_ latexmath:[\text{hc}_{s,i} := hc_i] _) to avoid a mismatch between the master time_ latexmath:[tc_{i+1}] _and the slave internal time_ latexmath:[tc_{s,i+1}] _for large i.]_
+_[Formally, argument `currentCommunicationPoint` is not needed._
+_It is present in order to handle a mismatch between the master and the FMU state of the slave: The `currentCommunicationPoint` and the FMU state of the slaves defined by former_ <<fmi3DoStep>> _or_ `fmi3SetFMUState` _calls have to be consistent with respect to each other._
+_For example, if the slave does not use the update formula for the <<independent>> variable as required above,_ latexmath:[tc_{i+1} = tc_i + hc_i] _(using argument_ latexmath:[tc_i] = `currentCommunicationPoint` _of_ <<fmi3DoStep>>) _but uses internally an own update formula, such as_ latexmath:[tc_{s,i+1} = tc_{s,i} + hc_{s,i}] _then the slave could use as time increment_ latexmath:[\text{hc}_{s,i} := (tc_i - tc_{s,i}) + hc_i] _(instead of_ latexmath:[\text{hc}_{s,i} := hc_i] _) to avoid a mismatch between the master time_ latexmath:[tc_{i+1}] _and the slave internal time_ latexmath:[tc_{s,i+1}] _for large i.]_
 
-Argument `noSetFMUStatePriorToCurrentPoint` is `fmi3True` if `fmi3SetFMUState` will no longer be called for time instants prior to `currentCommunicationPoint` in this simulation run _[the slave can use this flag to flush a result buffer]_.
+_rgument `noSetFMUStatePriorToCurrentPoint` is `fmi3True` if `fmi3SetFMUState` will no longer be called for time instants prior to `currentCommunicationPoint` in this simulation run _[the slave can use this flag to flush a result buffer]_.
 
 The function returns: +
 `fmi3OK` - if the communication step was computed successfully until its end. +
 `fmi3Discard` - if the slave computed successfully only a subinterval of the communication step.
 The master can call <<fmi3GetDoStepDiscardedStatus>> to get further information.
 If possible, the master should retry the simulation with a shorter communication step size.
-_[Redoing a step is only possible if the FMU state has been recorded at the beginning of the current (discarded) step with <<fmi3GetFMUState>>.
-Redoing a step is performed by calling `fmi3SetFMUState` and afterwards calling <<fmi3DoStep>> with the new communicationStepSize.
-Note that it is not possible to change `currentCommunicationPoint` in such a call.]_ +
+_[Redoing a step is only possible if the FMU state has been recorded at the beginning of the current (discarded) step with <<fmi3GetFMUState>>._
+_Redoing a step is performed by calling `fmi3SetFMUState` and afterwards calling <<fmi3DoStep>> with the new communicationStepSize._
+_Note that it is not possible to change `currentCommunicationPoint` in such a call.]_ +
 `fmi3Error` - the communication step could not be carried out at all.
 The master can try to repeat the step with other input values and/or a different communication step size in the same way as described in the `fmi3Discard` case above. +
 `fmi3Fatal` - if an error occurred which corrupted the FMU irreparably.
@@ -95,7 +95,7 @@ It depends on the capabilities of the slave which parameter constellations and c
 
 Status information is retrieved from the slave by the following function:
 
-[[fmi3GetDoStepDiscardedStatus,`fmi3GetDoStepDiscardedStatus()`]]
+[[fmi3GetDoStepDiscardedStatus,`fmi3GetDoStepDiscardedStatus`]]
 [source, C]
 ----
 include::../headers/fmi3FunctionTypes.h[tags=GetDoStepDiscardedStatus]
@@ -112,22 +112,28 @@ The following state machine defines the supported calling sequences.
 [#figure-co-simulation-state-machine]
 image::images/calling-sequence-co-simulation.svg[width=80%, align="center"]
 
-In this Co-Simulation mode the following functions must not be called: `fmi3ActivateModelPartition()`, <<fmi3NewDiscreteStates>>, <<fmi3EnterEventMode>>, <<fmi3SetClock>>, <<fmi3GetClock>>, <<fmi3SetIntervalFraction>>, <<fmi3GetIntervalFraction>>, <<fmi3SetIntervalDecimal>>, <<fmi3GetIntervalDecimal>> including all functions that are specific to fmuType `fmi3ModelExchange`.
+In this Co-Simulation mode the following functions must not be called: `fmi3ActivateModelPartition`, <<fmi3NewDiscreteStates>>, <<fmi3EnterEventMode>>, <<fmi3SetClock>>, <<fmi3GetClock>>, <<fmi3SetIntervalFraction>>, <<fmi3GetIntervalFraction>>, <<fmi3SetIntervalDecimal>>, <<fmi3GetIntervalDecimal>> including all functions that are specific to fmuType `fmi3ModelExchange`.
 
 ====== State: slaveSetableFMUstate [[state-slave-setable-fmu-state-co-simulation]]
-In all states of this super state it is allowed to call
-<<fmi3GetFMUState>>, <<fmi3SetFMUState>>, <<fmi3FreeFMUState>>`, <<fmi3SerializedFMUStateSize>>, <<fmi3SerializeFMUState>>, `fmi3DeSerializeFMUState()`, <<fmi3Reset>>, <<fmi3GetVersion>>, `fmi3SetDebugLogging()` and <<fmi3FreeInstance>>.
 
-If any function returns with `fmi3Fatal` the FMU enters state `Fatal`.
+In all states of this super state it is allowed to call <<fmi3GetFMUState>>, <<fmi3SetFMUState>>, <<fmi3FreeFMUState>>`, <<fmi3SerializedFMUStateSize>>, <<fmi3SerializeFMUState>>, `fmi3DeSerializeFMUState`, <<fmi3Reset>>, <<fmi3GetVersion>>, `fmi3SetDebugLogging` and <<fmi3FreeInstance>>.
+
+If any function returns with `fmi3Fatal` the FMU enters state *Fatal*.
 
 ====== State: slaveUnderEvaluation [[state-slave-under-evaluation-co-simulation]]
-This super state is entered by the FMU when <<fmi3Instantiate>> is called. If any function returns `fmi3Error` the FMU enters state `Terminated`.
+
+This super state is entered by the FMU when <<fmi3Instantiate>> is called.
+If any function returns `fmi3Error` the FMU enters state *Terminated*.
 
 ====== State: slaveInitialized [[state-slave-initialized-co-simulation]]
-This super state is entered by the FMU when <<fmi3ExitInitializationMode>> is called. If the function <<fmi3Terminate>> is called, the FMU enters state `Terminated`.
+
+This super state is entered by the FMU when <<fmi3ExitInitializationMode>> is called.
+If the function <<fmi3Terminate>> is called, the FMU enters state *Terminated*.
 
 ====== State: Instantiated [[state-instantiated-co-simulation]]
-In this state the FMU can do one-time initializations and allocate memory. The FMU sets all variables to its <<start>> values.
+
+In this state the FMU can do one-time initializations and allocate memory.
+The FMU sets all variables to its <<start>> values.
 
 Allowed Function Calls::
 <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3SetInputDerivatives>>, <<fmi3EnterConfigurationMode>>
@@ -161,6 +167,7 @@ Forbidden Function Calls::
 <<fmi3Instantiate>>, <<fmi3Terminate>>, <<fmi3DoStep>>, <<fmi3DoEarlyReturn>>, <<fmi3EnterInitializationMode>>, <<fmi3GetDoStepDiscardedStatus>>, <<fmi3EnterConfigurationMode>>, <<fmi3ExitConfigurationMode>>, <<fmi3SetupExperiment>>, <<fmi3EnterStepMode>>
 
 ====== State: Step Mode [[state-step-mode-co-simulation]]
+
 This state is used by the master to progress simulation time.
 
 Allowed Function Calls::
@@ -172,8 +179,8 @@ This function must not be called if the FMU contains no <<tunable>> <<structural
 
 <<fmi3DoStep>>::
 Within fmi3DoStep() the FMU may call <<fmi3CallbackIntermediateUpdate>>
-If the function returns with `fmi3OK` or `fmi3Warning` the FMU stays in this state.
-If the function returns with `fmi3Discard` the FMU enters state `Step Discarded`.
+* If the function returns with `fmi3OK` or `fmi3Warning` the FMU stays in this state.
+* If the function returns with `fmi3Discard` the FMU enters state `Step Discarded`.
 
 `fmi3Set{VariableType}`::
 For variables with:
@@ -210,21 +217,22 @@ Forbidden Function Calls::
 <<fmi3ExitConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3GetDoStepDiscardedStatus>>, <<fmi3DoEarlyReturn>>, <<fmi3EnterStepMode>>
 
 ====== State: Intermediate Update Mode [[state-intermediate-update-mode-co-simulation]]
+
 In this state the master can retrieve information from the FMU between communication points.
 Functions called in this state must not return `fmi3Discard`.
 
 The FMU enters this state by calling <<fmi3CallbackIntermediateUpdate>> within <<fmi3DoStep>> and leaves the state towards state `Step Mode` if the function returns `fmi3OK` or `fmi3Warning`.
-If the function returns `fmi3Error` the FMU enters state `Terminated`.
-If the function returns `fmi3Fatal` the FMU enters state `Fatal`.
+If the function returns `fmi3Error` the FMU enters state *Terminated*.
+If the function returns `fmi3Fatal` the FMU enters state *Fatal*.
 
 Allowed Function Calls::
 <<fmi3DoEarlyReturn>>
 
-`fmi3Set{VariableTypes}()`, <<fmi3SetInputDerivatives>>::
+`fmi3Set{VariableTypes}`, <<fmi3SetInputDerivatives>>::
 If `intermediateUpdateInfo->intermediateVariableSetAllowed` is equal to `fmi3True`, the value of intermediate variables can be set.
 Intermediate variables are variables that are marked with attribute <<intermediateAccess>> = `true` in the `modelDescription.xml`.
 
-`fmi3Get{VariableTypes}()`, <<fmi3GetOutputDerivatives>>::
+`fmi3Get{VariableTypes}`, <<fmi3GetOutputDerivatives>>::
 If `intermediateUpdateInfo->intermediateVariableGetAllowed` is equal to `fmi3True`, the value of intermediate variables can be retrieved.
 Intermediate variables are variables that are marked with attribute <<intermediateAccess>> = `true` in the `modelDescription.xml`.
 
@@ -233,6 +241,7 @@ The same functions which are not allowed to be called in `Step Mode` must not be
 Additionally the following functions must not be called  <<fmi3EnterConfigurationMode>>, <<fmi3Terminate>>, <<fmi3DoStep>>, <<fmi3GetDirectionalDerivative>>.
 
 ====== State: Reconfiguration Mode [[state-reconfiguration-mode-co-simulation]]
+
 In this state <<structuralParameter,`structural parameters`>> with <<variability>> = <<tunable>> can be changed.
 This state is entered from state `Step Mode` by calling <<fmi3EnterConfigurationMode>> and left back to `Step Mode` by calling <<fmi3ExitConfigurationMode>>.
 
@@ -246,6 +255,7 @@ Forbidden Function Calls::
  <<fmi3EnterConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3GetDoStepDiscardedStatus>>, <<fmi3DoStep>>, <<fmi3EnterStepMode>>, <<fmi3SetInputDerivatives>>, <<fmi3GetDirectionalDerivative>>, <<fmi3GetOutputDerivatives>>, `fmi3Get{VariableTypes}`
 
 ====== State: Step Discarded [[state-step-discarded-co-simulation]]
+
 The FMU changes into this state if it is not able to compute a communication step completely by returning `fmi3Discard` from <<fmi3DoStep>>.
 This might have been caused by numerical problems or intended stop of the simulation run.
 In case of numerical problems the master may try to achieve a correct solution for example by repeating the last step with a different communication step size or by continuing from the `lastSuccessfulTime`.
@@ -266,6 +276,7 @@ Forbidden Function Calls::
 <<fmi3EnterConfigurationMode>>, <<fmi3ExitConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3DoStep>>, `fmi3Set{VariableType}`, <<fmi3DoEarlyReturn>>, <<fmi3SetInputDerivatives>>
 
 ====== State: Terminated [[state-terminated-co-simulation]]
+
 In this state, the solution at the final time of the simulation can be retrieved.
 
 Allowed Function Calls::
@@ -275,6 +286,7 @@ Forbidden Function Calls::
 <<fmi3EnterConfigurationMode>>, <<fmi3ExitConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3DoStep>>, `fmi3Set{VariableType}`, <<fmi3DoEarlyReturn>>, <<fmi3SetInputDerivatives>>
 
 ====== State: Fatal [[state-fatal-co-simulation]]
+
 The FMU enters this state if a function call of this or any other instance of this FMU returns `fmi3Fatal`.
 In this state it is not allowed to call any function of the FMU.
 
@@ -285,6 +297,7 @@ Forbidden Function Calls::
 all
 
 ====== State: Configuration Mode [[state-configuration-mode-co-simulation]]
+
 In this state <<structuralParameter,`structural parameters`>> with <<variability>> = <<tunable>> can be changed.
 
 This state is entered from state `Instantiated` by calling <<fmi3EnterConfigurationMode>> and left back to `Instantiated` by calling <<fmi3ExitConfigurationMode>>.
@@ -298,9 +311,9 @@ Only for variables with <<causality>> = <<structuralParameter>> and <<variabilit
 Forbidden Function Calls::
  <<fmi3EnterConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3GetDoStepDiscardedStatus>>, <<fmi3DoStep>>, <<fmi3EnterStepMode>>, <<fmi3SetInputDerivatives>>, <<fmi3GetDirectionalDerivative>>, <<fmi3GetOutputDerivatives>>, `fmi3Get{VariableTypes}`
 
-_[
-TODO: update table
-The allowed function calls in the respective states are summarized in the following table (functions marked in [yellow-background]#"yellow"# are only available for Co-Simulation, the other functions are available both for Model Exchange and Co-Simulation):
+_[The allowed function calls in the respective states are summarized in the following table (functions marked in [yellow-background]#"yellow"# are only available for Co-Simulation, the other functions are available both for Model Exchange and Co-Simulation):_
+
+// TODO: update table
 
 [cols="10,1,1,1,1,1,1,1,1,1,1",width="40%"]
 |====
@@ -385,12 +398,11 @@ include::examples/c-code/co_simulation.c[tags=CoSimulation]
 ----
 
 ==== Early-return Requested by the Co-Simulation Master in fmi3ModeCoSimulation [[earlyreturn-co-simulation]]
+
 The boolean capability flag `canReturnEarlyAfterIntermediateUpdate` in the modelDescription XML file indicates whether the FMU supports the early-return feature.
 The default value of this capability flag is `false`.
 Each time an internal discontinuity or an event happens inside an FMU with capability flag `canReturnEarlyAfterIntermediateUpdate=true`, the callback function <<fmi3CallbackIntermediateUpdate>> is invoked by the FMU and the associated structure <<fmi3IntermediateUpdateInfo>> is sent back to the Co-Simulation master.
 The master can only use this early return functionality if it provides the <<fmi3CallbackIntermediateUpdate>> callback function pointer in <<fmi3CallbackFunctions>> in <<fmi3Instantiate>>.
-
-fmi3IntermediateUpdate
 
 [[fmi3CallbackIntermediateUpdate,`fmi3CallbackIntermediateUpdate`]]
 [source, c]
@@ -405,8 +417,8 @@ include::../headers/fmi3FunctionTypes.h[tag=IntermediateUpdateInfo]
 ----
 
 The Co-Simulation master can request the FMU to end the <<fmi3DoStep>> at a Newtonian time instant and to do an early return by calling the <<fmi3DoEarlyReturn>> function inside the callback function <<fmi3CallbackIntermediateUpdate>>.
-The Co-Simulation master is only allowed to call this function, if the boolean variable `fmi3IntermediateUpdateInfo->canReturnEarly` is `fmi3True`.
-If the master does not call <<fmi3DoEarlyReturn>> the FMU continues the <<fmi3DoStep>> computation until the next predefined communication instant (i.e., currentCommunicationPoint + communicationStepSize) or until the next call of <<fmi3CallbackIntermediateUpdate>>.
+The Co-Simulation master is only allowed to call this function, if `fmi3IntermediateUpdateInfo->canReturnEarly = fmi3True`.
+If the master does not call <<fmi3DoEarlyReturn>> the FMU continues the <<fmi3DoStep>> computation until the next predefined communication instant (i.e., `currentCommunicationPoint + communicationStepSize`) or until the next call of <<fmi3CallbackIntermediateUpdate>>.
 
 [[fmi3DoEarlyReturn,`fmi3DoEarlyReturn`]]
 [source, c]
@@ -428,8 +440,6 @@ The Co-Simulation master can decide if a rollback of the FMU to reach the `early
 Note that `Event Mode` is not supported in `fmi3ModeCoSimulation`.
 
 ==== Mode fmi3ModeHybridCoSimulation [[api-hybrid-co-simulation]]
-:IUTIME: intermediateUpdateTime
-
 
 If the boolean capability flag `providesHybridCoSimulation` and `canReturnEarlyAfterIntermediateUpdate = true` the Co-Simulation master can use the mode `fmi3ModeHybridCoSimulation`.
 
@@ -454,9 +464,13 @@ If an event happens or a <<outputClock>> ticks, `intermediateUpdateTime` is the 
 If the FMU signals an `earlyReturn = fmi3True` and `fmi3OK` after returning from <<fmi3DoStep>> then `intermediateUpdateTime` is the internal simulation time of the FMU of the last <<fmi3CallbackIntermediateUpdate>> call that signaled `canReturnEarly = fmi3true`.
 `intermediateUpdateTime` is also the time of intermediate steps of the internal FMU solver.
 
-The following `fmi3Boolean` variables define the reasons for the <<fmi3CallbackIntermediateUpdate>> call. Several variables can be set by the FMU. Default value of variables is `fmi3False`.
+The following `fmi3Boolean` variables define the reasons for the <<fmi3CallbackIntermediateUpdate>> call.
+Several variables can be set by the FMU.
+Default value of variables is `fmi3False`.
 
-* when `eventOccurred` is `fmi3True`, the master must call <<fmi3DoEarlyReturn>> to do an early return and handle the event via entering event mode. In this case, `earlyReturnTime` argument of <<fmi3DoEarlyReturn>> is ignored. In `Event Mode` the master shall call the <<fmi3NewDiscreteStates>> function for gathering <<fmi3EventInfo>> related information about the event occurred at `intermediateUpdateTime`.
+* when `eventOccurred` is `fmi3True`, the master must call <<fmi3DoEarlyReturn>> to do an early return and handle the event via entering event mode.
+In this case, `earlyReturnTime` argument of <<fmi3DoEarlyReturn>> is ignored.
+In `Event Mode` the master shall call the <<fmi3NewDiscreteStates>> function for gathering <<fmi3EventInfo>> related information about the event occurred at `intermediateUpdateTime`.
 
 * when `clocksTicked`  is `fmi3True`, it means that <<fmi3GetClock>> function should be called for gathering all <<clock>> related information about ticking <<outputClock,`output clocks`>> at `intermediateUpdateTime`.
 If this flag is `fmi3True` the master must call <<fmi3DoEarlyReturn>> to do an early return and handle the <<clock>> event in `Event Mode`.
@@ -471,7 +485,8 @@ In this case, `earlyReturnTime` argument of <<fmi3DoEarlyReturn>> is ignored.
 * when `canReturnEarly` is `fmi3True` the master can request the FMU to return early at the current `intermediateUpdateTime` time instant via calling <<fmi3DoEarlyReturn>> within the callback function <<fmi3CallbackIntermediateUpdate>>.
 If `canReturnEarly` is `fmi3False` the FMU will not do the early return, regardless of the master request.
 
-Note that only the first discontinuity event at a Newtonian time instant shall be signaled that way. But in `Event Mode`, there may be an event iteration at a Newtonian time instant and have super dense time instants.
+Note that only the first discontinuity event at a Newtonian time instant shall be signaled that way.
+But in `Event Mode`, there may be an event iteration at a Newtonian time instant and have super dense time instants.
 
 Based on the information delivered in <<fmi3IntermediateUpdateInfo>>, additional information about the discontinuity at that time instant can be obtained from the <<fmi3EventInfo>> structure after calling  <<fmi3NewDiscreteStates>>  and/or <<fmi3GetClock>>.
 
@@ -493,9 +508,10 @@ If an FMU provides the early-return capability that includes the handling of eve
 The master should indicate to the FMU that this early-return feature is also supported by the master.
 The Co-Simulation master signals to the FMU that it supports and has recognized the early return Co-Simulation capabilities of the FMU by setting the CoSimulation mode to `fmi3ModeHybridCoSimulation` in the <<fmi3Instantiate>> function.
 
-The FMU stops computation at the first encountered internal event (if any) and the event time is provided through `{STIUI}.{IUTIME}`.
-If <<fmi3DoStep>> returns with `earlyReturn = fmi3True` and an event has happened, i.e., `{STIUI}.eventOccurred` is `fmi3True`, then an event handling has to be done by the Co-Simulation master.
-In order to start event handling the Co-Simulation master has to call <<fmi3EnterEventMode>> for that FMU to push the FMU into `Event Mode`. In this mode the Co-Simulation master is supposed to catch all events through the <<fmi3NewDiscreteStates>> function and the <<fmi3EventInfo>> structure.
+The FMU stops computation at the first encountered internal event (if any) and the event time is provided through `intermediateUpdateInfo.intermediateUpdateTime`.
+If <<fmi3DoStep>> returns with `earlyReturn = fmi3True` and an event has happened, i.e. `intermediateUpdateInfo.eventOccurred` is `fmi3True`, then an event handling has to be done by the Co-Simulation master.
+In order to start event handling the Co-Simulation master has to call <<fmi3EnterEventMode>> for that FMU to push the FMU into `Event Mode`.
+In this mode the Co-Simulation master is supposed to catch all events through the <<fmi3NewDiscreteStates>> function and the <<fmi3EventInfo>> structure.
 
 If the early-return request of the Co-Simulation master is ignored by the FMU, then <<fmi3DoStep>> returns with `earlyReturn = fmi3False`.
 The master can start a resynchronization of FMUs at an event time, if the `currentCommunicationPoint` has passed the event time, the master can roll-back the FMU and repeat the step with a suitable `communicationStepSize` (if the FMU supports the roll-back).
@@ -517,7 +533,6 @@ It is not allowed to call <<fmi3EnterEventMode>> or <<fmi3EnterStepMode>> for an
 
 ===== State Machine of Calling Sequence from Master to Slave in fmi3ModeHybridCoSimulation
 
-
 ==== Co-Simulation with Clock Support in fmi3ModeHybridCoSimulation [[api-clocked-co-simulation]]
 
 In this section, signaling and retrieving <<clock>> ticks as well as the interface for supporting <<clock,`clocks`>> in FMI for Co-Simulation will be discussed.
@@ -527,12 +542,10 @@ Note, even if no <<clock>> is defined by an FMU in `modelDescription.xml`, the m
 
 If an FMU provides <<clock,`clocks`>>, but the Co-Simulation master does not support or does not want to support early-return or <<clock,`clocks`>>, by setting Co-Simulation mode to `fmi3ModeCoSimulation`, the activation of model partitions inside of the FMU has to be handled internally within <<fmi3DoStep>>.
 
-_[Remark:_
-_Wrapping towards other Co-Simulation modes can influence the simulation results._
+_[Remark: Wrapping towards other Co-Simulation modes can influence the simulation results._
 _Depending on the model especially wrapping towards the mode `fmi3ModeCoSimulation` may result in divergent simulation results._
 _Especially aperiodic <<inputClock,`input clocks`>> can not always be sufficiently emulated in modes that do not directly support <<clock,`clocks`>>._
-_Therefore it is recommended that the FMU provides logging information to the user about the influence of the current mode on simulation results, if non-optimal modes are used by the simulation environment.
-]_
+_Therefore it is recommended that the FMU provides logging information to the user about the influence of the current mode on simulation results, if non-optimal modes are used by the simulation environment.]_
 
 [[fmi3EnterStepMode,`fmi3EnterStepMode`]]
 [source, C]
@@ -540,8 +553,8 @@ _Therefore it is recommended that the FMU provides logging information to the us
 include::../headers/fmi3FunctionTypes.h[tag=EnterStepMode]
 ----
 
-
 ===== Transfer of Input / Output Values and Parameters in fmi3ModeHybridCoSimulation [[transfer-of-input-output-and-parameters-clocked-co-simulation]]
+
 If the Co-Simulation master supports <<clock,`clocks`>>, all <<inputClock,`input clocks`>> of the model should be handled and <<inputClock>> events should be scheduled by the master.
 If an <<outputClock>> ticks, the FMU invokes the <<fmi3CallbackIntermediateUpdate>> callback and sets `intermediateUpdateInfo.clocksTicked` to `fmi3True`.
 Then the master must call <<fmi3DoEarlyReturn>> to do an early return from <<fmi3DoStep>>.
@@ -565,7 +578,7 @@ If <<fmi3DoStep>> returns with `earlyReturn = fmi3True` and `intermediateUpdateI
 In order to retrieve the status of <<outputClock,`output clocks`>>, <<fmi3GetClock>> and <<fmi3GetIntervalDecimal>> or <<fmi3GetIntervalFraction>> need to be called in the Event Mode.
 If the <<fmi3DoStep>> return value is `fmi3OK` and `earlyReturn = fmi3False`, the calling of <<fmi3GetClock>>, <<fmi3GetIntervalDecimal>>, <<fmi3GetIntervalFraction>>, <<fmi3NewDiscreteStates>> is only meaningful after <<fmi3SetClock>> in the case of super-dense time iterations are desired.
 
-Similar to the Model Exchange case, the allowed call order is <<fmi3GetClock>>, <<fmi3GetIntervalDecimal>>, <<fmi3GetIntervalFraction>>, `fmi3Get{VariableType}()`, `fmi3Set{VariableType}()`.
+Similar to the Model Exchange case, the allowed call order is <<fmi3GetClock>>, <<fmi3GetIntervalDecimal>>, <<fmi3GetIntervalFraction>>, `fmi3Get{VariableType}`, `fmi3Set{VariableType}`.
 Function calls of this call order can be omitted.
 
 The handling of return values of function calls is identical to mode `fmi3ModeCoSimulation`.
@@ -574,8 +587,8 @@ If `eventInfo.terminateSimulation` becomes `fmi3True` after calling <<fmi3NewDis
 Once handling of the <<clock>> events finished, the master calls <<fmi3EnterStepMode>> for that FMU to push it into Step Mode.
 Note that it is not allowed to call <<fmi3EnterEventMode>> or <<fmi3EnterStepMode>> in Co-Simulation mode `fmi3ModeCoSimulation` or `fmi3ScheduledExecutionSimulation`.
 
-_[Usually the Co-Simulation master should be able to derive (but is not forced to do so) the correct communication point times for <<inputClock,`input clocks`>> in advance and thus it should be able to set the proper `communicationStepSize` for <<fmi3DoStep>>.
-This might not be possible if an aperiodic <<inputClock>> of an FMU depends on the ticking of an aperiodic <<outputClock>> of another FMU or other aperiodic tick sources.]_
+_[Usually the Co-Simulation master should be able to derive (but is not forced to do so) the correct communication point times for <<inputClock,`input clocks`>> in advance and thus it should be able to set the proper `communicationStepSize` for <<fmi3DoStep>>._
+_This might not be possible if an aperiodic <<inputClock>> of an FMU depends on the ticking of an aperiodic <<outputClock>> of another FMU or other aperiodic tick sources.]_
 
 ===== State Machine of Calling Sequence from Master to Slave in fmi3ModeHybridCoSimulation [[state-machine-calling-sequence-clocked-co-simulation]]
 
@@ -585,36 +598,43 @@ The following state machine defines the supported calling sequences.
 image::images/calling-sequence-hybrid-co-simulation.svg[width=80%, align="center"]
 [#figure-hybrid-co-simulation-state-machine]
 
-In this Co-Simulation mode the following functions must not be called: `fmi3ActivateModelPartition()` including all functions that are specific to fmuType `fmi3ModelExchange`.
+In this Co-Simulation mode the following functions must not be called: `fmi3ActivateModelPartition` including all functions that are specific to fmuType `fmi3ModelExchange`.
 
 Unlike the state machine in section <<state-machine-co-simulation>> the entry state after *Initialization Mode* is the *Event Mode* in order to allow the FMU to handle the very first discrete event.
 Each state of the state machine corresponds to a certain phase of a simulation as follows:
 
 ====== State: slaveSetableFMUstate
+
 This super state in Hybrid Co-Simulation does not differ from Co-Simulation described in section <<state-slave-setable-fmu-state-co-simulation>>.
 
 ====== State: slaveUnderEvaluation
+
 This super state in Hybrid Co-Simulation does not differ from Co-Simulation described in section <<state-slave-under-evaluation-co-simulation>>.
 
 ====== State: slaveInitialized
+
 This super state in Hybrid Co-Simulation does not differ from Co-Simulation described in section <<state-slave-initialized-co-simulation>>.
 
 ====== State: Instantiated
+
 This super state in Hybrid Co-Simulation does not differ from Co-Simulation described in section <<state-instantiated-co-simulation>>.
 
 ====== State: Configuration Mode
+
 This state in Hybrid Co-Simulation does not differ from Co-Simulation described in section <<state-configuration-mode-co-simulation>>.
 
 ====== State: Initialization Mode
+
 This state in Hybrid Co-Simulation does not differ from Co-Simulation described in section <<state-initialization-mode-co-simulation>>.
 
 ====== State: Event Mode
-The master and the FMU enter this state when the master calls <<fmi3ExitInitializationMode>> in state `Initialization Mode` or <<fmi3ExitConfigurationMode>> in state `Reconfiguration Mode` or <<fmi3EnterEventMode>> in state `Step Mode`.
+
+The master and the FMU enter this state when the master calls <<fmi3ExitInitializationMode>> in state `Initialization Mode` or <<fmi3ExitConfigurationMode>> in state *Reconfiguration Mode* or <<fmi3EnterEventMode>> in state `Step Mode`.
 In order to handle discrete events and <<clock>> ticks, the FMU is pushed into the event mode by calling <<fmi3EnterEventMode>>
 
 Allowed Function Calls::
 <<fmi3Terminate>>::
-Upon return of <<fmi3NewDiscreteStates>>, if `fmi3EventInfo->terminateSimulation = fmi3True`, the master should finish the cosimulation by calling `fmi3Terminate` on all FMUs.
+Upon return of <<fmi3NewDiscreteStates>>, if `fmi3EventInfo->terminateSimulation = fmi3True`, the master should finish the Co-Simulation by calling `fmi3Terminate` on all FMUs.
 
 <<fmi3EnterConfigurationMode>>::
 With this function call the Reconfiguration Mode is entered.
@@ -645,9 +665,11 @@ It is not allowed to call these functions for <<output>>, aperiodic and strictly
 For <<input>> periodic <<clock,`clocks`>>, these functions are called after the first <<clock>> activaion.
 
 ====== State: Step Mode
+
 This state in Hybrid Co-Simulation does not differ from Co-Simulation described in section <<state-step-mode-co-simulation>>.
 
 ====== State: Intermediate Update Mode
+
 This state in Hybrid Co-Simulation differ from Co-Simulation described in section <<state-step-mode-co-simulation>> as following:
 
 Allowed Function Calls::
@@ -659,20 +681,24 @@ Forbidden Function Calls::
 All API functions not listed in the allowed function list, including <<fmi3GetClock>> and  <<fmi3SetClock>> are forbidden in this mode.
 
 ====== State: Reconfiguration Mode
+
 This state in Hybrid Co-Simulation does not differ from Co-Simulation described in section <<state-reconfiguration-mode-co-simulation>>.
 
 ====== State: Step Discarded
+
 This state in Hybrid Co-Simulation does not differ from Co-Simulation described in section <<state-step-discarded-co-simulation>>.
 
 ====== State: Terminated
+
 This state in Hybrid Co-Simulation does not differ from Co-Simulation described in section <<state-terminated-co-simulation>>.
 
 ====== State: Fatal
+
 This state in Hybrid Co-Simulation does not differ from Co-Simulation described in section <<state-fatal-co-simulation>>.
 
-_[
-#[TODO]: Update table. Remove stepComplete, stepInProgress, stepCanceled? Where is the state Error described in the state machine?#
-The allowed function calls in the respective states are summarized in the following table (functions marked in [yellow-background]#"yellow"# are only available for Co-Simulation, the other functions are available both for Model Exchange and Co-Simulation):
+// TODO: Update table. Remove stepComplete, stepInProgress, stepCanceled? Where is the state Error described in the state machine?
+
+_[The allowed function calls in the respective states are summarized in the following table (functions marked in [yellow-background]#"yellow"# are only available for Co-Simulation, the other functions are available both for Model Exchange and Co-Simulation):_
 
 [cols="10,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1",width="40%"]
 |====
@@ -727,10 +753,14 @@ The allowed function calls in the respective states are summarized in the follow
 |<<fmi3GetDoStepDiscardedStatus>> {set:cellbgcolor:yellow} |  {set:cellbgcolor!} |  |  |  |  |  |  |  |  |  |x |  |  |  |
 |====
 
+_]_
+
 ===== Code Example for fmi3ModeHybridCoSimulation [[code-example-clocked-co-simulation]]
 
 In the following example, the usage of the FMI functions is sketched in order to clarify the typical calling sequence of the functions in a simulation environment.
-We consider ... #[TODO]: Description of code example. Explained once validated, after examples are ready?#
+We consider ...
+
+// TODO: Description of code example. Explained once validated, after examples are ready?
 
 The error handling is implemented in a very rudimentary way.
 
@@ -740,7 +770,6 @@ include::examples/c-code/co_simulation_clocked.c[tags=CoSimulation]
 ----
 
 ==== Scheduled Execution Simulation [[api-scheduled-execution-simulation]]
-:stem: latexmath
 
 This section contains the interface description for supporting the scheduled execution mode from a C program.
 
@@ -752,20 +781,21 @@ If the flag `providesScheduledExecutionSimulation = false`, it is not allowed to
 
 If no <<inputClock,`input clocks`>> are defined by the FMU it is not allowed to set `providesScheduledExecutionSimulation` to `true` in the `modelDescription.xml`.
 
-Error, reset or terminate information is a global state of the FMU. If e.g. an function returns `fmi3Discard` or `fmi3Error` this is also assumed for all active or preempted model partitions.
-In case of `fmi3Discard` or `fmi3Error` no repetition of the step is possible, the only possible way to go forward is to enter the `terminated`state and to end or to reset the simulation or - if supported - to set the FMU back to a former state.
+Error, reset or terminate information is a global state of the FMU.
+If e.g. an function returns `fmi3Discard` or `fmi3Error` this is also assumed for all active or preempted model partitions.
+In case of `fmi3Discard` or `fmi3Error` no repetition of the step is possible, the only possible way to go forward is to enter the *Terminated* state and to end or to reset the simulation or - if supported - to set the FMU back to a former state.
 
 ===== Transfer of Input / Output Values and Parameters in fmi3ModeScheduledExecutionSimulation
 
 The simulation master sets and gets variable values as defined in section <<get-and-set-variable-values>>.
 
-Before scheduling a model partition it is allowed to set all variables assigned to that model partition via its associated <<clock>> (including all global variables that are not associated to a <<clock>>) via `fmi3Set{VariableType}()`.
-After the computation of a model partition (call of `fmi3ActivateModelPartition()` with the <<clockReference>> of the <<clock>> that is associated to the model partition) all variables that are assigned to this model partition (including all global variables that are not associated to a <<clock>>) can be retrieved via `fmi3Get{VariableType}()`.
+Before scheduling a model partition it is allowed to set all variables assigned to that model partition via its associated <<clock>> (including all global variables that are not associated to a <<clock>>) via `fmi3Set{VariableType}`.
+After the computation of a model partition (call of `fmi3ActivateModelPartition` with the <<clockReference>> of the <<clock>> that is associated to the model partition) all variables that are assigned to this model partition (including all global variables that are not associated to a <<clock>>) can be retrieved via `fmi3Get{VariableType}`.
 Set/get operations have to be atomic for a single variable.
 
 _[The value of global variables can be influenced by more than one model partition if multiple model partitions are active at the same time.]_
 
-The computational effort has to be predictable, thus all computationally expensive operations needed to calculate a model partition have to be contained within the `fmi3ActivateModelPartition()` function.
+The computational effort has to be predictable, thus all computationally expensive operations needed to calculate a model partition have to be contained within the `fmi3ActivateModelPartition` function.
 The simulation master can assume that `fmi3Get{VariableType} and fmi3Set{VariableType}` operations are not computationally expensive.
 In mode `fmi3ModeScheduledExecutionSimulation` the handling of <<fmi3CallbackIntermediateUpdate>> callbacks is the same as in section <<clocked-co-simulation>>.
 The only difference is that an early return has no meaning in this mode and  no additional event handling based on <<fmi3NewDiscreteStates>> is conducted.
@@ -778,40 +808,41 @@ If this mode is set, the master has to directly control the time of computation 
 The activation states of <<outputClock,`output clocks`>> are transported via <<fmi3CallbackIntermediateUpdate>> and <<fmi3GetClock>>.
 
 [[fmi3ActivateModelPartition]]
-Each `fmi3ActivateModelPartition()` call is now associated to the computation of a (publicly disclosed, externally controlled) model partition of the model and therefore to a single defined <<inputClock>>.
+Each `fmi3ActivateModelPartition` call is now associated to the computation of a (publicly disclosed, externally controlled) model partition of the model and therefore to a single defined <<inputClock>>.
 
 [source, C]
 ----
 include::../headers/fmi3FunctionTypes.h[tag=ActivateModelPartition]
 ----
 
-The `fmi3ActivateModelPartition()` function has the following parameters:
+The `fmi3ActivateModelPartition` function has the following parameters:
 
-- `fmi3Instance instance`: same meaning as for other fmi3 functions
+- `fmi3Instance instance`: same meaning as for other `fmi3*` functions
 
 - `fmi3ValueReference` <<clockReference>>: <<valueReference>> of an <<inputClock>> defined in the `modelDescription.xml` which shall be activated
 
 - `fmi3Float64 activationTime`: simulation (i.e. virtual) time of the <<clock>> tick
 
-Scheduling of `fmi3ActivateModelPartition()` calls for each FMU is done by the simulation master. Calls are based on ticks of periodic or aperiodic <<inputClock,`input clocks`>>.
+Scheduling of `fmi3ActivateModelPartition` calls for each FMU is done by the simulation master.
+Calls are based on ticks of periodic or aperiodic <<inputClock,`input clocks`>>.
 These <<inputClock>> ticks can be based on <<clock>> ticks from FMU external sources (e.g. <<outputClock,`output clocks`>> of other FMUs) or other external <<clock,`clocks`>>/events/interrupts assigned via the simulation master configuration (such external events can be based on a potentially unpredictable process or can be just simulation time based events e.g. the planned communication point).
-The `fmi3ActivateModelPartition()` function is not called for <<outputClock,`output clocks`>> of an FMU.
+The `fmi3ActivateModelPartition` function is not called for <<outputClock,`output clocks`>> of an FMU.
 
 The <<fmi3DoStep>>, <<fmi3SetClock>>, <<fmi3SetIntervalDecimal>>, <<fmi3SetIntervalFraction>>, <<fmi3DoEarlyReturn>>, <<fmi3EnterEventMode>>, <<fmi3EnterStepMode>> functions must not be called in this Co-Simulation mode.
 
-The value for the `fmi3ActivateModelPartition()` parameter `activationTime` is the <<clock>> tick time latexmath:[t_i] from the  assigned <<inputClock>> (which is known to the Co-Simulation master).
+The value for the `fmi3ActivateModelPartition` parameter `activationTime` is the <<clock>> tick time latexmath:[t_i] from the  assigned <<inputClock>> (which is known to the Co-Simulation master).
 
 Refer to <<math-scheduled-execution-simulation>> and <<clock-types-for-evaluation-of-clocked-model-partitions>>.
 
 This is a different timing concept compared to <<fmi3DoStep>> calls.
-A `fmi3ActivateModelPartition()` call will compute the results of the model partition defined by <<clockReference>> (i.e. <<valueReference>> of the variable that defines a <<clock>>) for the current <<clock>> tick latexmath:[t_i].
+A `fmi3ActivateModelPartition` call will compute the results of the model partition defined by <<clockReference>> (i.e. <<valueReference>> of the variable that defines a <<clock>>) for the current <<clock>> tick latexmath:[t_i].
 
-The value for the `fmi3ActivateModelPartition()` parameter `activationTime` is the <<clock>> tick time latexmath:[t_i] from the assigned <<inputClock>> (which is known to the Co-Simulation master).
+The value for the `fmi3ActivateModelPartition` parameter `activationTime` is the <<clock>> tick time latexmath:[t_i] from the assigned <<inputClock>> (which is known to the Co-Simulation master).
 Refer to the <<clock>> time progress definition (<<clock-types-for-evaluation-of-clocked-model-partitions>>) for periodic <<clock,`clocks`>>.
 
-If required, the FMU can internally derive the <<clock>> interval stem:[\Delta T_i] based on the last <<clock>> tick time stem:[t_{i-1}] i.e. last activationTime for this <<clockReference>> (based on last `fmi3ActivateModelPartition()` call)
+If required, the FMU can internally derive the <<clock>> interval latexmath:[\Delta T_i] based on the last <<clock>> tick time latexmath:[t_{i-1}] i.e. last activationTime for this <<clockReference>> (based on last `fmi3ActivateModelPartition` call).
 
-It is not allowed to call `fmi3ActivateModelPartition()` for a <<clockReference>> (i.e. <<valueReference>> of <<clock>> variable) more than once for the same activationTime latexmath:[t_i].
+It is not allowed to call `fmi3ActivateModelPartition` for a <<clockReference>> (i.e. <<valueReference>> of <<clock>> variable) more than once for the same activationTime latexmath:[t_i].
 
 ===== State Machine for fmi3ModeScheduledExecutionSimulation
 
@@ -824,59 +855,63 @@ image::images/calling-sequence-co-simulation_scheduled_execution.svg[width=80%, 
 
 In this Co-Simulation mode the following functions must not be called: <<fmi3DoStep>>, <<fmi3NewDiscreteStates>>, <<fmi3SetClock>>, <<fmi3SetIntervalDecimal>>, <<fmi3SetIntervalFraction>>, <<fmi3DoEarlyReturn>>, <<fmi3EnterEventMode>>, <<fmi3EnterStepMode>> including all functions that are specific to fmuType `fmi3ModelExchange`.
 
-The states `Configuration Mode`, `Instantiated`, `Initialization Mode`, `Terminated`, `Fatal` are handled in the same way as in mode `fmi3ModeCoSimulation` with the exception that the generally not allowed functions of the Co-Simulation mode `fmi3ModeScheduledExecutionSimulation` must not be called.
+The states *Configuration Mode*, *Instantiated*, *Initialization Mode*, *Terminated*, and *Fatal* are handled in the same way as in mode `fmi3ModeCoSimulation` with the exception that the generally not allowed functions of the Co-Simulation mode `fmi3ModeScheduledExecutionSimulation` must not be called.
 
 ====== State: slaveSetableFMUstate
-In all states of this super state it is allowed to call
-<<fmi3GetFMUState>>, `fmi3SetFMUState()`, `fmi3FreeFMUState()`, <<fmi3SerializedFMUStateSize>>, <<fmi3SerializeFMUState>>, <<fmi3DeSerializeFMUState>>, <<fmi3Reset>>, <<fmi3GetVersion>>, `fmi3SetDebugLogging()` and <<fmi3FreeInstance>>.
 
-If any function returns with `fmi3Fatal` the FMU enters state `Fatal`.
+In all states of this super state it is allowed to call <<fmi3GetFMUState>>, `fmi3SetFMUState`, `fmi3FreeFMUState`, <<fmi3SerializedFMUStateSize>>, <<fmi3SerializeFMUState>>, <<fmi3DeSerializeFMUState>>, <<fmi3Reset>>, <<fmi3GetVersion>>, `fmi3SetDebugLogging` and <<fmi3FreeInstance>>.
+
+If any function returns with `fmi3Fatal` the FMU enters state *Fatal*.
 
 ====== State: slaveUnderEvaluation
-This super state is entered by the FMU when <<fmi3Instantiate>> is called. If any function returns `fmi3Error` or `fmi3Discard`  the FMU enters state `Terminated`.
+
+This super state is entered by the FMU when <<fmi3Instantiate>> is called.
+If any function returns `fmi3Error` or `fmi3Discard` the FMU enters state *Terminated*.
 
 ====== State: slaveInitialized
-This super state is entered by the FMU when `fmi3ExitInitializatoinMode()` is called.
-If the function <<fmi3Terminate>> is called, the FMU enters state `Terminated` from all states of this super state.
-The FMU enters state `Terminated` only after all other tasks related to the computation of model partitions of this FMU have ended.
-After <<fmi3Terminate>> has been called no new tasks can be started (e.g. related to <<outputClock>> ticks) and all other function calls for this FMU must return `fmi3Error` until the state `Terminated` is reached.
+
+This super state is entered by the FMU when `fmi3ExitInitializatoinMode` is called.
+If the function <<fmi3Terminate>> is called, the FMU enters state *Terminated* from all states of this super state.
+The FMU enters state *Terminated* only after all other tasks related to the computation of model partitions of this FMU have ended.
+After <<fmi3Terminate>> has been called no new tasks can be started (e.g. related to <<outputClock>> ticks) and all other function calls for this FMU must return `fmi3Error` until the state *Terminated* is reached.
 
 ====== State: Clock Activation Mode
-The FMU enters this state when the master calls <<fmi3ExitInitializationMode>> in state `Initialization Mode` or <<fmi3ExitConfigurationMode>> in state `Reconfiguration Mode`.
-In this state the master can create multiple concurrent tasks related to an FMU and in each task the master can activate one or multiple <<inputClock,`input clocks`>> of an FMU based on the defined <<clock>> properties via a `fmi3ActivateModelPartition()` call for each <<clock>>.
+
+The FMU enters this state when the master calls <<fmi3ExitInitializationMode>> in state `Initialization Mode` or <<fmi3ExitConfigurationMode>> in state *Reconfiguration Mode*.
+In this state the master can create multiple concurrent tasks related to an FMU and in each task the master can activate one or multiple <<inputClock,`input clocks`>> of an FMU based on the defined <<clock>> properties via a `fmi3ActivateModelPartition` call for each <<clock>>.
 
 Allowed Function Calls::
 
-`fmi3ActivateModelPartition()`::
+`fmi3ActivateModelPartition`::
 If the function returns with `fmi3OK` or `fmi3Warning` the FMU stays in this state.
 In case of `fmi3Fatal` the master can prematurely end all tasks related to the computation of model partitions of this FMU.
-In case of `fmi3Discard` or `fmi3Error` the master must wait until all other tasks related to the computation of model partitions of this FMU have ended, but no new tasks can be started (e.g. related to <<outputClock>> tick) and all other function calls for this FMU must also return `fmi3Discard` or `fmi3Error` until the state `terminated` is reached.
+In case of `fmi3Discard` or `fmi3Error` the master must wait until all other tasks related to the computation of model partitions of this FMU have ended, but no new tasks can be started (e.g. related to <<outputClock>> tick) and all other function calls for this FMU must also return `fmi3Discard` or `fmi3Error` until the state *Terminated* is reached.
 +
-It is recommended to call `fmi3Set{VariableType}` and `fmi3Get{VariableType}` in the same task as `fmi3ActivateModelPartition()` for setting and retrieving variable values associated to a <<clock>> activation.
+It is recommended to call `fmi3Set{VariableType}` and `fmi3Get{VariableType}` in the same task as `fmi3ActivateModelPartition` for setting and retrieving variable values associated to a <<clock>> activation.
 
-<<get-and-set-variable-values,fmi3Set{VariableType}()>>, `fmi3SetRealInputDerivatives()`::
-Is called before the start of the computation of a model partition (i.e. before call of `fmi3ActivateModelPartition()`) and only for global variables and variables associated to the <<inputClock>> assigned to the model partition.
-+
-The restrictions related to variable <<causality>> and <<variability>> defined for `Step Mode` in mode `fmi3ModeCoSimulation` apply.
-+
-If the function returns with `fmi3OK` or `fmi3Warning` the FMU stays in this state.
-In case the function returns `fmi3Fatal` the master can prematurely end all tasks related to the computation of model partitions of this FMU.
-In case the function returns `fmi3Discard` or `fmi3Error` the master must wait until all other tasks related to the computation of the model partitions of this FMU have ended, but new tasks must not be started (e.g. related to <<outputClock>> ticks) and all other function calls for this FMU must also return `fmi3Discard` or `fmi3Error` until the state `Terminated` is reached.
-
-<<get-and-set-variable-values,fmi3Get{VariableType}>>, `fmi3GetRealOutputDerivatives()`, <<fmi3GetDirectionalDerivative>>`::
-Is called after the end of the computation of a model partition (i.e. after return of `fmi3ActivateModelPartition()`) and only for global variables and variables associated to the <<inputClock>> assigned to the model partition.
+<<get-and-set-variable-values,fmi3Set{VariableType}>>, `fmi3SetRealInputDerivatives`::
+Is called before the start of the computation of a model partition (i.e. before call of `fmi3ActivateModelPartition`) and only for global variables and variables associated to the <<inputClock>> assigned to the model partition.
 +
 The restrictions related to variable <<causality>> and <<variability>> defined for `Step Mode` in mode `fmi3ModeCoSimulation` apply.
 +
 If the function returns with `fmi3OK` or `fmi3Warning` the FMU stays in this state.
 In case the function returns `fmi3Fatal` the master can prematurely end all tasks related to the computation of model partitions of this FMU.
-In case the function returns `fmi3Discard` or `fmi3Error` the master must wait until all other tasks related to the computation of model partitions of this FMU have ended, but new tasks must not be started (e.g. related to <<outputClock>> ticks) and all other function calls for this FMU have to also return `fmi3Discard` or `fmi3Error` until the state `Terminated` is reached.
+In case the function returns `fmi3Discard` or `fmi3Error` the master must wait until all other tasks related to the computation of the model partitions of this FMU have ended, but new tasks must not be started (e.g. related to <<outputClock>> ticks) and all other function calls for this FMU must also return `fmi3Discard` or `fmi3Error` until the state *Terminated* is reached.
 
-It is not allowed to call `fmi3Get{VariableType}` functions after `fmi3Set{VariableType}` functions without an `fmi3ActivateModelPartition()` call in between.
+<<get-and-set-variable-values,fmi3Get{VariableType}>>, `fmi3GetRealOutputDerivatives`, <<fmi3GetDirectionalDerivative>>`::
+Is called after the end of the computation of a model partition (i.e. after return of `fmi3ActivateModelPartition`) and only for global variables and variables associated to the <<inputClock>> assigned to the model partition.
++
+The restrictions related to variable <<causality>> and <<variability>> defined for `Step Mode` in mode `fmi3ModeCoSimulation` apply.
++
+If the function returns with `fmi3OK` or `fmi3Warning` the FMU stays in this state.
+In case the function returns `fmi3Fatal` the master can prematurely end all tasks related to the computation of model partitions of this FMU.
+In case the function returns `fmi3Discard` or `fmi3Error` the master must wait until all other tasks related to the computation of model partitions of this FMU have ended, but new tasks must not be started (e.g. related to <<outputClock>> ticks) and all other function calls for this FMU have to also return `fmi3Discard` or `fmi3Error` until the state *Terminated* is reached.
 
-_[The reason is to avoid different interpretations of the caching, since contrary to FMI for Model Exchange, <<fmi3DoStep>> will perform the actual calculation instead of `fmi3Get{VariableType}`, and therefore, dummy algebraic loops at communication points cannot be handled by an appropriate sequence of `fmi3Get{VariableType}` and, `fmi3Set{VariableType}` calls as for Model Exchange.
+It is not allowed to call `fmi3Get{VariableType}` functions after `fmi3Set{VariableType}` functions without an `fmi3ActivateModelPartition` call in between.
 
-Example:
+_[The reason is to avoid different interpretations of the caching, since contrary to FMI for Model Exchange, <<fmi3DoStep>> will perform the actual calculation instead of `fmi3Get{VariableType}`, and therefore, dummy algebraic loops at communication points cannot be handled by an appropriate sequence of `fmi3Get{VariableType}` and, `fmi3Set{VariableType}` calls as for Model Exchange._
+
+_Example:_
 
 [cols="3,4",options="header"]
 |====
@@ -896,21 +931,21 @@ _fmi3Get{VariableType} on outputs // not allowed_ +
 fmi3ActivateModelPartition +
 _fmi3Get{VariableType} on outputs_ +
 |====
-]_
+
+_]_
 
 <<fmi3CallbackIntermediateUpdate>>::
 Only in this state the FMU is allowed to call the callback <<fmi3CallbackIntermediateUpdate>>.
-The callback may be called from concurrent tasks within `fmi3ActivateModelPartition()`.
+The callback may be called from concurrent tasks within `fmi3ActivateModelPartition`.
 The function must not return `fmi3Discard`.
-
 
 <<fmi3EnterConfigurationMode>>::
 This function must not be called if the FMU contains no <<structuralParameter,`structural parameters`>> or other tasks related to the computation of model partitions of this FMU are currently active or preempted.
 Thus this function can not be called concurrently for model partitions of an FMU but only for the whole FMU instance.
 +
-If the function returns with `fmi3OK` or `fmi3Warning` the FMU goes into state `Reconfiguration Mode`.
+If the function returns with `fmi3OK` or `fmi3Warning` the FMU goes into state *Reconfiguration Mode*.
 
-`fmi3Terminate(), fmi3Reset()`, <<fmi3FreeInstance>>::
+`fmi3Terminate`, `fmi3Reset`, <<fmi3FreeInstance>>::
 These functions can not be called concurrently for model partitions of an FMU but only for the whole FMU instance.
 If these functions are called while a model partition of an FMU is currently active or preempted, the FMU changes its state after the computation of all model partitions of this FMU has ended.
 
@@ -922,16 +957,17 @@ Forbidden Function Calls::
 Additionally to the generally forbidden functions in this Co-Simulation mode as listed above, the following functions must not be called in this state: <<fmi3ExitConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3GetDoStepDiscardedStatus>>
 
 ====== State: Intermediate Update Mode
+
 In this state the master can retrieve information from the FMU between communication points.
 Functions called in this state must not return `fmi3Discard`.
 
-The FMU enters this state by calling <<fmi3CallbackIntermediateUpdate>>  within `fmi3ActivateModelPartition()` and leaves the state towards state `Clock Activation Mode` if the function returns `fmi3OK` or `fmi3Warning`.
-If the function returns `fmi3Error` the FMU enters state `Terminated`.
-If the function returns `fmi3Fatal` the FMU enters state `Fatal`.
+The FMU enters this state by calling <<fmi3CallbackIntermediateUpdate>>  within `fmi3ActivateModelPartition` and leaves the state towards state `Clock Activation Mode` if the function returns `fmi3OK` or `fmi3Warning`.
+If the function returns `fmi3Error` the FMU enters state *Terminated*.
+If the function returns `fmi3Fatal` the FMU enters state *Fatal*.
 
 
 Forbidden Function Calls::
-The same functions which are not allowed to be called in `Clock Activation Mode` must not be called in this state. Additionally the following functions must not be called `fmi3ActivateModelPartition()`, <<fmi3EnterConfigurationMode>>, <<fmi3Terminate>>.
+The same functions which are not allowed to be called in `Clock Activation Mode` must not be called in this state. Additionally the following functions must not be called `fmi3ActivateModelPartition`, <<fmi3EnterConfigurationMode>>, <<fmi3Terminate>>.
 
 Allowed Function Calls::
 For a <<outputClock>> only the first call of `fmi3GetClock` for a specific activation of this <<clock>> signals `fmi3True`.
@@ -939,51 +975,49 @@ The FMU sets the reported activation state immediately back to `fmi3False` for t
 The master can call `fmi3Set{VariableType}` and `fmi3Get{VariableType}` during the callback for variables associated to a <<outputClock>> that is active during this callback.
 Also intermediate variable access is allowed as defined in <<state-intermediate-update-mode-co-simulation>>
 
-_[Based on the FMI standard it cannot be determined which part of the code of an FMU has called the callback function <<fmi3CallbackIntermediateUpdate>>.
-This is especially the case for the Co-Simulation mode `fmi3ModeScheduledExecutionSimulation` in which multiple model partitions can be active at the same time.
-This causes no issues since all function call prerequisites are connected to the activation state of <<clock,`clocks`>>, `modelDescription.xml` information and additionally available information of the struct <<fmi3IntermediateUpdateInfo>>]_
+_[Based on the FMI standard it cannot be determined which part of the code of an FMU has called the callback function <<fmi3CallbackIntermediateUpdate>>._
+_This is especially the case for the Co-Simulation mode `fmi3ModeScheduledExecutionSimulation` in which multiple model partitions can be active at the same time._
+_This causes no issues since all function call prerequisites are connected to the activation state of <<clock,`clocks`>>, `modelDescription.xml` information and additionally available information of the struct <<fmi3IntermediateUpdateInfo>>]_
 
 ====== State: Reconfiguration Mode
+
 In this state <<structuralParameter,`structural parameters`>> with <<variability>> = <<tunable>> can be changed.
-This state is entered from state `Clock Activation Mode` by calling <<fmi3EnterConfigurationMode>> and left back to `Clock Activation Mode` by calling <<fmi3ExitConfigurationMode>>.
+This state is entered from state *Clock Activation Mode* by calling <<fmi3EnterConfigurationMode>> and left back to *Clock Activation Mode* by calling <<fmi3ExitConfigurationMode>>.
 
 Allowed Function Calls::
-<<fmi3ExitConfigurationMode>>::
-
-`fmi3Set{VariableTypes}`::
-Only for variables with <<causality>> = <<structuralParameter>> and <<variability>> = <<tunable>>.
+- <<fmi3ExitConfigurationMode>>
+- `fmi3Set{VariableTypes}`: Only for variables with <<causality>> = <<structuralParameter>> and <<variability>> = <<tunable>>.
 
 Forbidden Function Calls::
-Additionally to the generally forbidden functions in this Co-Simulation mode listed above the following functions must not be called in this state: <<fmi3EnterConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3GetDoStepDiscardedStatus>>, `fmi3ActivateModelPartition()`,`fmi3SetRealInputDerivatives()`, <<fmi3GetDirectionalDerivative>>, `fmi3GetRealOutputDerivatives()`, `fmi3Get{VariableTypes}`, <<fmi3DoEarlyReturn>>
+Additionally to the generally forbidden functions in this Co-Simulation mode listed above the following functions must not be called in this state: <<fmi3EnterConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3GetDoStepDiscardedStatus>>, `fmi3ActivateModelPartition`,`fmi3SetRealInputDerivatives`, <<fmi3GetDirectionalDerivative>>, `fmi3GetRealOutputDerivatives`, `fmi3Get{VariableTypes}`, <<fmi3DoEarlyReturn>>
 
-
-_[TODO non-normative table of states and function calls]_
+// TODO: add non-normative table of states and function calls
 
 ===== Preemption Support [[preemption-support]]
 
-For real-time applications the simulation time equals the real wall <<clock>> time, thus each `fmi3ActivateModelPartition()` computation step has to be finished in real-time within its current period time length (computation time is not only defined by the runtime of `fmi3ActivateModelPartition()` but also by the time for setting and getting variables and related operations).
-Usually a preemptive scheduling of the `fmi3ActivateModelPartition()`, `fmi3Get{VariableType}()`, `fmi3Set{VariableType}()` calls is required for respecting this constraint.
+For real-time applications the simulation time equals the real wall <<clock>> time, thus each `fmi3ActivateModelPartition` computation step has to be finished in real-time within its current period time length (computation time is not only defined by the runtime of `fmi3ActivateModelPartition` but also by the time for setting and getting variables and related operations).
+Usually a preemptive scheduling of the `fmi3ActivateModelPartition`, `fmi3Get{VariableType}`, `fmi3Set{VariableType}` calls is required for respecting this constraint.
 
-The FMU's code has to be prepared for being able to correctly handle preemptive calls of `fmi3ActivateModelPartition()`,`fmi3Get{VariableType}()`,`fmi3Set{VariableType}()`.
+The FMU's code has to be prepared for being able to correctly handle preemptive calls of `fmi3ActivateModelPartition`, `fmi3Get{VariableType}`, `fmi3Set{VariableType}`.
 That requires a secured internal and external access to global states and variable values.
 Thus in this Co-Simulation mode a support for a correct handling of the preemption of model partition computations is required.
 That also requires that the FMU reports the active state of a <<outputClock>> only with the first call of <<fmi3GetClock>> for a specific activation of this <<clock>> and sets the reported activation state immediately back to `false` for the following <<fmi3GetClock>> calls for that <<clock>> until this <<outputClock>> is internally activated again.
 
 If a preemptive multitasking regime is intended an individual task (or thread -- task and thread are used synonymously here) for each model partition (associated to an <<inputClock>>) has to be created.
-The task for computing each `fmi3ActivateModelPartition()` is created and controlled by the simulation master, not by the FMU.
+The task for computing each `fmi3ActivateModelPartition` is created and controlled by the simulation master, not by the FMU.
 So the FMU exporting tool does not need to take care for that (except for preparing its code to support preemption).
 
-_[If only one single model partition (<<inputClock>>) is available via the interface of an FMU, preemptive calls of the related `fmi3ActivateModelPartition()` function are possible by default since there are no external cross dependencies within one model partition between communication points.]_
+_[If only one single model partition (<<inputClock>>) is available via the interface of an FMU, preemptive calls of the related `fmi3ActivateModelPartition` function are possible by default since there are no external cross dependencies within one model partition between communication points.]_
 
-Based on the <<inputClock>> settings defined in the XML the master calls `fmi3Set{VariableType}()`, `fmi3ActivateModelPartition()`, `fmi3Get{VariableType}()` calls.
+Based on the <<inputClock>> settings defined in the XML the master calls `fmi3Set{VariableType}`, `fmi3ActivateModelPartition`, `fmi3Get{VariableType}` calls.
 Set/get calls for each task are only allowed for variables that are associated to the <<inputClock>> associated to that task or - here preemption issues become important - to variables that are associated to no <<clock,`clocks`>> (global variables), based on the XML information (see 4.4.3).
 
-_[The recommendation is to avoid global variable associations as much as possible in the XML.
-It is also recommended to reduce dependencies (defined in XML model structure) between variables located in different model partitions of one FMU, since this also requires in most cases that the related variables have to be global variables.]_
+_[The recommendation is to avoid global variable associations as much as possible in the XML._
+_It is also recommended to reduce dependencies (defined in XML model structure) between variables located in different model partitions of one FMU, since this also requires in most cases that the related variables have to be global variables.]_
 
 The Co-Simulation master has no knowledge about the FMU internal communication between the model partitions of a single FMU and does not handle it.
 
-The simulation master schedules the `fmi3ActivateModelPartition()` (as well as related `fmi3Get{VariableType}` and `fmi3Set{VariableType}`) calls based on given priorities for <<inputClock,`input clocks`>> defined in the `modelDescription.xml`.
+The simulation master schedules the `fmi3ActivateModelPartition` (as well as related `fmi3Get{VariableType}` and `fmi3Set{VariableType}`) calls based on given priorities for <<inputClock,`input clocks`>> defined in the `modelDescription.xml`.
 
 Priority (see <<clock-type-definition>>):
 
@@ -1016,7 +1050,7 @@ include::../headers/fmi3FunctionTypes.h[tag=PreemptionLock]
 
 Even if the Co-Simulation master does not support preemption and the mode `fmi3ModeScheduledExecutionSimulation`, at least an empty implementation of these callback functions is required.
 
-Example for the use of `fmi3CallbackLockPreemption()` and `fmi3CallbackUnlockPreemption()` callback functions in the FMU code:
+Example for the use of `fmi3CallbackLockPreemption` and `fmi3CallbackUnlockPreemption` callback functions in the FMU code:
 
 [source, C]
 ----
@@ -1063,7 +1097,6 @@ include::examples/pseudo_code_co_simulation_scheduled_execution_simulation.txt[]
 
 
 ==== Intermediate Variable Access [[api-intermediate-variable-access]]
-:DOSTEP: fmi3DoStep()
 
 If the Co-Simulation master signals the support for intermediate variable access see section <<co-simulation-feature-selection>> and an FMU has at least one variable with <<intermediateAccess>> = `true`, the FMU can invoke the <<fmi3CallbackIntermediateUpdate>> callback function to sent the <<fmi3IntermediateUpdateInfo>> back to the Co-Simulation master.
 

--- a/docs/4_3_co-simulation_schema.adoc
+++ b/docs/4_3_co-simulation_schema.adoc
@@ -23,7 +23,7 @@ These attributes have the following meaning (all attributes are optional with ex
 |_Description_
 
 |`modelIdentifier`
-|Short class name according to C syntax, for example, "A_B_C".
+|Short class name according to C syntax, for example, `A_B_C`.
 Used as prefix for FMI functions if the functions are provided in C source code or in static libraries, but not if the functions are provided by a DLL/SharedObject.
 `modelIdentifier` is also used as name of the static library or DLL/SharedObject.
 See also <<header-files-and-naming-of-functions>>.
@@ -31,12 +31,13 @@ See also <<header-files-and-naming-of-functions>>.
 |`needsExecutionTool`
 |If `true`, a tool is needed to execute the model.
 The FMU just contains the communication to this tool (see <<figure-co-simulation-with-tool-coupling>>).
-_[Typically, this information is only utilized for information purposes.
-For example, a Co-Simulation master can inform the user that a tool has to be available on the computer where the slave is instantiated.
-The name of the tool can be taken from attribute `generationTool` of `fmiModelDescription`.]_
+_[Typically, this information is only utilized for information purposes._
+_For example, a Co-Simulation master can inform the user that a tool has to be available on the computer where the slave is instantiated._
+_The name of the tool can be taken from attribute `generationTool` of `fmiModelDescription`.]_
 
 |`canBeInstantiatedOnlyOncePerProcess`
-|This flag indicates cases (especially for embedded code), where only one instance per FMU is possible. (For multiple instantiation the default is `false`; if multiple instances are needed, the FMUs must be instantiated in different processes.).
+|This flag indicates cases (especially for embedded code), where only one instance per FMU is possible.
+(For multiple instantiation the default is `false`; if multiple instances are needed, the FMUs must be instantiated in different processes.).
 
 |`canNotUseMemoryManagementFunctions`
 |If `true`, the slave uses its own functions for memory allocation and freeing only.
@@ -71,8 +72,8 @@ The accessible variables are marked with attribute <<intermediateAccess>> = `tru
 
 |`canReturnEarlyAfterIntermediateUpdate`
 |If `true`, the slave is able to return early from <<fmi3DoStep>> if master calls <<fmi3DoEarlyReturn>> during callback function call `intermediateUpdate()` and `canReturnEarly = true` in `fmi3IntermediateUpdateInfo`.
-_[If set to `true` and `providesHybridCoSimulation` is set to `false`, the FMU supports the basic functionality of ending DoSteps before the planned next communication point time.
-This is controlled by the simulation master for avoiding unnecessary computations and roll backs of the FMU due to external events known by the simulation master]_
+_[If set to `true` and `providesHybridCoSimulation` is set to `false`, the FMU supports the basic functionality of ending DoSteps before the planned next communication point time._
+_This is controlled by the simulation master for avoiding unnecessary computations and roll backs of the FMU due to external events known by the simulation master]_
 
 |`providesHybridCoSimulation`
 |If `true`, the slave can be set to Co-Simulation mode `fmi3ModeHybridCoSimulation` during instantiation of FMU.
@@ -85,13 +86,11 @@ If set to `true` also `canReturnEarlyAfterIntermediateUpdate` must be set to `tr
 |If `false`, the slave can be set to Co-Simulation mode `fmi3ModeCoSimulation` during instantiation of FMU.
 _[the support of basic co-simulation should be possible for most Co-Simulation FMUs, thus the default value is `false`.]_
 
-
-
 |====
 
 The flags have the following default values. +
 boolean: `false` +
-unsignedInt: 0 +
+unsignedInt: `0` +
 
 Note that if `needsExecutionTool = true`, then it is required that the original tool is available to be executed in Co-Simulation mode.
 If `needsExecutionTool = false`, the slave is completely contained inside the FMU in source code or binary format (DLL/SharedObject).
@@ -111,12 +110,10 @@ include::examples/co_simulation.xml[]
 
 The simulation master collects the information about the capability of an FMU to perform an early return by analyzing the `modelDescription.xml` as defined in section <<fmi-description-schema>> and <<fmi-for-co-simulation>>.
 
-
 ===== Co-Simulation FMU (CoSimulation)
 In order to support the early return in <<fmi3DoStep>> the capability flag  `canReturnEarlyAfterIntermediateUpdate` in the XML should be `true`.
 
 ===== Example XML Description File
-
 
 Here is an example of an XML of an FMU supporting early return.
 
@@ -125,31 +122,27 @@ Here is an example of an XML of an FMU supporting early return.
 include::examples/co_simulation_early_return.xml[]
 ----
 
-:INSTANTIATE: fmi3Instantiate()
-
 ==== Co-Simulation with Clock Support [[schema-clocked-co-simulation]]
 
 The Co-Simulation master collects the information about the number and properties of <<clock,`clocks`>> supported by the FMU by analyzing the `modelDescription.xml`, see section <<clock-type-definition>>.
 
 The definition of <<clock,`clocks`>> is optional.
 
-Each <<inputClock>> that ticks outside of the FMU, is activated for an FMU based on their <<valueReference>>`.
+Each <<inputClock>> that ticks outside of the FMU, is activated for an FMU based on their <<valueReference>>.
 <<outputClock,`Output clocks`>> inside of an FMU signal their activation based on their <<valueReference>>`.
 
-_[If <<dependencies>> (_fmi3VariableDependency_) are defined in the `Modelstructure` section of the `modelDescription.xml`, it is recommended to define such <<dependencies>> only within a model partition of a model (i.e. between variables that are assigned to the same <<clock>>).]_
+_[If <<dependencies>> (`fmi3VariableDependency`) are defined in the `ModelStructure` section of the `modelDescription.xml`, it is recommended to define such <<dependencies>> only within a model partition of a model (i.e. between variables that are assigned to the same <<clock>>).]_
 
 If <<dependencies>> are defined for variables across model partitions, such variables can not be assigned to a <<clock>> via <<clockReference>>.
 
 For FMI for Co-Simulation, variables that are assigned to a model partition of the model based on <<clockReference>> are not necessarily `clocked`.
 Such variables can be Continuous-time or Discrete-time variables if the <<clock>> is of `clockType = CPClock`.
 
-
 ===== Capability Flags [[xml-flags-clocked-co-simulation]]
 
 If the XML file defines an FMU for Clocked Co-Simulation, element `CoSimulation` must be present as described in section <<fmi-for-co-simulation>>.
 
 In order to provide a Clocked Co-Simulation, the attribute `providesHybridCoSimulation` has set to be set to `true`.
-
 
 ===== Example XML Description File [[xml-example-clocked-co-simulation]]
 

--- a/docs/4___co-simulation.adoc
+++ b/docs/4___co-simulation.adoc
@@ -58,9 +58,9 @@ The Co-Simulation mode `fmi3ModeScheduledExecutionSimulation` addresses simulati
 This Co-Simulation mode provides support for a concurrent computation of model partitions (i.e. a support of multiple rates) on a single computational resource (e.g. CPU-core) for an FMU.
 For that a preemptive multitasking regime is intended (cooperative multitasking is not covered by this description).
 
-_[A parallel computation of model partitions is not part of the FMI 3.0 API.
-An FMU may still internally use parallel computation on multiple cores, but handling this is (currently) not part of the FMI standard. Such an internal parallel computation is not visible to the simulation master.
-It is a tool vendor specific solution that has ties to the used OS and the co-simulation environment]_
+_[A parallel computation of model partitions is not part of the FMI 3.0 API._
+_An FMU may still internally use parallel computation on multiple cores, but handling this is (currently) not part of the FMI standard. Such an internal parallel computation is not visible to the simulation master._
+_It is a tool vendor specific solution that has ties to the used OS and the co-simulation environment]_
 
 *Intermediate Variable Access* [[intermediate-variable-access]]
 
@@ -152,23 +152,20 @@ For setting the FMU to certain Co-Simulation modes the following capability flag
 
 |`fmi3ModeScheduledExecutionSimulation`
 |`providesScheduledExecutionSimulation`
-
 |===
 
 A detailed description of the capability flags is given in the following sections.
 
 Generally it is assumed that an FMI 3.0 for Co-Simulation FMU always supports the Co-Simulation mode `fmi3ModeCoSimulation`.
-If that is not possible for an FMU
-- e.g. if the FMU can not provide an emulation of <<inputClock>> tick occurrences -
-it has to include the capability flag `canNotUseBasicCoSimulation = true` in the `modelDescription.xml`.
+If that is not possible for an FMU - e.g. if the FMU can not provide an emulation of <<inputClock>> tick occurrences - it has to include the capability flag `canNotUseBasicCoSimulation = true` in the `modelDescription.xml`.
 
-If the FMU cannot provide a support for a Co-Simulation mode it has to refuse this mode via return value NULL for <<fmi3Instantiate>>.
+If the FMU cannot provide a support for a Co-Simulation mode it has to refuse this mode via return value `NULL` for <<fmi3Instantiate>>.
 
 *Multiple Co-Simulation Mode Support in one FMU*
 
-If the fmuType is `fmi3CoSimulation`, then it is encouraged to support multiple Co-Simulation modes in one FMU so it can be used in differently capable Co-Simulation master implementations and for different use cases.
-_[That improves the reusability of FMUs.
-A common application of this multiple mode support is the reuse of FMUs for real-time and non-real-time simulations.]_
+If the `fmuType` is `fmi3CoSimulation`, then it is encouraged to support multiple Co-Simulation modes in one FMU so it can be used in differently capable Co-Simulation master implementations and for different use cases.
+_[That improves the reusability of FMUs._
+_A common application of this multiple mode support is the reuse of FMUs for real-time and non-real-time simulations.]_
 
 The described multi mode support is based on wrapping functionality into the <<fmi3DoStep>> function via emulating missing features of the mode the FMU has been originally exported for.
 
@@ -178,5 +175,5 @@ _[Remark:_
 _Wrapping towards other Co-Simulation modes can influence the simulation results._
 _Depending on the model especially wrapping towards the mode `fmi3ModeCoSimulation` may result in divergent simulation results._
 _Especially aperiodic <<inputClock,`input clocks`>> can not always be sufficiently emulated in modes that do not directly support <<clock,`clocks`>>._
-_Therefore it is recommended that the FMU provides logging information to the user about the influence of the current mode on simulation results, if non-optimal modes are used by the simulation environment.
-]_
+_Therefore it is recommended that the FMU provides logging information to the user about the influence of the current mode on simulation results, if non-optimal modes are used by the simulation environment._
+_]_

--- a/docs/5___literature.adoc
+++ b/docs/5___literature.adoc
@@ -1,21 +1,23 @@
 == Literature
 
-- &#197;kesson J., Braun W., Lindholm P., and Bachmann B. (2012): **Generation of Sparse Jacobians for the Functional Mockup Interface 2.0**. 9th International Modelica Conference, Munich, 2012. http://www.ep.liu.se/ecp/076/018/ecp12076018.pdf
+[bibliography]
+== References
 
-- Benveniste A., Caillaud B., Pouzet M. (2010): **The Fundamentals of Hybrid Systems Modelers**. In 49th IEEE International Conference on Decision and Control (CDC), Atlanta, Georgia, USA, December 15-17. http://www.di.ens.fr/~pouzet/bib/cdc10.pdf
+- [[[ABL12]]] &#197;kesson J., Braun W., Lindholm P., and Bachmann B. (2012): **Generation of Sparse Jacobians for the Functional Mockup Interface 2.0**. 9th International Modelica Conference, Munich, 2012. http://www.ep.liu.se/ecp/076/018/ecp12076018.pdf
 
-- Blochwitz T., Otter M., Arnold M., Bausch C., Clau&#223; C., Elmqvist H., Junghanns A., Mauss J., Monteiro M., Neidhold T., Neumerkel D., Olsson H., Peetz J.-V., Wolf S. (2011): **The Functional Mockup Interface for Tool independent Exchange of Simulation Models**. 8th International Modelica Conference, Dresden 2011. http://www.ep.liu.se/ecp/063/013/ecp11063013.pdf
+- [[[BCP10]]] Benveniste A., Caillaud B., Pouzet M. (2010): **The Fundamentals of Hybrid Systems Modelers**. In 49th IEEE International Conference on Decision and Control (CDC), Atlanta, Georgia, USA, December 15-17. http://www.di.ens.fr/~pouzet/bib/cdc10.pdf
 
-- Blochwitz T., Otter M., &#197;kesson J., Arnold M., Clau&#223; C., Elmqvist H., Friedrich M., Junghanns A., Mauss J,, Neumerkel D., Olsson H., Viel A. (2012): **Functional Mockup Interface 2.0: The Standard for Tool independent Exchange of Simulation Models**. 9th International Modelica Conference, Munich, 2012. http://www.ep.liu.se/ecp/076/017/ecp12076017.pdf
+- [[[BOA11]]] Blochwitz T., Otter M., Arnold M., Bausch C., Clau&#223; C., Elmqvist H., Junghanns A., Mauss J., Monteiro M., Neidhold T., Neumerkel D., Olsson H., Peetz J.-V., Wolf S. (2011): **The Functional Mockup Interface for Tool independent Exchange of Simulation Models**. 8th International Modelica Conference, Dresden 2011. http://www.ep.liu.se/ecp/063/013/ecp11063013.pdf
 
-- K&#252;bler R., Schiehlen, W. (2000): **Two methods of simulator coupling**. Mathematical and Computer Modeling of Dynamical Systems 6 pp. 93-113.
-  Lee E.A., Zheng H. (2007): Leveraging Synchronous Language Principles for Heterogeneous Modeling and Design of Embedded Systems. EMSOFT'07, Sept. 30 - Oct. 3, 2007, Salzburg, Austria. https://ptolemy.berkeley.edu/publications/papers/07/unifying/LeeZheng_SRUnifying.pdf
+- [[[BOA12]]] Blochwitz T., Otter M., &#197;kesson J., Arnold M., Clau&#223; C., Elmqvist H., Friedrich M., Junghanns A., Mauss J., Neumerkel D., Olsson H., Viel A. (2012): **Functional Mockup Interface 2.0: The Standard for Tool independent Exchange of Simulation Models**. 9th International Modelica Conference, Munich, 2012. http://www.ep.liu.se/ecp/076/017/ecp12076017.pdf
 
-- Lee E.A., Zheng H. (2007): **Leveraging Synchronous Language Principles for Heterogeneous Modeling and Design of Embedded Systems**. EMSOFT'07, September 30-October 3, Salzburg, Austria. https://dl.acm.org/citation.cfm?id=1289949
+- [[[KS00]]] K&#252;bler R., Schiehlen W. (2000): **Two methods of simulator coupling**. Mathematical and Computer Modeling of Dynamical Systems 6 pp. 93-113.
 
-- Modelica (2012): **Modelica, A Unified Object-Oriented Language for Systems Modeling**. Language Specification, Version 3.3, May 9, 2012. https://www.modelica.org/documents/ModelicaSpec33.pdf
+- [[[LZ07]]] Lee E.A., Zheng H. (2007): **Leveraging Synchronous Language Principles for Heterogeneous Modeling and Design of Embedded Systems**. EMSOFT'07, September 30-October 3, Salzburg, Austria. https://ptolemy.berkeley.edu/publications/papers/07/unifying/LeeZheng_SRUnifying.pdf
 
-- MODELISAR Glossary (2009): **MODELISAR WP2 Glossary and Abbreviations**. Version 1.0, June 9, 2009. Pouzet M. (2006): Lucid Synchrone, Version 3.0, Tutorial and Reference Manual.
+- [[[MLS12]]] Modelica (2012): **Modelica, A Unified Object-Oriented Language for Systems Modeling**. Language Specification, Version 3.3, May 9, 2012. https://www.modelica.org/documents/ModelicaSpec33.pdf
+
+- [[[MG09]]] MODELISAR Glossary (2009): **MODELISAR WP2 Glossary and Abbreviations**. Version 1.0, June 9, 2009.
+
+- [[[PZ06]]] Pouzet M. (2006): Lucid Synchrone, Version 3.0, Tutorial and Reference Manual.
   http://www.di.ens.fr/~pouzet/lucid-synchrone/
-
-- XML: www.w3.org/XML, en.wikipedia.org/wiki/XML

--- a/docs/6___appendix.adoc
+++ b/docs/6___appendix.adoc
@@ -487,7 +487,7 @@ Examples of simulation programs are: AMESim, Dymola, SIMPACK, SimulationX, SIMUL
 |A simulator can include one or more _simulation programs_, which solve a common simulation task.
 
 |_solver_
-|_Software component,_ which includes algorithms to solve __model__s, for example, _integration algorithms_ and _event handling_ methods.
+|_Software component,_ which includes algorithms to solve _models_, for example, _integration algorithms_ and _event handling_ methods.
 
 |_state_
 |The continuous <<state,`states`>> of a model are all variables that appear differentiated in the model and are independent from each other. +

--- a/headers/fmi3FunctionTypes.h
+++ b/headers/fmi3FunctionTypes.h
@@ -232,110 +232,164 @@ typedef fmi3Status fmi3ResetTYPE(fmi3Instance instance);
 /* Getting and setting variable values */
 /* tag::Getters[] */
 typedef fmi3Status fmi3GetFloat32TYPE(fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      fmi3Float32 values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      fmi3Float32 values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3GetFloat64TYPE(fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      fmi3Float64 values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      fmi3Float64 values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3GetInt8TYPE   (fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      fmi3Int8 values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      fmi3Int8 values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3GetUInt8TYPE  (fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      fmi3UInt8 values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      fmi3UInt8 values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3GetInt16TYPE  (fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      fmi3Int16 values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      fmi3Int16 values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3GetUInt16TYPE (fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      fmi3UInt16 values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      fmi3UInt16 values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3GetInt32TYPE  (fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      fmi3Int32 values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      fmi3Int32 values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3GetUInt32TYPE (fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      fmi3UInt32 values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      fmi3UInt32 values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3GetInt64TYPE  (fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      fmi3Int64 values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      fmi3Int64 values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3GetUInt64TYPE (fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      fmi3UInt64 values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      fmi3UInt64 values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3GetBooleanTYPE(fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      fmi3Boolean values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      fmi3Boolean values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3GetStringTYPE (fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      fmi3String values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      fmi3String values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3GetBinaryTYPE (fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      size_t sizes[], fmi3Binary values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      size_t sizes[],
+                                      fmi3Binary values[],
+                                      size_t nValues);
 /* end::Getters[] */
 
 /* tag::Setters[] */
 typedef fmi3Status fmi3SetFloat32TYPE(fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      const fmi3Float32 values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      const fmi3Float32 values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3SetFloat64TYPE(fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      const fmi3Float64 values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      const fmi3Float64 values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3SetInt8TYPE   (fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      const fmi3Int8 values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      const fmi3Int8 values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3SetUInt8TYPE  (fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      const fmi3UInt8 values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      const fmi3UInt8 values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3SetInt16TYPE  (fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      const fmi3Int16 values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      const fmi3Int16 values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3SetUInt16TYPE (fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      const fmi3UInt16 values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      const fmi3UInt16 values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3SetInt32TYPE  (fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      const fmi3Int32 values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      const fmi3Int32 values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3SetUInt32TYPE (fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      const fmi3UInt32 values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      const fmi3UInt32 values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3SetInt64TYPE  (fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      const fmi3Int64 values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      const fmi3Int64 values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3SetUInt64TYPE (fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      const fmi3UInt64 values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      const fmi3UInt64 values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3SetBooleanTYPE(fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      const fmi3Boolean values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      const fmi3Boolean values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3SetStringTYPE (fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      const fmi3String values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      const fmi3String values[],
+                                      size_t nValues);
 
 typedef fmi3Status fmi3SetBinaryTYPE (fmi3Instance instance,
-                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                      const size_t sizes[], const fmi3Binary values[], size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      const size_t sizes[],
+                                      const fmi3Binary values[],
+                                      size_t nValues);
 /* end::Setters[] */
 
 /* Getting Variable Dependency Information */
@@ -409,38 +463,47 @@ typedef fmi3Status fmi3ExitConfigurationModeTYPE(fmi3Instance instance);
 /* Clock related functions */
 /* tag::GetClock[] */
 typedef fmi3Status fmi3GetClockTYPE(fmi3Instance instance,
-                                    const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                    const fmi3ValueReference valueReferences[],
+                                    size_t nValueReferences,
                                     fmi3Clock values[]);
 /* end::GetClock[] */
 
 /* tag::SetClock[] */
 typedef fmi3Status fmi3SetClockTYPE(fmi3Instance instance,
-                                    const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                    const fmi3Clock values[], const fmi3Boolean *subactive);
+                                    const fmi3ValueReference valueReferences[],
+                                    size_t nValueReferences,
+                                    const fmi3Clock values[],
+                                    const fmi3Boolean *subactive);
 /* end::SetClock[] */
 
 /* tag::GetIntervalDecimal[] */
 typedef fmi3Status fmi3GetIntervalDecimalTYPE(fmi3Instance instance,
-                                              const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                              const fmi3ValueReference valueReferences[],
+                                              size_t nValueReferences,
                                               fmi3Float64 interval[]);
 /* end::GetIntervalDecimal[] */
 
 /* tag::GetIntervalFraction[] */
 typedef fmi3Status fmi3GetIntervalFractionTYPE(fmi3Instance instance,
-                                               const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                               fmi3UInt64 intervalCounter[], fmi3UInt64 resolution[]);
+                                               const fmi3ValueReference valueReferences[],
+                                               size_t nValueReferences,
+                                               fmi3UInt64 intervalCounter[],
+                                               fmi3UInt64 resolution[]);
 /* end::GetIntervalFraction[] */
 
 /* tag::SetIntervalDecimal[] */
 typedef fmi3Status fmi3SetIntervalDecimalTYPE(fmi3Instance instance,
-                                              const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                              const fmi3ValueReference valueReferences[],
+                                              size_t nValueReferences,
                                               fmi3Float64 interval[]);
 /* end::SetIntervalDecimal[] */
 
 /* tag::SetIntervalFraction[] */
 typedef fmi3Status fmi3SetIntervalFractionTYPE(fmi3Instance instance,
-                                               const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                               fmi3UInt64 intervalCounter[], fmi3UInt64 resolution[]);
+                                               const fmi3ValueReference valueReferences[],
+                                               size_t nValueReferences,
+                                               fmi3UInt64 intervalCounter[],
+                                               fmi3UInt64 resolution[]);
 /* end::SetIntervalFraction[] */
 
 /* tag::NewDiscreteStates[] */


### PR DESCRIPTION
- apply one-sentence-per-line rule
- add underscores to every italic line
- remove excess line breaks
- fix double quotes vs. backticks
- add xrefs to literature