### PR TITLE
Fmi3 state names #705

### DIFF
--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -441,7 +441,7 @@ If `stopTimeDefined = fmi3False`, then no final value of the <<independent>> var
 include::../headers/fmi3FunctionTypes.h[tags=EnterConfigurationMode]
 ----
 
-Informs the FMU to enter the Configuration Mode or Reconfiguration Mode.
+Informs the FMU to enter the *Configuration Mode* or *Reconfiguration Mode*.
 
 [[fmi3ExitConfigurationMode,`fmi3ExitConfigurationMode`]]
 [source, C]
@@ -449,7 +449,7 @@ Informs the FMU to enter the Configuration Mode or Reconfiguration Mode.
 include::../headers/fmi3FunctionTypes.h[tags=ExitConfigurationMode]
 ----
 
-Informs the FMU to exit the Configuration Mode or Reconfiguration Mode.
+Informs the FMU to exit the *Configuration Mode* or *Reconfiguration Mode*.
 
 [[fmi3EnterInitializationMode,`fmi3EnterInitializationMode`]]
 [source, C]
@@ -457,7 +457,7 @@ Informs the FMU to exit the Configuration Mode or Reconfiguration Mode.
 include::../headers/fmi3FunctionTypes.h[tags=EnterInitializationMode]
 ----
 
-Informs the FMU to enter Initialization Mode.
+Informs the FMU to enter *Initialization Mode*.
 Before calling this function, all variables with attribute `<Variable <<initial>>` = <<exact>> or <<approx>>`>` can be set with the `fmi3SetXXX` functions (the `Variable` attributes are defined in the Model Description File, see <<definition-of-model-variables>>).
 Setting other variables is not allowed.
 Furthermore, <<fmi3SetupExperiment>> must be called at least once before calling <<fmi3EnterInitializationMode>>, in order that `startTime` is defined.
@@ -468,8 +468,8 @@ Furthermore, <<fmi3SetupExperiment>> must be called at least once before calling
 include::../headers/fmi3FunctionTypes.h[tags=ExitInitializationMode]
 ----
 
-Informs the FMU to exit Initialization Mode.
-For `fmuType = fmi3ModelExchange`, this function switches off all initialization equations, and the FMU enters Event Mode implicitly; that is, all continuous-time and active discrete-time equations are available.
+Informs the FMU to exit *Initialization Mode*.
+For `fmuType = fmi3ModelExchange`, this function switches off all initialization equations, and the FMU enters *Event Mode* implicitly; that is, all continuous-time and active discrete-time equations are available.
 
 [[fmi3Terminate,`fmi3Terminate`]]
 [source, C]
@@ -605,7 +605,7 @@ y_j=g_j(x_{j-1},u_j,t_j);
 Variables latexmath:[x_j] are called `states of a clocked partition`, or `discrete-time states` and latexmath:[j] is the latexmath:[j+1]th tick of the associated <<clock>>.
 Variables latexmath:[u_j] are the (external or <<local>>) <<input,`inputs`>> and latexmath:[y_j] are the (external or <<local>>) <<output,`outputs`>> of a clocked partition.
 A discrete-time <<state>> can be from any type of a Variable (with exception of a <<clock>>) such as of type `fmi3Float64` or `fmi3Boolean`.
-A clocked partition is not executed during initialization mode, but it is executed the first time at its first <<clock>> tick.
+A clocked partition is not executed during *Initialization Mode*, but it is executed the first time at its first <<clock>> tick.
 The associated <<clock>> of the model partion is synchronous to its discrete-time <<state,`states`>>.
 Discrete-time <<state,`states`>> are listed in the ModelStructure and have the Variable xml-attribute <<previous>> referring to the variable holding the previous value of the <<state>>.
 They can have initial values defined by xml-attributes <<initial>> and <<start>>, or the initial values are computed internally as a function of parameters.
@@ -708,7 +708,7 @@ _[This information can be used for emulating periodic <<inputClock,`input clocks
 
 If latexmath:[\Delta T] is fixed for an FMU and cannot be changed it is a strictly periodic <<clock>>.
 The <<clock>> is periodic, if latexmath:[\Delta T] can be defined before calling `fmi3EnterInitializationMode` via <<fmi3SetIntervalDecimal>> or <<fmi3SetIntervalFraction>>.
-The <<clock>> is aperiodic if latexmath:[\Delta T] is not constant during a simulation run (<<fmi3SetIntervalDecimal>> or <<fmi3SetIntervalFraction>> can be called for that <<clock>> during event mode).
+The <<clock>> is aperiodic if latexmath:[\Delta T] is not constant during a simulation run (<<fmi3SetIntervalDecimal>> or <<fmi3SetIntervalFraction>> can be called for that <<clock>> during *Event Mode*).
 
 ====== Clock Priority
 
@@ -824,17 +824,17 @@ The following table summarizes the use of the API functions by the environment f
 |<<inputClock,`Input clock`>>
 
 |_fmi3GetClock_
-|Call during event mode
-|Call during event mode
+|Call during *Event Mode*
+|Call during *Event Mode*
 
 |_fmi3SetClock_
-|Call only if recomputations of clock state are needed during event mode.
-|Call after entering event mode.
-Repeated calls if recomputations of clock state are needed during event mode.
+|Call only if recomputations of clock state are needed during *Event Mode*.
+|Call after entering *Event Mode*.
+Repeated calls if recomputations of clock state are needed during *Event Mode*.
 
 |_fmi3GetIntervalDecimal_ _fmi3GetIntervalFraction_
-|Call during event mode
-|Call during event mode
+|Call during *Event Mode*
+|Call during *Event Mode*
 
 |_fmi3SetIntervalDecimal_ _fmi3SetIntervalFraction_
 |Don't call.
@@ -946,9 +946,9 @@ The number of <<valueReference>>pass:[s] is given by the argument `nKnown`.
 
 - Argument `nDvUnknown` provides the number of values in `dvUnknown` which is only equal to `nUnknown` if all <<valueReference>>pass:[s] of `vrUnknown` point to variables.
 
-An FMU has different Modes and in every Mode an FMU might be described by different equations and different unknowns.
+An FMU has different modes and in every mode an FMU might be described by different equations and different unknowns.
 The precise definitions are given in the mathematical descriptions of Model Exchange (<<math-model-exchange>>) and Co-Simulation (<<math-co-simulation>>).
-In every Mode, the general form of the FMU equations are:
+In every mode, the general form of the FMU equations are:
 
 [latexmath]
 ++++
@@ -957,24 +957,24 @@ In every Mode, the general form of the FMU equations are:
 
 where
 
-* latexmath:[\color{blue}{\mathbf{v}_{unknown}}] is the vector of unknown Real variables computed in the actual Mode:
+* latexmath:[\color{blue}{\mathbf{v}_{unknown}}] is the vector of unknown Real variables computed in the actual mode:
 
-** Initialization Mode: The exposed unknowns listed under `<ModelStructure><InitialUnknowns>` that have type Real.
+** *Initialization Mode*: The exposed unknowns listed under `<ModelStructure><InitialUnknowns>` that have type Real.
 
-** Continuous-Time Mode (Model Exchange): The continuous-time outputs and state derivatives (= the variables listed under `<ModelStructure><Outputs>` with type Real and <<variability>> = <<continuous>> and the variables listed as state derivatives under `<ModelStructure><Derivatives>`).
+** *Continuous-Time Mode* (Model Exchange): The continuous-time outputs and state derivatives (= the variables listed under `<ModelStructure><Outputs>` with type Real and <<variability>> = <<continuous>> and the variables listed as state derivatives under `<ModelStructure><Derivatives>`).
 
-** Event Mode (Model Exchange): The same variables as in the Continuous-Time Mode and additionally variables under `<ModelStructure><Outputs>` with type Real and <<variability>> = <<discrete>>.
+** *Event Mode* (Model Exchange): The same variables as in the *Continuous-Time Mode* and additionally variables under `<ModelStructure><Outputs>` with type Real and <<variability>> = <<discrete>>.
 
-** Step Mode (Co-Simulation): The variables listed under `<ModelStructure><Outputs>` with type Real and <<variability>> = <<continuous>> or <<discrete>>.
+** *Step Mode* (Co-Simulation): The variables listed under `<ModelStructure><Outputs>` with type Real and <<variability>> = <<continuous>> or <<discrete>>.
 If `<ModelStructure><Derivatives>` is present, also the variables listed here as state derivatives.
 
-* latexmath:[\color{blue}{\mathbf{v}_{known}}] is the vector of Real <<input>> variables of function *h* that changes its value in the actual Mode.
+* latexmath:[\color{blue}{\mathbf{v}_{known}}] is the vector of Real <<input>> variables of function *h* that changes its value in the actual mode.
 Details are described in the description of element <<dependencies>> in <<ModelStructure>>.
-_[For example continuous-time <<input,`inputs`>> in Continuous-Time Mode._
+_[For example continuous-time <<input,`inputs`>> in *Continuous-Time Mode*._
 _If a variable with <<causality>> = <<independent>> is explicitly defined under `Variable`pass:[s], a directional derivative with respect to this variable can be computed._
 _If such a variable is not defined, the directional derivative with respect to the <<independent>> variable cannot be calculated]._
 
-* latexmath:[\color{blue}{\mathbf{v}_{rest}}] is the set of <<input>> variables of function *h* that either changes its value in the actual Mode but are non-Real variables, or do not change their values in this Mode, but change their values in other Modes _[for example, discrete-time <<input,`inputs`>> in Continuous-Time Mode]_.
+* latexmath:[\color{blue}{\mathbf{v}_{rest}}] is the set of <<input>> variables of function *h* that either changes its value in the actual mode but are non-Real variables, or do not change their values in this mode, but change their values in other modes _[for example, discrete-time <<input,`inputs`>> in *Continuous-Time Mode*]_.
 
 If the capability attribute `providesDirectionalDerivative = true`, <<fmi3GetDirectionalDerivative>> computes a linear combination of the partial derivatives of *h* with respect to the selected <<input>> variables latexmath:[\color{blue}{\mathbf{v}_{known}}]:
 
@@ -986,8 +986,8 @@ If the capability attribute `providesDirectionalDerivative = true`, <<fmi3GetDir
 Accordingly, it computes the directional derivative vector latexmath:[\color{blue}{\Delta \mathbf{v}_{unknown}}] (`dvUnknown`) from the seed vector latexmath:[\color{blue}{\Delta \mathbf{v}_{known}}] (`dvKnown`)
 
 _[The variable relationships are different in different modes._
-_For example, during Continuous-Time Mode, a continuous-time output y does not depend on discrete-time <<input,`inputs`>> (because they are held constant between events)._
-_However, at Event Mode, y depends on discrete-time <<input,`inputs`>>._
+_For example, during *Continuous-Time Mode*, a continuous-time output y does not depend on discrete-time <<input,`inputs`>> (because they are held constant between events)._
+_However, at *Event Mode*, y depends on discrete-time <<input,`inputs`>>._
 _The function may compute the directional derivatives by numerical differentiation taking into account the sparseness of the equation system, or (preferred) by analytic derivatives._
 
 _Example:_ +

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -124,7 +124,7 @@ These definitions are used in the XML element `ModelVariables`.
 
 |`ModelStructure`
 |Defines the structure of the model.
-Especially, the ordered lists of <<output,`outputs`>>, continuous-time <<state,`states`>> and initial unknowns (the unknowns during Initialization Mode) are defined here.
+Especially, the ordered lists of <<output,`outputs`>>, continuous-time <<state,`states`>> and initial unknowns (the unknowns during *Initialization Mode*) are defined here.
 Furthermore, the dependency of the unkowns from the knowns can be optionally defined.
 _[This information can be, for example, used to compute efficiently a sparse Jacobian for simulation, or to utilize the <<input>> / <<output>> dependency in order to detect that in some cases there are actually no algebraic loops when connecting FMUs together]_.
 |====
@@ -1289,7 +1289,7 @@ Examples: (a) automatic tests of FMUs are performed, and the FMU is tested by pr
 If the <<input>> variable is iteration variable of this algebraic loop, then initialization starts with its <<start>> value.]_
 
 If <<causality>> = <<input>> the value for <<initial>> has to be set to <<exact>> and it is required to provide a <<start>> value for describing the expected initial contidion of master <<clock,`clocks`>> for that FMU.
-If an <<inputClock>> has `fmi3True` as an <<start>> value the master should activate the <<clock>> the first time it enters event mode.
+If an <<inputClock>> has `fmi3True` as an <<start>> value the master should activate the <<clock>> the first time it enters *Event Mode*.
 The master can nevertheless choose different <<start>> values if it is not possible to fulfill the conditions in a simulation setup.
 
 If <<causality>> = <<output>> the <<initial>> attribute value is set to <<calculated>> and no <<start>> value is provided.
@@ -1503,7 +1503,7 @@ with
 
 _[Note: (1) If <<causality>> = <<independent>>, it is neither allowed to define a value for <<initial>> nor a value for start._
 _(2) If <<causality>> = <<input>>, it is not allowed to define a value for <<initial>> and a value for <<start>> must be defined._
-_(3) If \(C) and <<initial>> = <<exact>>, then the variable is explicitly defined by its <<start>> value in Initialization Mode (so directly after calling <<fmi3ExitInitializationMode>>, the value of the variable is either the <<start>> value stored in element `<Variable><XXX start=YYY/>` or the value provided by `fmi3SetXXX`, if this function was called on this variable).]_
+_(3) If \(C) and <<initial>> = <<exact>>, then the variable is explicitly defined by its <<start>> value in *Initialization Mode* (so directly after calling <<fmi3ExitInitializationMode>>, the value of the variable is either the <<start>> value stored in element `<Variable><XXX start=YYY/>` or the value provided by `fmi3SetXXX`, if this function was called on this variable).]_
 
 The following combinations of <<variability>>/<<causality>> settings are allowed:
 
@@ -1694,11 +1694,11 @@ _Usually, this is `time`_
 
 >|_[green]#(16)#_
 |_<<fixed>> structual <<parameter>>_
-|_<<parameter,`Paramter`>> used in  `Dimension` element;  can be changed before initialization in *Configuration Mode* state_
+|_<<parameter,`Paramter`>> used in  `Dimension` element;  can be changed before initialization in *Configuration Mode*_
 
 >|_[green]#(17)#_
 |_<<tunable>> structual <<parameter>>_
-|_<<parameter,`Parameter`>> used in  `Dimension` element;  can be changed before initialization in *Configuration Mode* and in in *Reconfiguration Mode* state_
+|_<<parameter,`Parameter`>> used in  `Dimension` element;  can be changed before initialization in *Configuration Mode* and in in *Reconfiguration Mode*_
 
 >|_[green]#(18)#_
 |_<<clock>>_
@@ -1718,7 +1718,7 @@ _Instead, this is a short hand notation for:_
 
 . _Stop the simulation at an event instant (usually, a step event, in other words, after a successful integration step)._
 
-. _Change the values of the <<tunable>> (structural) <<parameter,`parameters`>>. For <<tunable>> <<structuralParameter,`structural parameters`>>, the *Reconfiguration Mode* state must be entered before and left afterwards._
+. _Change the values of the <<tunable>> (structural) <<parameter,`parameters`>>. For <<tunable>> <<structuralParameter,`structural parameters`>>, the *Reconfiguration Mode* must be entered before and left afterwards._
 
 . _Compute all <<parameter,`parameters`>> (and sizes of variables, <<state,`states`>>, <<derivative,`derivatives`>>, event indicators, ...) that depend on the <<tunable>> (structural) <<parameter,`parameters`>>._
 
@@ -1728,7 +1728,7 @@ _Basically this means that a new simulation run is started from the previous FMU
 _With this interpretation, changing <<parameter,`parameters`>> online is "clean", as long as these changes appear at an event instant._
 
 _FMI for Co-Simulation:_
-_Changing of <<tunable>> <<parameter,`parameters`>> is allowed before an <<fmi3DoStep>> call (so, whenever an <<input>> can be set with `fmi3SetXXX`) and before <<fmi3ExitInitializationMode>> is called (that is before and during Initialization Mode)._
+_Changing of <<tunable>> <<parameter,`parameters`>> is allowed before an <<fmi3DoStep>> call (so, whenever an <<input>> can be set with `fmi3SetXXX`) and before <<fmi3ExitInitializationMode>> is called (that is before and during *Initialization Mode*)._
 _The FMU internally carries out event handling if necessary.]_
 
 ===== Aliasing of Variables [[aliasing-of-variables]]
@@ -1888,8 +1888,8 @@ _[Note that all <<output>> variables are listed here, especially <<discrete>> an
 _The ordering of the variables in this list is defined by the exporting tool._
 _Usually, it is best to order according to the declaration order in the source model, since then the `Outputs` list does not change if the declaration order of <<output,`outputs`>> in the source model is not changed._
 _This is for example, important for linearization, in order that the interpretation of the output vector does not change for a re-exported FMU.]_
-Attribute <<dependencies>> defines the dependencies of the <<output,`outputs`>> from the knowns at the current super dense time instant in Event and in Continuous-Time Mode (Model Exchange) and at the current communication point (Co-Simulation).
-The functional dependency is defined as (dependencies of variables that are fixed in Event and Continuous-Time Mode and at communication points are not shown): +
+Attribute <<dependencies>> defines the dependencies of the <<output,`outputs`>> from the knowns at the current super dense time instant in Event and in *Continuous-Time Mode* (Model Exchange) and at the current communication point (Co-Simulation).
+The functional dependency is defined as (dependencies of variables that are fixed in Event and *Continuous-Time Mode* and at communication points are not shown): +
 [blue]#latexmath:[\color{blue}{(\mathbf{y}_c, \mathbf{y}_d) := \mathbf{f}_{output}(\mathbf{x}_c, \mathbf{u}_c, \mathbf{u}_d, t, \mathbf{p}_{tune})}]#
 
 |`Derivatives`
@@ -1907,14 +1907,14 @@ _[This is the default._
 _If an FMU supports both Model Exchange and Co-Simulation, then the `Derivatives` element might be present, since it is needed for Model Exchange._
 _If the above flag is set to `false` for the Co-Simulation case, then the `Derivatives` element is ignored for Co-Simulation._
 _If "inline integration" is used for a Co-Simulation slave, then the model still has continuous-time <<state,`states`>> and just a special solver is used (internally the implementation results in a discrete-time system, but from the outside, it is still a continuous-time system).]_ +
-Attribute <<dependencies>> defines the dependencies of the state derivatives from the knowns at the current super dense time instant in Event and in Continuous-Time Mode (Model Exchange) and at the current communication point (Co-Simulation).
-The functional dependency is defined as (dependencies of variables that are fixed in Event and Continuous-Time Mode and at communication points are not shown): +
+Attribute <<dependencies>> defines the dependencies of the state derivatives from the knowns at the current super dense time instant in Event and in *Continuous-Time Mode* (Model Exchange) and at the current communication point (Co-Simulation).
+The functional dependency is defined as (dependencies of variables that are fixed in Event and *Continuous-Time Mode* and at communication points are not shown): +
 [blue]#latexmath:[\color{blue}{\dot{\mathbf{x}_c} := \mathbf{f}_{der}(\mathbf{x}_c, \mathbf{u}_c, \mathbf{u}_d, t, \mathbf{p}_{tune})}]#
 
 |`InitialUnknowns`
 a|
 [[InitialUnknowns,`InitialUnknowns`]]
-Ordered list of all exposed <<Unknown,`Unknowns`>> in Initialization Mode.
+Ordered list of all exposed <<Unknown,`Unknowns`>> in *Initialization Mode*.
 This list consists of all variables with
 
 . <<causality>> = <<output>> and (<<initial>> = <<approx>> or <<calculated>>), and
@@ -1924,12 +1924,12 @@ This list consists of all variables with
 . all continuous-time <<state,`states`>> and all state derivatives (defined with element `<Derivatives>` from `<ModelStructure>`) with <<initial>> = <<approx>> or <<calculated>> _[if a Co-Simulation FMU does not define the <Derivatives> element, (3) cannot be present]_.
 
 The resulting list is not allowed to have duplicates (for example, if a <<state>> is also an <<output>>, it is included only once in the list). +
-Attribute <<dependencies>> defines the dependencies of the <<Unknown,`Unknowns`>> from the `Knowns` in Initialization Mode at the initial time.
+Attribute <<dependencies>> defines the dependencies of the <<Unknown,`Unknowns`>> from the `Knowns` in *Initialization Mode* at the initial time.
 The functional dependency is defined as:
 
 [blue]#latexmath:[\color{blue}{\dot{\mathbf{v}}_{initialUnknowns} := \mathbf{f}_{init}(\mathbf{u}_c, \mathbf{u}_d, t_0, \mathbf{v}_{initial=exact})}]#
 
-Since, <<output,`outputs`>>, continuous-time <<state,`states`>> and state derivatives are either present as `Knowns` (if <<initial>> = <<exact>>) or as <<Unknown,`Unknowns`>> (if <<initial>> = <<approx>> or <<calculated>>), they can be inquired with `fmi3GetXXX` in InitializationMode.
+Since, <<output,`outputs`>>, continuous-time <<state,`states`>> and state derivatives are either present as `Knowns` (if <<initial>> = <<exact>>) or as <<Unknown,`Unknowns`>> (if <<initial>> = <<approx>> or <<calculated>>), they can be inquired with `fmi3GetXXX` in *Initialization Mode*.
 
 _[Example: Assume an FMU is defined in the following way:_
 
@@ -1952,9 +1952,9 @@ where
 
 - latexmath:[\color{blue}{v_{unknown}}] is the unknown variable defined with this element _[for example, an <<output>> or a state derivative]._
 
-- latexmath:[\color{blue}{\mathbf{v}_{known}}] is the vector of input arguments of function `h` that changes its value in the actual Mode _[for example, continuous-time <<input,`inputs`>> in Continuous-Time Mode]_.
+- latexmath:[\color{blue}{\mathbf{v}_{known}}] is the vector of input arguments of function `h` that changes its value in the actual mode _[for example, continuous-time <<input,`inputs`>> in *Continuous-Time Mode*]_.
 
-- latexmath:[\color{blue}{\mathbf{v}_{freeze}}] is the set of input arguments of function `h` that do not change their values in this Mode, but change their values in other Modes _[for example, <<fixed>> <<parameter,`parameters`>> in Continuous-Time Mode]_.
+- latexmath:[\color{blue}{\mathbf{v}_{freeze}}] is the set of input arguments of function `h` that do not change their values in this mode, but change their values in other modes _[for example, <<fixed>> <<parameter,`parameters`>> in *Continuous-Time Mode*]_.
 
 Attribute <<dependencies>> of <<Unknown>> defines the dependency of latexmath:[\color{blue}{v_{unknown}}] with respect to latexmath:[\color{blue}{\mathbf{v}_{known}}]. +
 _[If, for example, a continuous-time <<output>>_ latexmath:[\color{blue}{y_{2}}] _is a function of the continuous-time <<input,`inputs`>>_ latexmath:[\color{blue}{u_{3}}] _and_ latexmath:[\color{blue}{u_{5}}], _and these <<input,`inputs`>> have changed, then_ `fmi3SetXXX` _on_ latexmath:[\color{blue}{u_{3}}] _and_ latexmath:[\color{blue}{u_{5}}] _must always be called before calling_ `fmi3GetXXX` _on_ latexmath:[\color{blue}{y_{2}}] _.]_
@@ -1992,7 +1992,7 @@ Optional attribute defining the dependencies of the unknown latexmath:[\color{bl
 If not present, it must be assumed that the <<Unknown>> depends on all `Knowns`.
 If present as empty list, the <<Unknown>> depends on none of the `Knowns`.
 Otherwise the <<Unknown>> depends on the `Knowns` defined by the given `Variable` value references. +
-`Knowns` latexmath:[\color{blue}{\mathbf{v}_{\text{known}}}] in Event and Continuous-Time Mode (Model Exchange) and at communication points (Co-Simulation) for elements `Outputs`, `Derivatives`:
+`Knowns` latexmath:[\color{blue}{\mathbf{v}_{\text{known}}}] in Event and *Continuous-Time Mode* (Model Exchange) and at communication points (Co-Simulation) for elements `Outputs`, `Derivatives`:
 
 - inputs (variables with <<causality>> = <<input>>)
 
@@ -2001,7 +2001,7 @@ Otherwise the <<Unknown>> depends on the `Knowns` defined by the given `Variable
 - <<independent>> variable (usually time; <<causality>> = <<independent>>).
 If an <<independent>> variable is not explicitly defined under `Variable`pass:[s], it is assumed that the <<Unknown>> depends explicitly on the <<independent>> variable.
 
-`Knowns` latexmath:[\color{blue}{\mathbf{v}_{\text{known}}}] in Initialization Mode (for elements <<InitialUnknowns>>):
+`Knowns` latexmath:[\color{blue}{\mathbf{v}_{\text{known}}}] in *Initialization Mode* (for elements <<InitialUnknowns>>):
 
 - inputs (variables with <<causality>> = <<input>>)
 
@@ -2031,13 +2031,13 @@ Only for Real unknowns latexmath:[\color{blue}{v_{\text{unknown}}}]:
 
 `=` <<constant>>: constant factor, latexmath:[\color{blue}{c \cdot v_{known,i}}] where latexmath:[\color{blue}{c}] is an expression that is evaluated before <<fmi3EnterInitializationMode>> is called.
 
-Only for Real unknowns latexmath:[\color{blue}{v_{\text{unknown}}}] in Event and Continuous-Time Mode (Model Exchange) and at communication points (Co-Simulation), and not for <<InitialUnknowns>> for Initialization Mode:
+Only for Real unknowns latexmath:[\color{blue}{v_{\text{unknown}}}] in Event and *Continuous-Time Mode* (Model Exchange) and at communication points (Co-Simulation), and not for <<InitialUnknowns>> for *Initialization Mode*:
 
 `=` <<fixed>>: fixed factor, latexmath:[\color{blue}{p \cdot v_{known,i}}] where latexmath:[\color{blue}{p}] is an expression that is evaluated before <<fmi3ExitInitializationMode>> is called.
 
-`=` <<tunable>>: tunable factor, latexmath:[\color{blue}{p \cdot v_{known,i}}] where latexmath:[\color{blue}{p}] is an expression that is evaluated before <<fmi3ExitInitializationMode>> is called and in Event Mode due to an external event (Model Exchange) or at a communication point (Co-Simulation)
+`=` <<tunable>>: tunable factor, latexmath:[\color{blue}{p \cdot v_{known,i}}] where latexmath:[\color{blue}{p}] is an expression that is evaluated before <<fmi3ExitInitializationMode>> is called and in *Event Mode* due to an external event (Model Exchange) or at a communication point (Co-Simulation)
 
-`=` <<discrete>>: discrete factor, latexmath:[\color{blue}{d \cdot v_{known,i}}] where latexmath:[\color{blue}{d}] is an expression that is evaluated before <<fmi3ExitInitializationMode>> is called and in Event Mode due to an external or internal event or at a communication point (Co-Simulation).
+`=` <<discrete>>: discrete factor, latexmath:[\color{blue}{d \cdot v_{known,i}}] where latexmath:[\color{blue}{d}] is an expression that is evaluated before <<fmi3ExitInitializationMode>> is called and in *Event Mode* due to an external or internal event or at a communication point (Co-Simulation).
 
 If <<dependenciesKind>> is present, <<dependencies>> must be present and must have the same number of list elements.
 |====
@@ -2115,7 +2115,7 @@ _The definition of the model structure is then:_
 include::examples/model_structure_example2.xml[tags=ModelStructure]
 ----
 
-_[Note that_ latexmath:[\color{blue}{y = d \cdot u}] _where_ latexmath:[\color{blue}{d}] _changes only during Event Mode (_ latexmath:[\color{blue}{d = 2 \cdot u}] _or_ latexmath:[\color{blue}{3 \cdot u\ }] _depending on relation_ latexmath:[\color{blue}{u > 0}] _that changes only at Event Mode)._
+_[Note that_ latexmath:[\color{blue}{y = d \cdot u}] _where_ latexmath:[\color{blue}{d}] _changes only during *Event Mode* (_ latexmath:[\color{blue}{d = 2 \cdot u}] _or_ latexmath:[\color{blue}{3 \cdot u\ }] _depending on relation_ latexmath:[\color{blue}{u > 0}] _that changes only at *Event Mode*)._
 _Therefore <<dependenciesKind>> = <<discrete>>.]_
 
 _Example 3:_
@@ -2136,7 +2136,7 @@ _The definition of the model structure is then:_
 include::examples/model_structure_example3.xml[tags=ModelStructure]
 ----
 
-_[Note that_ latexmath:[\color{blue}{y = c}] _where_ latexmath:[\color{blue}{c}] _changes only during Event Mode (_ latexmath:[\color{blue}{c = 2}] _or_ latexmath:[\color{blue}{3\ }] _depending on relation_ latexmath:[\color{blue}{u > 0}] _that changes only at Event Mode)._
+_[Note that_ latexmath:[\color{blue}{y = c}] _where_ latexmath:[\color{blue}{c}] _changes only during *Event Mode* (_ latexmath:[\color{blue}{c = 2}] _or_ latexmath:[\color{blue}{3\ }] _depending on relation_ latexmath:[\color{blue}{u > 0}] _that changes only at *Event Mode*)._
 _Therefore <<dependenciesKind>> = <<dependenciesKind,`dependent`>> because it is not a linear relationship on_ latexmath:[\color{blue}{u}]. _]_
 
 _Defining FMU features with the_ <<dependencies>> _list:_
@@ -2144,12 +2144,12 @@ _Defining FMU features with the_ <<dependencies>> _list:_
 _[Note that via the <<dependencies>> list the supported features of the FMU can be defined._
 _Examples:_
 
-- _If a state derivative `der_x` is a function of a <<parameter>> p (so of a <<start>> value of a variable with <<causality>> = <<parameter>> and <<variability>> = <<fixed>>), and the FMU does not support an iteration over `p` during `InitializationMode` (for example, to iterate over p such that the state derivative `der_x` is zero), then the <<dependencies>> list of `der_x` should not include `p`._
+- _If a state derivative `der_x` is a function of a <<parameter>> p (so of a <<start>> value of a variable with <<causality>> = <<parameter>> and <<variability>> = <<fixed>>), and the FMU does not support an iteration over `p` during *Initialization Mode* (for example, to iterate over p such that the state derivative `der_x` is zero), then the <<dependencies>> list of `der_x` should not include `p`._
 _If an FMU is imported in an environment and such an iteration is set up, then the tool can figure out that the resulting algebraic system of equations is structurally singular and therefore can reject such a definition._
 
 - _For standard Co-Simulation FMUs, it is common that no algebraic loops over the <<input>> / <<output>> variables nor over start-values is supported._
 _In such a case, all <<dependencies>> lists for <<output>> variables under the <<InitialUnknowns>> element should be defined as empty lists defining that the setting of <<input,`inputs`>> and/or of <<start>> values does not influence the <<output,`outputs`>>._
-_As a result, it is not possible to formulate algebraic loops of connected FMUs during InitializationMode.]_
+_As a result, it is not possible to formulate algebraic loops of connected FMUs during *Initialization Mode*.]_
 
 ==== Variable Naming Conventions (variableNamingConvention) [[variableNamingConvention]]
 

--- a/docs/3_1_model_exchange_math.adoc
+++ b/docs/3_1_model_exchange_math.adoc
@@ -184,8 +184,8 @@ Every event removes automatically a previous definition of latexmath:[T_{next}],
 
 ^|latexmath:[\mathbf{r}(t_i)]
 |A vector of Boolean variables with latexmath:[r_{i} := z_{i} > 0].
-When entering Continuous-Time Mode all relations reported via the event indicators latexmath:[\mathbf{z}] are fixed and during this Mode these relations are replaced by latexmath:[\mathbf{r}].
-Only during Initialization or Event Mode the domains latexmath:[z_{i} > 0] can be changed.
+When entering *Continuous-Time Mode* all relations reported via the event indicators latexmath:[\mathbf{z}] are fixed and during this mode these relations are replaced by latexmath:[\mathbf{r}].
+Only during *Initialization Mode* or *Event Mode* the domains latexmath:[z_{i} > 0] can be changed.
 For notational convenience, latexmath:[\mathbf{r} := \mathbf{z} > 0]is an abbreviation for latexmath:[\mathbf{r}:=\{z_1>0, z_2>0, \ldots \}].
 _[For more details, see "Remark 3" below.]_
 |====
@@ -195,14 +195,14 @@ _[For more details, see "Remark 3" below.]_
 Computing the solution of an FMI model means to split the solution process in different phases, and in every phase different equations and solution methods are utilized.
 The phases can be categorized according to the following modes:
 
-Initialization Mode::
+===== Initialization Mode
 This mode is used to compute at the start time stem[t_0] initial values for continuous-time <<state,`states`>>, latexmath:[\mathbf{x}_c(t_0)], and for the <<previous>> (internal) discrete-time <<state,`states`>>, latexmath:[\mathbf{x}_d(t_0)], by utilizing extra equations not present in the other modes (for example, equations to define the <<start>> value for a <<state>> or for the derivative of a <<state>>).
 
-Continuous-Time Mode::
+===== Continuous-Time Mode
 This mode is used to compute the values of all (real) continuous-time variables between events by numerically solving ordinary differential and algebraic equations.
 All discrete-time variables are fixed during this phase and the corresponding discrete-time equations are not evaluated.
 
-Event Mode::
+===== Event Mode
 This mode is used to compute new values for all continuous-time variables, as well as for all discrete-time variables that are activated at the current event instant latexmath:[t], given the values of the variables from the <<previous>> instant latexmath:[{}^{\bullet}t].
 This is performed by solving algebraic equations consisting of all continuous-time and all active discrete-time equations.
 In FMI 2.0 there is no mechanism that the FMU can provide the information whether a discrete-time variable is active or is not active (is not computed) at an event instant.
@@ -225,10 +225,10 @@ _This loop might be solved iteratively with a Newton method._
 _In every iteration the iteration variable latexmath:[u_4] is provided by the solver, and via the shown sequence of `fmi3SetXXX` and `fmi3GetXXX` calls, the residue is computed and is provided back to the solver._
 _Based on the residue a new value of latexmath:[u_4] is provided._
 _The iteration is terminated when the residue is close to zero._
-_These types of artifical or real algebraic loops can occur in all the different modes, such as Initialization Mode, Event Mode, and Continuous-Time Mode._
-_Since different variables are computed in every Mode and the causality of variable computation can be different in Initialization Mode as with respect to the other two Modes, it might be necessary to solve different kinds of loops in the different Modes.]_
+_These types of artifical or real algebraic loops can occur in all the different modes, such as *Initialization Mode*, *Event Mode*, and *Continuous-Time Mode*._
+_Since different variables are computed in every mode and the causality of variable computation can be different in *Initialization Mode* as with respect to the other two modes, it might be necessary to solve different kinds of loops in the different modes.]_
 
-In <<table-math-model-exchange>> the equations are defined that can be evaluated in the respective Mode.
+In <<table-math-model-exchange>> the equations are defined that can be evaluated in the respective mode.
 The following color coding is used in the table:
 
 * [silver]#*grey*#: If a variable in an argument list is marked in [silver]#grey#, then this variable is not changing in this mode and just the last calculated value from the previous mode is internally used.
@@ -253,18 +253,18 @@ _However, super-dense time defines precisely when a new "model evaluation" start
 |Set <<independent>> variable time latexmath:[T_{R0}] and define latexmath:[t_0 := (t_{R0},0)]|<<fmi3SetupExperiment>>
 |Set variables latexmath:[\mathbf{v}_{initial=exact}] and latexmath:[\mathbf{v}_{initial=approx}]  that have a <<start>> value (<<initial>> = <<exact>> or <<approx>>) |`fmi3SetXXX`
 2+|*_Equations during Initialization Mode_*
-|[lime]#Enter Initialization Mode at latexmath:[t=t_0] (activate initialization,
+|[lime]#Enter *Initialization Mode* at latexmath:[t=t_0] (activate initialization,
 discrete-time and continuous-time equations)#| `[lime]#fmi3EnterInitializationMode#`
 |Set variables latexmath:[\mathbf{v}_{initial=exact}] that have a <<start>> value with
 <<initial>> = <<exact>> (<<independent>> <<parameter,`parameters`>> latexmath:[\mathbf{p}] and
 continuous-time <<state,`states`>> with <<start>> values latexmath:[\mathbf{x}_{c,initial=exact}] are included here) | `fmi3SetXXX`
 |Set continuous-time and discrete-time <<input,`inputs`>>  latexmath:[\mathbf{u}(\color{grey}t_{\color{grey} 0})]| `fmi3SetXXX`
 |[blue]#latexmath:[\mathbf{v}_{initialUnknowns}:=f_{init}(\mathbf{u_c}, \mathbf{u_d}, \color{grey}t_{\color{grey} 0}, \mathbf{v}_{initial=exact}])# | `[blue]#fmi3GetXXX#`, `[blue]#fmi3GetContinuousStates#`
-|[lime]#Exit Initialization Mode (de-activate initialization equations)#| `[lime]#fmi3ExitInitializationMode#`
+|[lime]#Exit *Initialization Mode* (de-activate initialization equations)#| `[lime]#fmi3ExitInitializationMode#`
 2+|*_Equations during Event Mode_*
-|[lime]#Enter Event Mode at latexmath:[t = t_{i}] with latexmath:[{t_{i}\ : = (t}_{R},t_{I} + 1)] *if*  externalEvent *or* nextMode latexmath:[\equiv] EventMode *or* latexmath:[t_i=(T_{next}(t_{i-1}), 0)] *or*  latexmath:[\min_{t>t_{i-1}} t:\left\lbrack z_{j}\left( t \right) > 0\  \neq \ z_{j}\left( t_{i - 1} \right) > 0 \right\rbrack] +
+|[lime]#Enter *Event Mode* at latexmath:[t = t_{i}] with latexmath:[{t_{i}\ : = (t}_{R},t_{I} + 1)] *if*  externalEvent *or* nextMode latexmath:[\equiv] EventMode *or* latexmath:[t_i=(T_{next}(t_{i-1}), 0)] *or*  latexmath:[\min_{t>t_{i-1}} t:\left\lbrack z_{j}\left( t \right) > 0\  \neq \ z_{j}\left( t_{i - 1} \right) > 0 \right\rbrack] +
 (activate discrete-time equations)#|
-`[lime]#fmi3EnterInitializationMode#` [lime]#(only from Continuous-Time Mode or after calling# `[lime]#fmi3SetTime#`
+`[lime]#fmi3EnterInitializationMode#` [lime]#(only from *Continuous-Time Mode* or after calling# `[lime]#fmi3SetTime#`
 [lime]#if FMU has no continuous-time equations)#
 |Set <<independent>> <<tunable>> <<parameter,`parameters`>> latexmath:[\mathbf{p}_{tune}] +
 (and do not set other <<parameter,`parameters`>> latexmath:[\mathbf{p}_{other}])
@@ -293,7 +293,7 @@ latexmath:[\qquad \qquad T_{next}=T_{next}(\mathbf{x}_c,{}^\bullet\mathbf{x}_d, 
 |Set <<independent>> variable time latexmath:[t_i := (T_{next},0)]| <<fmi3SetTime>> +
 (if no continuous-time equations)
 2+|*_Equations during Continuous-Time Mode_*
-|[lime]#Enter Continuous-Time Mode:# +
+|[lime]#Enter *Continuous-Time Mode*:# +
 [lime]#latexmath:[\qquad \textrm{// de-activate discrete-time equations}]# +
 [lime]#latexmath:[\qquad \textrm{// "freeze" variables:}]# +
 [lime]#latexmath:[\qquad \mathbf{r} := \mathbf{z}>0 \qquad \textrm{//all relations}]# +
@@ -327,7 +327,7 @@ latexmath:[\mathbf{f}_{init}, \mathbf{f}_{sim} \in C^0] (=continuous functions w
 
 _[Remark 1 - Calling Sequences:_
 
-_In the table above, for notational convenience in every Mode one function call is defined to compute all output arguments from all inputs arguments._
+_In the table above, for notational convenience in every mode one function call is defined to compute all output arguments from all inputs arguments._
 _In reality, every scalar output argument is computed by one `fmi3GetXXX` function call._
 _Additionally, the output argument need not be a function of all input arguments, but of only a subset from it, as defined in the XML file under `<ModelStructure>`._
 _This is essential when FMUs are connected in a loop, as shown in <<figure-connected-fmus>>. For example, since_ latexmath:[y_{2a}] _depends only on_ latexmath:[u_{1a}] _, but not on_ latexmath:[u_{1b}]_, it is possible to call_ `fmi3SetXXX` _to set_ latexmath:[u_{1a}] _, and then inquire_ latexmath:[y_{2a}] _with_ `fmi3GetXXX` _without setting_ latexmath:[u_{1b}] _beforehand._
@@ -399,8 +399,8 @@ _This restriction is communicated to the environment of the FMU by the `ScalarVa
 _Remark 3 - Event Indicators / Freezing Relations:_
 
 _In the above table, vector_ *r* _is used to collect all relations together that are utilized in the event indicators_ **z** _.
-_In Continuous-Time Mode all these relations are `frozen` and do not change during the evaluations in the respective Mode._
-_This is indicated in the table above by computing_ *r* _when entering the Continuous-Time Mode and providing_ *r* _as (internal) input argument to the evaluation functions._
+_In *Continuous-Time Mode* all these relations are `frozen` and do not change during the evaluations in the respective mode._
+_This is indicated in the table above by computing_ *r* _when entering the *Continuous-Time Mode* and providing_ *r* _as (internal) input argument to the evaluation functions._
 _Example:_
 
 _An equation of the form_
@@ -414,15 +414,15 @@ _can be implemented in the FMU as:_
 ----
 z1 := x1 - x2;
 z2 := x3 - x1;
-if InitializationMode or EventMode then
+if *Initialization Mode* or *Event Mode* then
   r1 := z1 > 0;
   r2 := z2 > 0;
 end if;
 y = if r1 or r2 then +1 else -1
 ----
 
-_Therefore, the original if-clause is evaluated in this form only during Initialization and Event Mode._
-_In Continuous-Time Mode this equation is evaluated as:_
+_Therefore, the original if-clause is evaluated in this form only during *Initialization Mode* and *Event Mode*._
+_In *Continuous-Time Mode* this equation is evaluated as:_
 
 ----
 z1 = x1 - x2;
@@ -430,7 +430,7 @@ z2 = x3 - x1
 y = if r1 or r2 then +1 else -1;
 ----
 
-_and when entering Continuous-Time Mode r1 and r2 are computed as_
+_and when entering *Continuous-Time Mode* r1 and r2 are computed as_
 
 ----
 r1 = z1 > 0
@@ -452,15 +452,15 @@ _Remark 4 - Pure Discrete-Time FMUs:_
 
 _If an FMU has only discrete-time equations (and no variables with <<variability>> = <<continuous>>), then the environment need not to call <<fmi3EnterContinuousTimeMode>> but can directly call <<fmi3SetTime>> to set the value of the next event instant, before <<fmi3EnterEventMode>> is called.]_
 
-An FMU is initialized in Initialization Mode with latexmath:[\mathbf{f}_{init}(\ldots)].
+An FMU is initialized in *Initialization Mode* with latexmath:[\mathbf{f}_{init}(\ldots)].
 The input arguments to this function consist of the <<input>> variables (= variables with <<causality>> = <<input>>), of the <<independent>> variable (= variable with <<causality>> = <<independent>>; usually the default value `time`), and of all variables that have a <<start>> value with (explicitly or implicitly) <<initial>> = <<exact>> in order to compute the continuous-time <<state,`states`>> and the output variables at the initial time latexmath:[t_0].
 In the above table, the variables with <<initial>> = <<exact>> are collected together in variable latexmath:[\mathbf{v}_{initial=exact}].
 For example, initialization might be defined by providing initial <<start>> values for the <<state,`states`>>, latexmath:[\mathbf{x}_{c0}], or by stating that the state derivatives are zero (latexmath:[\dot{\mathbf{x}}_{c} = \mathbf{0}]).
-Initialization is a difficult topic by itself, and it is required that an FMU solves a well-defined initialization problem inside the FMU in Initialization Mode. +
-After calling <<fmi3ExitInitializationMode>>, the FMU is implicitly in Event Mode, and all discrete-time and continuous-time variables at the initial time instant latexmath:[(t_R, 0)] can be calculated.
+Initialization is a difficult topic by itself, and it is required that an FMU solves a well-defined initialization problem inside the FMU in *Initialization Mode*. +
+After calling <<fmi3ExitInitializationMode>>, the FMU is implicitly in *Event Mode*, and all discrete-time and continuous-time variables at the initial time instant latexmath:[(t_R, 0)] can be calculated.
 If these variables are present in an algebraic loop, iteration can be used to compute them.
-Once finalized, <<fmi3NewDiscreteStates>> must be called, and depending on the value of the return argument, the FMU either continues the event iteration at the initial time instant or switches to Continuous-Time Mode. +
-After switching to Continuous-Time Mode, the integration is started.
+Once finalized, <<fmi3NewDiscreteStates>> must be called, and depending on the value of the return argument, the FMU either continues the event iteration at the initial time instant or switches to *Continuous-Time Mode*. +
+After switching to *Continuous-Time Mode*, the integration is started.
 Basically, in this phase the <<derivative,`derivatives`>> of the continuous <<state,`states`>> are computed.
 If FMUs and/or submodels are connected together, then the <<input,`inputs`>> of these models are the <<output,`outputs`>> of other models, and therefore, the corresponding FMU outputs must be computed.
 Whenever result values shall be stored, usually at output points defined before the start of the simulation, the `fmi3GetXXX` function with respect to the desired variables must be called. +
@@ -468,8 +468,8 @@ Continuous integration is stopped at an event instant.
 An event instant is determined by a time, state or step event, or by an external event triggered by the environment.
 In order to determine a state event, the event indicators *z* have to be inquired at every completed integrator step.
 Once the event indicators signal a change of their domain, an iteration over time is performed between the previous and the actual completed integrator step, in order to determine the time instant of the domain change up to a certain precision. +
-After an event is triggered, the FMU needs to be switched to Event Mode.
-In this mode, systems of equations over connected FMUs might be solved (similarily as in Continuous-Time Mode).
+After an event is triggered, the FMU needs to be switched to *Event Mode*.
+In this mode, systems of equations over connected FMUs might be solved (similarily as in *Continuous-Time Mode*).
 Once convergence is reached, <<fmi3NewDiscreteStates>> must be called to increment super dense time (and conceptually update the discrete-time <<state,`states`>> defined internally in the FMU by latexmath:[^{\bullet}\mathbf{x}_d := \mathbf{x}_d]).
 Depending on the discrete-time model, a new event iteration might be needed (for example, because the FMU describes internally a state machine
 and transitions are still able to fire, but new <<input,`inputs`>> shall be taken into account). +

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -33,7 +33,7 @@ include::../headers/fmi3FunctionTypes.h[tags=SetContinuousStates]
 
 Set a new (continuous) state vector and re-initialize caching of variables that depend on the <<state,`states`>>.
 Argument `nx` is the length of vector `x` and is provided for checking purposes (variables that depend solely on<<constant,`constants`>>, <<parameter,`parameters`>>, time, and <<input,`inputs`>> do not need to be newly computed in the sequel, but the previously computed values can be reused).
-Note that the continuous <<state,`states`>> might also be changed in Event Mode.
+Note that the continuous <<state,`states`>> might also be changed in *Event Mode*.
 Note that `fmi3Status = fmi3Discard` is possible.
 
 [source, C]
@@ -91,7 +91,7 @@ include::../headers/fmi3FunctionTypes.h[tags=EventInfo]
 
 The FMU is in *Event Mode* and the super dense time is incremented by this call. +
 If the super dense time before a call to <<fmi3NewDiscreteStates>> was latexmath:[(t_R,t_I)], then the time instant after the call is latexmath:[(t_R,t_I)]. +
-If return argument `pass:[fmi3eventInfo->newDiscreteStatesNeeded] = fmi3True`, the FMU should stay in Event Mode, and the FMU requires to set new inputs to the FMU (`fmi3SetXXX` on <<input,`inputs`>>) to compute and get the <<output,`outputs`>> (`fmi3GetXXX` on <<output,`outputs`>>) and to call <<fmi3NewDiscreteStates>> again.
+If return argument `pass:[fmi3eventInfo->newDiscreteStatesNeeded] = fmi3True`, the FMU should stay in *Event Mode*, and the FMU requires to set new inputs to the FMU (`fmi3SetXXX` on <<input,`inputs`>>) to compute and get the <<output,`outputs`>> (`fmi3GetXXX` on <<output,`outputs`>>) and to call <<fmi3NewDiscreteStates>> again.
 Depending on the connection with other FMUs, the environment shall
 
 - call <<fmi3Terminate>>, if `terminateSimulation = fmi3True` is returned by at least one FMU,
@@ -220,12 +220,12 @@ Note that the FMU can always determine in which state it is since every state is
 The transition conditions `external event`, `time event`, and `state event` are defined in <<math-model-exchange>>.
 Each state of the state machine corresponds to a certain phase of a simulation as follows:
 
-instantiated::
+Instantiated::
 In this state, <<start>> and guess values (= variables that have <<initial>> = <<exact>> or <<approx>>) can be set.
 
 Configuration Mode::
 In this state <<structuralParameter,`structural parameters`>> with <<variability>> = <<fixed>> or <<variability>> = <<tunable>> can be changed.
-This state is entered from state *instantiated* by calling <<fmi3EnterConfigurationMode>> and left back to *instantiated* by calling <<fmi3ExitConfigurationMode>>.
+This state is entered from state *Instantiated* by calling <<fmi3EnterConfigurationMode>> and left back to *Instantiated* by calling <<fmi3ExitConfigurationMode>>.
 <<fmi3EnterConfigurationMode>> can only be called if the FMU contains at least one <<structuralParameter,`structural parameter`>>
 
 Initialization Mode::
@@ -248,7 +248,7 @@ In this state <<structuralParameter,`structural parameters`>> with <<variability
 This state is entered from state *Event Mode* by calling <<fmi3EnterConfigurationMode>> and left back to *Event Mode* by calling <<fmi3ExitConfigurationMode>>.
 <<fmi3EnterConfigurationMode>> can only be called if the FMU contains at least one <<structuralParameter,`structural parameter`>>
 
-terminated::
+Terminated::
 In this state, the solution at the final time of a simulation can be retrieved.
 
 Note that simulation backward in time is only allowed over continuous time intervals.
@@ -266,14 +266,14 @@ The allowed function calls in the respective states are summarized in the follow
 .2+.>|*Function*
 8+|*FMI 2.0 for Model Exchange*
 
-|[vertical-text]#start, end#
-|[vertical-text]#instantiated#
+|[vertical-text]#Start, End#
+|[vertical-text]#Instantiated#
 |[vertical-text]#Initialization Mode#
 |[vertical-text]#Event Mode#
 |[vertical-text]#Continuous-Time Mode#
-|[vertical-text]#terminated#
-|[vertical-text]#error#
-|[vertical-text]#fatal#
+|[vertical-text]#Terminated#
+|[vertical-text]#Error#
+|[vertical-text]#Fatal#
 
 |<<fmi3GetVersion>>                    |x |x |x |x |x |x |x |
 |<<fmi3SetDebugLogging>>               |  |x |x |x |x |x |x |
@@ -358,7 +358,7 @@ This concerns the following API calls: <<fmi3SetClock>>, <<fmi3GetClock>>, <<fmi
 A <<clock>> event is handled by the environment in the following way:
 
 Enter event mode::
-The event mode is entered after initialization (call to function <<fmi3ExitInitializationMode>>) or during simulation with a call to the function <<fmi3EnterEventMode>>. The FMU activates <<outputClock,`output clocks`>>.
+The *Event Mode* is entered after initialization (call to function <<fmi3ExitInitializationMode>>) or during simulation with a call to the function <<fmi3EnterEventMode>>. The FMU activates <<outputClock,`output clocks`>>.
 
 Synchronize clock activation and intervals with the environment::
 

--- a/docs/4_1_co-simulation_math.adoc
+++ b/docs/4_1_co-simulation_math.adoc
@@ -224,18 +224,18 @@ This is performed through an auxiliary function _[this relationship is defined i
 Computing the solution of an FMI Co-Simulation model means to split the solution process in two phases and in every phase different equations and solution methods are utilized.
 The phases can be categorized according to the following modes:
 
-Initialization Mode::
+===== Initialization Mode
 This mode is used to compute at the start time latexmath:[t_0] initial values for internal variables of the Co-Simulation slave, especially for continuous-time <<state,`states`>>, latexmath:[\mathbf{x}_d(t_0)], and for the previous discrete-time <<state,`states`>>, latexmath:[^{\bullet}\mathbf{x}_d(t_0)], by utilizing extra equations not present in the other mode _[for example, equations to set all <<derivative,`derivatives`>> to zero, that is, to initialize in steady-state]_.
 If the slave is connected in loops with other models, iterations over the FMU equations are possible.
 Algebraic equations are solved in this mode.
 
-Step Mode::
+===== Step Mode
 This mode is used to compute the values of all (real) continuous-time and discrete-time variables at communication points by numerically solving ordinary differential, algebraic and discrete equations.
 If the slave is connected in loops with other models, no iterations over the FMU equations are possible.
 
 _[Note that for a Co-Simulation FMU, no super dense time description is used at communication points.]_
 
-The equations are defined in <<table-math-co-simulation>> can be evaluated in the respective Mode.
+The equations are defined in <<table-math-co-simulation>> can be evaluated in the respective mode.
 The following color coding is used in the table:
 
 [cols="1,8"]
@@ -253,7 +253,7 @@ For an output argument, calling `fmi3Get{VariableType}` on such a variable retur
 |====
 |*Equations* |*FMI functions*
 
-2+|*Equations before Initialization Mode* (`instantiated` in state machine)
+2+|*Equations before Initialization Mode* (*Instantiated* in state machine)
 
 |Set and set <<start>> value of <<independent>> variable latexmath:[tc_{i=0}]
 |<<fmi3SetupExperiment>>
@@ -261,9 +261,9 @@ For an output argument, calling `fmi3Get{VariableType}` on such a variable retur
 |Set variables and that have a start value (<<initial>> = <<exact>> or <<approx>>)
 |`fmi3Set{VariableType}`
 
-2+|*Equations during Initialization Mode* (`InitializationMode` in state machine)
+2+|*Equations during Initialization Mode* (*Initialization Mode* in state machine)
 
-|[lime]#Enter Initialization Mode at (activate initialization, discrete-time and continuous-time equations)# |[lime]#fmi3EnterInitializationMode#
+|[lime]#Enter *Initialization Mode* at (activate initialization, discrete-time and continuous-time equations)# |[lime]#fmi3EnterInitializationMode#
 
 |Set variables latexmath:[v_{initial=exact}] and latexmath:[v_{initial=approx}] that have a <<start>> value with <<initial>> = <<exact>> (<<independent>> <<parameter,`parameters`>> latexmath:[\mathbf{p}] and continuous-time <<state,`states`>> with start values latexmath:[\mathbf{x}_{c,initial=exact}] are included here)
 |`fmi3Set{VariableType}`
@@ -276,7 +276,7 @@ For an output argument, calling `fmi3Get{VariableType}` on such a variable retur
 |`[blue]#fmi3Get{VariableType}#` +
 `[blue]#fmi3GetDirectionalDerivative#`
 
-|[lime]#Exit Initialization Mode (de-activate initialization equations)#
+|[lime]#Exit *Initialization Mode* (de-activate initialization equations)#
 |[lime]#fmi3ExitInitializationMode#
 
 2+|*Equations during Step Mode* (`stepComplete`, `stepInProgress` in state machine)
@@ -305,10 +305,10 @@ latexmath:[\mathbf{f}_{init}, \mathbf{f}_{out} \in C^0] (=continuous functions w
 
 _[Remark - Calling Sequences:_
 
-_In the table above, for notational convenience in Initialization Mode one function call is defined to compute all output arguments from all inputs arguments._
+_In the table above, for notational convenience in *Initialization Mode* one function call is defined to compute all output arguments from all inputs arguments._
 _In reality, every variable output argument is computed by one_ `fmi3Get{VariableType}` _function call._
 
-_In Step Mode the input arguments to_ latexmath:[\mathbf{f}_{doStep}] _are defined by calls to_ `fmi3Set{VariableType}` _and_ `fmi3SetRealInputDerivatives` _functions._
+_In *Step Mode* the input arguments to_ latexmath:[\mathbf{f}_{doStep}] _are defined by calls to_ `fmi3Set{VariableType}` _and_ `fmi3SetRealInputDerivatives` _functions._
 _The variables computed by_ latexmath:[\mathbf{f}_{doStep}] _can be inquired by_  `fmi3Get{VariableType}` _function calls.]_
 
 ==== Early Return from Current Communication Step
@@ -347,16 +347,16 @@ Due to the early-return mechanism, the overall execution time of the simulation 
 The notion of <<clock>> in FMI for Model Exchange has been extended to the FMI for Co-Simulation.
 
 Both <<outputClock,`output clocks`>> and <<inputClock,`input clocks`>> are supported in Co-Simulation with <<clock,`clocks`>>.
-In order to handle <<inputClock,`input`>> and <<outputClock,`output clocks`>> in Co-Simulation, a new Event mode has been introduced.
+In order to handle <<inputClock,`input`>> and <<outputClock,`output clocks`>> in Co-Simulation, a new *Event Mode* has been introduced.
 
 The concept and the way <<inputClock,`input`>> and <<outputClock,`output clocks`>> are handled are very similar in Model Exchange and Co-simulation.
 In order to handle <<inputClock,`input clocks`>>, the Co-Simulation master schedules <<inputClock,`input clocks`>> and adjusts the communication steps in such a way that <<inputClock>> ticks become communication points.
-At these communication points, the FMU is pushed to the Event mode and <<inputClock,`input clocks`>> are handled.
+At these communication points, the FMU is pushed to the *Event Mode* and <<inputClock,`input clocks`>> are handled.
 
 <<outputClock,`Output clocks`>>, on the other hand, are detected by the FMU.
 The FMU detects an <<outputClock>> and informs the master by invoking a callback in which the event time and the event type is communicated to the master.
 Then FMU stops the current Co-Simulation step and returns back from <<fmi3DoStep>>.
-Then the FMU is pushed to the Event mode and the event is handled.
+Then the FMU is pushed to the *Event Mode* and the event is handled.
 Note that, since output events time instants are not known in advance, at output event time instants, new communication steps are created.
 
 

--- a/docs/4_2_co-simulation_api.adoc
+++ b/docs/4_2_co-simulation_api.adoc
@@ -114,18 +114,18 @@ image::images/calling-sequence-co-simulation.svg[width=80%, align="center"]
 
 In this Co-Simulation mode the following functions must not be called: <<fmi3ActivateModelPartition>>, <<fmi3NewDiscreteStates>>, <<fmi3EnterEventMode>>, <<fmi3SetClock>>, <<fmi3GetClock>>, <<fmi3SetIntervalFraction>>, <<fmi3GetIntervalFraction>>, <<fmi3SetIntervalDecimal>>, <<fmi3GetIntervalDecimal>> including all functions that are specific to fmuType `fmi3ModelExchange`.
 
-====== State: SlaveSetableFMUstate [[state-slave-setable-fmu-state-co-simulation]]
+====== State: Slave Setable FMU State [[state-slave-setable-fmu-state-co-simulation]]
 
 In all states of this super state it is allowed to call <<fmi3GetFMUState>>, <<fmi3SetFMUState>>, <<fmi3FreeFMUState>>`, <<fmi3SerializedFMUStateSize>>, <<fmi3SerializeFMUState>>, `fmi3DeSerializeFMUState`, <<fmi3Reset>>, <<fmi3GetVersion>>, `fmi3SetDebugLogging` and <<fmi3FreeInstance>>.
 
 If any function returns with `fmi3Fatal` the FMU enters state *Fatal*.
 
-====== State: SlaveUnderEvaluation [[state-slave-under-evaluation-co-simulation]]
+====== State: Slave Under Evaluation [[state-slave-under-evaluation-co-simulation]]
 
 This super state is entered by the FMU when <<fmi3Instantiate>> is called.
 If any function returns `fmi3Error` the FMU enters state *Terminated*.
 
-====== State: SlaveInitialized [[state-slave-initialized-co-simulation]]
+====== State: Slave Initialized [[state-slave-initialized-co-simulation]]
 
 This super state is entered by the FMU when <<fmi3ExitInitializationMode>> is called.
 If the function <<fmi3Terminate>> is called, the FMU enters state *Terminated*.
@@ -603,15 +603,15 @@ In this Co-Simulation mode the following functions must not be called: <<fmi3Act
 Unlike the state machine in section <<state-machine-co-simulation>> the entry state after *Initialization Mode* is the *Event Mode* in order to allow the FMU to handle the very first discrete event.
 Each state of the state machine corresponds to a certain phase of a simulation as follows:
 
-====== State: SlaveSetableFMUstate
+====== State: Slave Setable FMU State
 
 This super state in Hybrid Co-Simulation does not differ from Co-Simulation described in section <<state-slave-setable-fmu-state-co-simulation>>.
 
-====== State: SlaveUnderEvaluation
+====== State: Slave Under Evaluation
 
 This super state in Hybrid Co-Simulation does not differ from Co-Simulation described in section <<state-slave-under-evaluation-co-simulation>>.
 
-====== State: SlaveInitialized
+====== State: Slave Initialized
 
 This super state in Hybrid Co-Simulation does not differ from Co-Simulation described in section <<state-slave-initialized-co-simulation>>.
 
@@ -857,18 +857,18 @@ In this Co-Simulation mode the following functions must not be called: <<fmi3DoS
 
 The states *Configuration Mode*, *Instantiated*, *Initialization Mode*, *Terminated*, and *Fatal* are handled in the same way as in mode `fmi3ModeCoSimulation` with the exception that the generally not allowed functions of the Co-Simulation mode `fmi3ModeScheduledExecutionSimulation` must not be called.
 
-====== State: SlaveSetableFMUstate
+====== State: Slave Setable FMU State
 
 In all states of this super state it is allowed to call <<fmi3GetFMUState>>, `fmi3SetFMUState`, `fmi3FreeFMUState`, <<fmi3SerializedFMUStateSize>>, <<fmi3SerializeFMUState>>, <<fmi3DeSerializeFMUState>>, <<fmi3Reset>>, <<fmi3GetVersion>>, `fmi3SetDebugLogging` and <<fmi3FreeInstance>>.
 
 If any function returns with `fmi3Fatal` the FMU enters state *Fatal*.
 
-====== State: SlaveUnderEvaluation
+====== State: Slave Under Evaluation
 
 This super state is entered by the FMU when <<fmi3Instantiate>> is called.
 If any function returns `fmi3Error` or `fmi3Discard` the FMU enters state *Terminated*.
 
-====== State: SlaveInitialized
+====== State: Slave Initialized
 
 This super state is entered by the FMU when `fmi3ExitInitializatoinMode` is called.
 If the function <<fmi3Terminate>> is called, the FMU enters state *Terminated* from all states of this super state.

--- a/docs/4_2_co-simulation_api.adoc
+++ b/docs/4_2_co-simulation_api.adoc
@@ -114,18 +114,18 @@ image::images/calling-sequence-co-simulation.svg[width=80%, align="center"]
 
 In this Co-Simulation mode the following functions must not be called: <<fmi3ActivateModelPartition>>, <<fmi3NewDiscreteStates>>, <<fmi3EnterEventMode>>, <<fmi3SetClock>>, <<fmi3GetClock>>, <<fmi3SetIntervalFraction>>, <<fmi3GetIntervalFraction>>, <<fmi3SetIntervalDecimal>>, <<fmi3GetIntervalDecimal>> including all functions that are specific to fmuType `fmi3ModelExchange`.
 
-====== State: slaveSetableFMUstate [[state-slave-setable-fmu-state-co-simulation]]
+====== State: SlaveSetableFMUstate [[state-slave-setable-fmu-state-co-simulation]]
 
 In all states of this super state it is allowed to call <<fmi3GetFMUState>>, <<fmi3SetFMUState>>, <<fmi3FreeFMUState>>`, <<fmi3SerializedFMUStateSize>>, <<fmi3SerializeFMUState>>, `fmi3DeSerializeFMUState`, <<fmi3Reset>>, <<fmi3GetVersion>>, `fmi3SetDebugLogging` and <<fmi3FreeInstance>>.
 
 If any function returns with `fmi3Fatal` the FMU enters state *Fatal*.
 
-====== State: slaveUnderEvaluation [[state-slave-under-evaluation-co-simulation]]
+====== State: SlaveUnderEvaluation [[state-slave-under-evaluation-co-simulation]]
 
 This super state is entered by the FMU when <<fmi3Instantiate>> is called.
 If any function returns `fmi3Error` the FMU enters state *Terminated*.
 
-====== State: slaveInitialized [[state-slave-initialized-co-simulation]]
+====== State: SlaveInitialized [[state-slave-initialized-co-simulation]]
 
 This super state is entered by the FMU when <<fmi3ExitInitializationMode>> is called.
 If the function <<fmi3Terminate>> is called, the FMU enters state *Terminated*.
@@ -174,13 +174,13 @@ Allowed Function Calls::
 <<fmi3SetInputDerivatives>>, <<fmi3GetDirectionalDerivative>>, <<fmi3GetOutputDerivatives>>, `fmi3Get{VariableType}`, <<fmi3Terminate>>
 
 <<fmi3EnterConfigurationMode>>::
-With this function call the Reconfiguration Mode is entered.
+With this function call the *Reconfiguration Mode* is entered.
 This function must not be called if the FMU contains no <<tunable>> <<structuralParameter,`structural parameters`>> (i.e. with <<causality>>= <<structuralParameter>> and <<variability>> = <<tunable>>).
 
 <<fmi3DoStep>>::
 Within fmi3DoStep() the FMU may call <<fmi3CallbackIntermediateUpdate>>
 * If the function returns with `fmi3OK` or `fmi3Warning` the FMU stays in this state.
-* If the function returns with `fmi3Discard` the FMU enters state `Step Discarded`.
+* If the function returns with `fmi3Discard` the FMU enters state *Step Discarded*.
 
 `fmi3Set{VariableType}`::
 For variables with:
@@ -221,7 +221,7 @@ Forbidden Function Calls::
 In this state the master can retrieve information from the FMU between communication points.
 Functions called in this state must not return `fmi3Discard`.
 
-The FMU enters this state by calling <<fmi3CallbackIntermediateUpdate>> within <<fmi3DoStep>> and leaves the state towards state `Step Mode` if the function returns `fmi3OK` or `fmi3Warning`.
+The FMU enters this state by calling <<fmi3CallbackIntermediateUpdate>> within <<fmi3DoStep>> and leaves the state towards state *Step Mode* if the function returns `fmi3OK` or `fmi3Warning`.
 If the function returns `fmi3Error` the FMU enters state *Terminated*.
 If the function returns `fmi3Fatal` the FMU enters state *Fatal*.
 
@@ -237,13 +237,13 @@ If `intermediateUpdateInfo->intermediateVariableGetAllowed` is equal to `fmi3Tru
 Intermediate variables are variables that are marked with attribute <<intermediateAccess>> = `true` in the `modelDescription.xml`.
 
 Forbidden Function Calls::
-The same functions which are not allowed to be called in `Step Mode` must not be called in this state.
+The same functions which are not allowed to be called in *Step Mode* must not be called in this state.
 Additionally the following functions must not be called  <<fmi3EnterConfigurationMode>>, <<fmi3Terminate>>, <<fmi3DoStep>>, <<fmi3GetDirectionalDerivative>>.
 
 ====== State: Reconfiguration Mode [[state-reconfiguration-mode-co-simulation]]
 
 In this state <<structuralParameter,`structural parameters`>> with <<variability>> = <<tunable>> can be changed.
-This state is entered from state `Step Mode` by calling <<fmi3EnterConfigurationMode>> and left back to `Step Mode` by calling <<fmi3ExitConfigurationMode>>.
+This state is entered from state *Step Mode* by calling <<fmi3EnterConfigurationMode>> and left back to *Step Mode* by calling <<fmi3ExitConfigurationMode>>.
 
 Allowed Function Calls::
 <<fmi3ExitConfigurationMode>>
@@ -268,9 +268,9 @@ Allowed Function Calls::
 The master calls this functions to retrieve information about the reason for discarding the last communication step.
 
 <<fmi3EnterStepMode>>::
-The <<fmi3EnterStepMode>> function pushes the FMU from `Step Discarded` to `Step Mode`.
-_[In Step Mode, the master may change again FMU <<input,`inputs`>> and <<parameter,`parameters`>>, or push the FMU into other states]_
-In this case, a new step may be started from `lastSuccessfulTime` which can be retrieved by the <<fmi3GetDoStepDiscardedStatus>> function in state `Step Discarded`.
+The <<fmi3EnterStepMode>> function pushes the FMU from *Step Discarded* to *Step Mode*.
+_[In *Step Mode*, the master may change again FMU <<input,`inputs`>> and <<parameter,`parameters`>>, or push the FMU into other states]_
+In this case, a new step may be started from `lastSuccessfulTime` which can be retrieved by the <<fmi3GetDoStepDiscardedStatus>> function in state *Step Discarded*.
 
 Forbidden Function Calls::
 <<fmi3EnterConfigurationMode>>, <<fmi3ExitConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3DoStep>>, `fmi3Set{VariableType}`, <<fmi3DoEarlyReturn>>, <<fmi3SetInputDerivatives>>
@@ -300,7 +300,7 @@ all
 
 In this state <<structuralParameter,`structural parameters`>> with <<variability>> = <<tunable>> can be changed.
 
-This state is entered from state `Instantiated` by calling <<fmi3EnterConfigurationMode>> and left back to `Instantiated` by calling <<fmi3ExitConfigurationMode>>.
+This state is entered from state *Instantiated* by calling <<fmi3EnterConfigurationMode>> and left back to *Instantiated* by calling <<fmi3ExitConfigurationMode>>.
 
 Allowed Function Calls::
 <<fmi3ExitConfigurationMode>>
@@ -319,16 +319,16 @@ _[The allowed function calls in the respective states are summarized in the foll
 |====
 .2+.>|*Function*
 10+|*FMI 3.0 for Co-Simulation*
-|[vertical-text]#start, end#
-|[vertical-text]#instantiated#
+|[vertical-text]#Start, End#
+|[vertical-text]#Instantiated#
 |[vertical-text]#Initialization Mode#
-|[vertical-text]#stepComplete#
-|[vertical-text]#stepInProgress#
-|[vertical-text]#stepDiscarded#
-|[vertical-text]#stepCanceled#
-|[vertical-text]#terminated#
-|[vertical-text]#error#
-|[vertical-text]#fatal#
+|[vertical-text]#StepComplete#
+|[vertical-text]#StepInProgress#
+|[vertical-text]#StepDiscarded#
+|[vertical-text]#StepCanceled#
+|[vertical-text]#Terminated#
+|[vertical-text]#Error#
+|[vertical-text]#Fatal#
 
 |<<fmi3GetVersion>>               |x |x |x |x |x |x |x |x |x |
 |<<fmi3SetDebugLogging>>          |  |x |x |x |x |x |x |x |x |
@@ -433,11 +433,11 @@ If the `earlyReturnTime` is greater than the last signaled `intermediateUpdateTi
 If the early return is conducted successfully by the FMU it must set the parameter `earlyReturn` to `fmi3True` in <<fmi3DoStep>> and return `fmi3OK`.
 In that case the internal simulation time of the FMU equals the value of `earlyReturnTime` of the last <<fmi3DoEarlyReturn>> call.
 
-If the requested `earlyReturnTime` is less than the last signaled `intermediateUpdateTime` or the FMU can not reach the requested `earlyReturnTime` for other reasons, the FMU must set the parameter `earlyReturn` to `fmi3True` in <<fmi3DoStep>> and return `fmi3Discard` and enter state `Step Discarded`.
+If the requested `earlyReturnTime` is less than the last signaled `intermediateUpdateTime` or the FMU can not reach the requested `earlyReturnTime` for other reasons, the FMU must set the parameter `earlyReturn` to `fmi3True` in <<fmi3DoStep>> and return `fmi3Discard` and enter state *Step Discarded*.
 
-In state `Step Discarded` the Co-Simulation master can retrieve the `lastSuccessfulTime` via calling <<fmi3GetDoStepDiscardedStatus>>.
+In state *Step Discarded* the Co-Simulation master can retrieve the `lastSuccessfulTime` via calling <<fmi3GetDoStepDiscardedStatus>>.
 The Co-Simulation master can decide if a rollback of the FMU to reach the `earlyReturnTime` time is required or it may continue the simulation from `lastSuccessfulTime` for that FMU.
-Note that `Event Mode` is not supported in `fmi3ModeCoSimulation`.
+Note that *Event Mode* is not supported in `fmi3ModeCoSimulation`.
 
 ==== Mode fmi3ModeHybridCoSimulation [[api-hybrid-co-simulation]]
 
@@ -468,12 +468,12 @@ The following `fmi3Boolean` variables define the reasons for the <<fmi3CallbackI
 Several variables can be set by the FMU.
 Default value of variables is `fmi3False`.
 
-* when `eventOccurred` is `fmi3True`, the master must call <<fmi3DoEarlyReturn>> to do an early return and handle the event via entering event mode.
+* when `eventOccurred` is `fmi3True`, the master must call <<fmi3DoEarlyReturn>> to do an early return and handle the event via entering *Event Mode*.
 In this case, `earlyReturnTime` argument of <<fmi3DoEarlyReturn>> is ignored.
-In `Event Mode` the master shall call the <<fmi3NewDiscreteStates>> function for gathering <<fmi3EventInfo>> related information about the event occurred at `intermediateUpdateTime`.
+In *Event Mode* the master shall call the <<fmi3NewDiscreteStates>> function for gathering <<fmi3EventInfo>> related information about the event occurred at `intermediateUpdateTime`.
 
 * when `clocksTicked`  is `fmi3True`, it means that <<fmi3GetClock>> function should be called for gathering all <<clock>> related information about ticking <<outputClock,`output clocks`>> at `intermediateUpdateTime`.
-If this flag is `fmi3True` the master must call <<fmi3DoEarlyReturn>> to do an early return and handle the <<clock>> event in `Event Mode`.
+If this flag is `fmi3True` the master must call <<fmi3DoEarlyReturn>> to do an early return and handle the <<clock>> event in *Event Mode*.
 In this case, `earlyReturnTime` argument of <<fmi3DoEarlyReturn>> is ignored.
 
 * when `intermediateVariableSetAllowed` is `fmi3True`, the FMU signals that intermediate output values can be collected by the Co-Simulation master.
@@ -486,7 +486,7 @@ In this case, `earlyReturnTime` argument of <<fmi3DoEarlyReturn>> is ignored.
 If `canReturnEarly` is `fmi3False` the FMU will not do the early return, regardless of the master request.
 
 Note that only the first discontinuity event at a Newtonian time instant shall be signaled that way.
-But in `Event Mode`, there may be an event iteration at a Newtonian time instant and have super dense time instants.
+But in *Event Mode*, there may be an event iteration at a Newtonian time instant and have super dense time instants.
 
 Based on the information delivered in <<fmi3IntermediateUpdateInfo>>, additional information about the discontinuity at that time instant can be obtained from the <<fmi3EventInfo>> structure after calling  <<fmi3NewDiscreteStates>>  and/or <<fmi3GetClock>>.
 
@@ -504,30 +504,30 @@ include::../headers/fmi3FunctionTypes.h[tag=EnterEventMode]
 
 The Co-Simulation master can also call <<fmi3EnterEventMode>> at communication instants to handle input events, as will be discussed in following sections.
 
-If an FMU provides the early-return capability that includes the handling of events in `Event Mode`, the FMU signals this via `canReturnEarlyAfterIntermediateUpdate` and `providesHybridCoSimulation = true` in the modelDescription.
+If an FMU provides the early-return capability that includes the handling of events in *Event Mode*, the FMU signals this via `canReturnEarlyAfterIntermediateUpdate` and `providesHybridCoSimulation = true` in the modelDescription.
 The master should indicate to the FMU that this early-return feature is also supported by the master.
 The Co-Simulation master signals to the FMU that it supports and has recognized the early return Co-Simulation capabilities of the FMU by setting the CoSimulation mode to `fmi3ModeHybridCoSimulation` in the <<fmi3Instantiate>> function.
 
 The FMU stops computation at the first encountered internal event (if any) and the event time is provided through `intermediateUpdateInfo.intermediateUpdateTime`.
 If <<fmi3DoStep>> returns with `earlyReturn = fmi3True` and an event has happened, i.e. `intermediateUpdateInfo.eventOccurred` is `fmi3True`, then an event handling has to be done by the Co-Simulation master.
-In order to start event handling the Co-Simulation master has to call <<fmi3EnterEventMode>> for that FMU to push the FMU into `Event Mode`.
+In order to start event handling the Co-Simulation master has to call <<fmi3EnterEventMode>> for that FMU to push the FMU into *Event Mode*.
 In this mode the Co-Simulation master is supposed to catch all events through the <<fmi3NewDiscreteStates>> function and the <<fmi3EventInfo>> structure.
 
 If the early-return request of the Co-Simulation master is ignored by the FMU, then <<fmi3DoStep>> returns with `earlyReturn = fmi3False`.
 The master can start a resynchronization of FMUs at an event time, if the `currentCommunicationPoint` has passed the event time, the master can roll-back the FMU and repeat the step with a suitable `communicationStepSize` (if the FMU supports the roll-back).
 
-In `Event Mode` and only after <<fmi3DoStep>> returns with `earlyReturn = fmi3True` a <<fmi3NewDiscreteStates>> call returns <<fmi3EventInfo>> structure as a return argument.
+In *Event Mode* and only after <<fmi3DoStep>> returns with `earlyReturn = fmi3True` a <<fmi3NewDiscreteStates>> call returns <<fmi3EventInfo>> structure as a return argument.
 Not all elements of <<fmi3EventInfo>> are relevant and only the following elements may be considered:
 
-- when `newDiscreteStatesNeeded = true` it means that the master should stay in Event Mode and another call to <<fmi3NewDiscreteStates>> is required.
+- when `newDiscreteStatesNeeded = true` it means that the master should stay in *Event Mode* and another call to <<fmi3NewDiscreteStates>> is required.
 
 - when `nextEventTimeDefined = true` it means that an event time is available and the value is given by the `nextEventTime` value.
 This is the case when the model can report in advance the accurate time of the next predictable time event.
 
 - when `terminateSimulation = true` it means that the model wants to stop integration and the Co-Simulation master should call <<fmi3Terminate>>.
 
-In Event Mode it is allowed to `fmi3Get{VariableType}` variable values of the FMU after the call of <<fmi3NewDiscreteStates>> and it is allowed to `fmi3Set{VariableType}` variable values before calling <<fmi3NewDiscreteStates>>.
-The FMU leaves Event Mode when the master calls <<fmi3EnterStepMode>> for that FMU.
+In *Event Mode* it is allowed to `fmi3Get{VariableType}` variable values of the FMU after the call of <<fmi3NewDiscreteStates>> and it is allowed to `fmi3Set{VariableType}` variable values before calling <<fmi3NewDiscreteStates>>.
+The FMU leaves *Event Mode* when the master calls <<fmi3EnterStepMode>> for that FMU.
 
 It is not allowed to call <<fmi3EnterEventMode>> or <<fmi3EnterStepMode>> for an FMU in mode `fmi3ModeCoSimulation` or `fmi3ModeScheduledExecutionSimulation`.
 
@@ -538,7 +538,7 @@ It is not allowed to call <<fmi3EnterEventMode>> or <<fmi3EnterStepMode>> for an
 In this section, signaling and retrieving <<clock>> ticks as well as the interface for supporting <<clock,`clocks`>> in FMI for Co-Simulation will be discussed.
 If an FMU for Co-Simulation declares <<clock,`clocks`>> and clocked variables in the `modelDescription.xml` file, it supports <<clock,`clocks`>>.
 The Co-Simulation master should indicate the FMU that the master has recognized the <<clock>> capabilities of the FMU and supports the <<clock>> handling by setting the Co-Simulation mode to `fmi3ModeHybridCoSimulation` in <<fmi3Instantiate>>.
-Note, even if no <<clock>> is defined by an FMU in `modelDescription.xml`, the master is allowed to set the Co-Simulation mode to `fmi3ModeHybridCoSimulation` to be able to do early return with event handling in `Event Mode`.
+Note, even if no <<clock>> is defined by an FMU in `modelDescription.xml`, the master is allowed to set the Co-Simulation mode to `fmi3ModeHybridCoSimulation` to be able to do early return with event handling in *Event Mode*.
 
 If an FMU provides <<clock,`clocks`>>, but the Co-Simulation master does not support or does not want to support early-return or <<clock,`clocks`>>, by setting Co-Simulation mode to `fmi3ModeCoSimulation`, the activation of model partitions inside of the FMU has to be handled internally within <<fmi3DoStep>>.
 
@@ -558,24 +558,24 @@ include::../headers/fmi3FunctionTypes.h[tag=EnterStepMode]
 If the Co-Simulation master supports <<clock,`clocks`>>, all <<inputClock,`input clocks`>> of the model should be handled and <<inputClock>> events should be scheduled by the master.
 If an <<outputClock>> ticks, the FMU invokes the <<fmi3CallbackIntermediateUpdate>> callback and sets `intermediateUpdateInfo.clocksTicked` to `fmi3True`.
 Then the master must call <<fmi3DoEarlyReturn>> to do an early return from <<fmi3DoStep>>.
-Then the master should push the FMU into `Event Mode` by calling <<fmi3EnterEventMode>>.
-Once the FMU is in `Event Mode`, the activation status of <<outputClock,`output clocks`>> are retrieved by <<fmi3GetClock>> function.
+Then the master should push the FMU into *Event Mode* by calling <<fmi3EnterEventMode>>.
+Once the FMU is in *Event Mode*, the activation status of <<outputClock,`output clocks`>> are retrieved by <<fmi3GetClock>> function.
 Then <<fmi3SetClock>> (and <<fmi3SetIntervalDecimal>> or <<fmi3SetIntervalFraction>> if necessary) should be invoked to enable the ticked <<inputClock,`input clocks`>>.
-Each <<clock>>, that ticks outside of the FMU (i.e. <<inputClock>>), is activated for an FMU based on its <<clockReference>> and an associated <<fmi3SetClock>> in `Event Mode`.
+Each <<clock>>, that ticks outside of the FMU (i.e. <<inputClock>>), is activated for an FMU based on its <<clockReference>> and an associated <<fmi3SetClock>> in *Event Mode*.
 <<fmi3SetClock>> can activate multiple <<clock,`clocks`>> with each call.
 An event iteration is possible.
-Once all <<clock>> events are handled for this time instant, the FMU should be pushed into Step Mode by calling <<fmi3EnterStepMode>>.
-In Step Mode, the Co-Simulation master can call <<fmi3DoStep>> for the time interval from the current event time instant until the next input event instant.
+Once all <<clock>> events are handled for this time instant, the FMU should be pushed into *Step Mode* by calling <<fmi3EnterStepMode>>.
+In *Step Mode*, the Co-Simulation master can call <<fmi3DoStep>> for the time interval from the current event time instant until the next input event instant.
 Note that <<fmi3DoStep>> may not reach the next input event instant because an early return may occur.
 
 The simulation master sets and gets <<clock>> variable values similar to the FMI for Model Exchange, as defined in <<fmi-api-setting-getting-clock-activation-state>>.
 
 ===== Computation in fmi3ModeHybridCoSimulation [[computation-clocked-co-simulation]]
 
-Similar to FMI for Model Exchange, in order to activate <<inputClock,`input clocks`>> of an FMU, it is required to push the FMU into Event Mode by calling <<fmi3EnterEventMode>>.
-If <<fmi3DoStep>> returns with `earlyReturn = fmi3True` and `intermediateUpdateInfo.eventOccurred` or `intermediateUpdateInfo.clocksTicked` is `fmi3True`, the FMU must be pushed into the Event Mode by calling <<fmi3EnterEventMode>>.
+Similar to FMI for Model Exchange, in order to activate <<inputClock,`input clocks`>> of an FMU, it is required to push the FMU into *Event Mode* by calling <<fmi3EnterEventMode>>.
+If <<fmi3DoStep>> returns with `earlyReturn = fmi3True` and `intermediateUpdateInfo.eventOccurred` or `intermediateUpdateInfo.clocksTicked` is `fmi3True`, the FMU must be pushed into the *Event Mode* by calling <<fmi3EnterEventMode>>.
 
-In order to retrieve the status of <<outputClock,`output clocks`>>, <<fmi3GetClock>> and <<fmi3GetIntervalDecimal>> or <<fmi3GetIntervalFraction>> need to be called in the Event Mode.
+In order to retrieve the status of <<outputClock,`output clocks`>>, <<fmi3GetClock>> and <<fmi3GetIntervalDecimal>> or <<fmi3GetIntervalFraction>> need to be called in the *Event Mode*.
 If the <<fmi3DoStep>> return value is `fmi3OK` and `earlyReturn = fmi3False`, the calling of <<fmi3GetClock>>, <<fmi3GetIntervalDecimal>>, <<fmi3GetIntervalFraction>>, <<fmi3NewDiscreteStates>> is only meaningful after <<fmi3SetClock>> in the case of super-dense time iterations are desired.
 
 Similar to the Model Exchange case, the allowed call order is <<fmi3GetClock>>, <<fmi3GetIntervalDecimal>>, <<fmi3GetIntervalFraction>>, `fmi3Get{VariableType}`, `fmi3Set{VariableType}`.
@@ -584,7 +584,7 @@ Function calls of this call order can be omitted.
 The handling of return values of function calls is identical to mode `fmi3ModeCoSimulation`.
 
 If `eventInfo.terminateSimulation` becomes `fmi3True` after calling <<fmi3NewDiscreteStates>> then the co-simulation should be terminated by calling <<fmi3Terminate>>.
-Once handling of the <<clock>> events finished, the master calls <<fmi3EnterStepMode>> for that FMU to push it into Step Mode.
+Once handling of the <<clock>> events finished, the master calls <<fmi3EnterStepMode>> for that FMU to push it into *Step Mode*.
 Note that it is not allowed to call <<fmi3EnterEventMode>> or <<fmi3EnterStepMode>> in Co-Simulation mode `fmi3ModeCoSimulation` or `fmi3ScheduledExecutionSimulation`.
 
 _[Usually the Co-Simulation master should be able to derive (but is not forced to do so) the correct communication point times for <<inputClock,`input clocks`>> in advance and thus it should be able to set the proper `communicationStepSize` for <<fmi3DoStep>>._
@@ -603,15 +603,15 @@ In this Co-Simulation mode the following functions must not be called: <<fmi3Act
 Unlike the state machine in section <<state-machine-co-simulation>> the entry state after *Initialization Mode* is the *Event Mode* in order to allow the FMU to handle the very first discrete event.
 Each state of the state machine corresponds to a certain phase of a simulation as follows:
 
-====== State: slaveSetableFMUstate
+====== State: SlaveSetableFMUstate
 
 This super state in Hybrid Co-Simulation does not differ from Co-Simulation described in section <<state-slave-setable-fmu-state-co-simulation>>.
 
-====== State: slaveUnderEvaluation
+====== State: SlaveUnderEvaluation
 
 This super state in Hybrid Co-Simulation does not differ from Co-Simulation described in section <<state-slave-under-evaluation-co-simulation>>.
 
-====== State: slaveInitialized
+====== State: SlaveInitialized
 
 This super state in Hybrid Co-Simulation does not differ from Co-Simulation described in section <<state-slave-initialized-co-simulation>>.
 
@@ -629,36 +629,36 @@ This state in Hybrid Co-Simulation does not differ from Co-Simulation described 
 
 ====== State: Event Mode
 
-The master and the FMU enter this state when the master calls <<fmi3ExitInitializationMode>> in state `Initialization Mode` or <<fmi3ExitConfigurationMode>> in state *Reconfiguration Mode* or <<fmi3EnterEventMode>> in state `Step Mode`.
-In order to handle discrete events and <<clock>> ticks, the FMU is pushed into the event mode by calling <<fmi3EnterEventMode>>
+The master and the FMU enter this state when the master calls <<fmi3ExitInitializationMode>> in state *Initialization Mode* or <<fmi3ExitConfigurationMode>> in state *Reconfiguration Mode* or <<fmi3EnterEventMode>> in state *Step Mode*.
+In order to handle discrete events and <<clock>> ticks, the FMU is pushed into the *Event Mode* by calling <<fmi3EnterEventMode>>
 
 Allowed Function Calls::
 <<fmi3Terminate>>::
 Upon return of <<fmi3NewDiscreteStates>>, if `fmi3EventInfo->terminateSimulation = fmi3True`, the master should finish the Co-Simulation by calling `fmi3Terminate` on all FMUs.
 
 <<fmi3EnterConfigurationMode>>::
-With this function call the Reconfiguration Mode is entered.
+With this function call the *Reconfiguration Mode* is entered.
 This function must not be called if the FMU contains no <<tunable>> <<structuralParameter,`structural parameters`>> (i.e. with <<causality>> = <<structuralParameter>> and <<variability>> = <<tunable>>).
 
 <<fmi3NewDiscreteStates>>::
 In order to handle discrete events <<fmi3NewDiscreteStates>> is called.
 This function returns the `fmi3EventInfo* eventInfo` structure.
-When `eventInfo.newDiscreteStatesNeeded = true`, the FMU should stay in Event Mode and another call to <<fmi3NewDiscreteStates>> is required.
+When `eventInfo.newDiscreteStatesNeeded = true`, the FMU should stay in *Event Mode* and another call to <<fmi3NewDiscreteStates>> is required.
 
 <<fmi3EnterStepMode>>::
-Once all events are handled and <<fmi3NewDiscreteStates>> returns with `eventInfo.newDiscreteStatesNeeded = false`, the FMU should return back to the Step Mode, unless the FMU requests to terminate the Co-Simulation by setting  `fmi3EventInfo->terminateSimulation` to `true`.
-In order to push the FMU into the `Step Mode`, the <<fmi3EnterStepMode>> function is used.
+Once all events are handled and <<fmi3NewDiscreteStates>> returns with `eventInfo.newDiscreteStatesNeeded = false`, the FMU should return back to the *Step Mode*, unless the FMU requests to terminate the Co-Simulation by setting  `fmi3EventInfo->terminateSimulation` to `true`.
+In order to push the FMU into the *Step Mode*, the <<fmi3EnterStepMode>> function is used.
 In this case, a new step can be started from the current communication point time.
 
 <<fmi3GetClock>>::
 The status of <<clock,`clocks`>> can be inquired by this function.
 
 <<fmi3SetClock>>::
-For <<inputClock,`input clocks`>>, <<fmi3SetClock>> is called after entering event mode to set the activation status of <<clock,`clocks`>>.
-For both <<input>> and trigerred <<clock,`clocks`>>, this function can be called several times, only if recomputations of clock state are needed during event mode.
+For <<inputClock,`input clocks`>>, <<fmi3SetClock>> is called after entering *Event Mode* to set the activation status of <<clock,`clocks`>>.
+For both <<input>> and trigerred <<clock,`clocks`>>, this function can be called several times, only if recomputations of clock state are needed during *Event Mode*.
 
 <<fmi3GetIntervalDecimal>> & <<fmi3GetIntervalFraction>>::
-For both <<outputClock,`output clocks`>> and <<inputClock,`input clocks`>> it is allowed to call these functions during event mode.
+For both <<outputClock,`output clocks`>> and <<inputClock,`input clocks`>> it is allowed to call these functions during *Event Mode*.
 
 <<fmi3SetIntervalDecimal>> & <<fmi3SetIntervalFraction>>::
 It is not allowed to call these functions for <<output>>, aperiodic and strictly periodic <<clock,`clocks`>>.
@@ -857,18 +857,18 @@ In this Co-Simulation mode the following functions must not be called: <<fmi3DoS
 
 The states *Configuration Mode*, *Instantiated*, *Initialization Mode*, *Terminated*, and *Fatal* are handled in the same way as in mode `fmi3ModeCoSimulation` with the exception that the generally not allowed functions of the Co-Simulation mode `fmi3ModeScheduledExecutionSimulation` must not be called.
 
-====== State: slaveSetableFMUstate
+====== State: SlaveSetableFMUstate
 
 In all states of this super state it is allowed to call <<fmi3GetFMUState>>, `fmi3SetFMUState`, `fmi3FreeFMUState`, <<fmi3SerializedFMUStateSize>>, <<fmi3SerializeFMUState>>, <<fmi3DeSerializeFMUState>>, <<fmi3Reset>>, <<fmi3GetVersion>>, `fmi3SetDebugLogging` and <<fmi3FreeInstance>>.
 
 If any function returns with `fmi3Fatal` the FMU enters state *Fatal*.
 
-====== State: slaveUnderEvaluation
+====== State: SlaveUnderEvaluation
 
 This super state is entered by the FMU when <<fmi3Instantiate>> is called.
 If any function returns `fmi3Error` or `fmi3Discard` the FMU enters state *Terminated*.
 
-====== State: slaveInitialized
+====== State: SlaveInitialized
 
 This super state is entered by the FMU when `fmi3ExitInitializatoinMode` is called.
 If the function <<fmi3Terminate>> is called, the FMU enters state *Terminated* from all states of this super state.
@@ -877,7 +877,7 @@ After <<fmi3Terminate>> has been called no new tasks can be started (e.g. relate
 
 ====== State: Clock Activation Mode
 
-The FMU enters this state when the master calls <<fmi3ExitInitializationMode>> in state `Initialization Mode` or <<fmi3ExitConfigurationMode>> in state *Reconfiguration Mode*.
+The FMU enters this state when the master calls <<fmi3ExitInitializationMode>> in state *Initialization Mode* or <<fmi3ExitConfigurationMode>> in state *Reconfiguration Mode*.
 In this state the master can create multiple concurrent tasks related to an FMU and in each task the master can activate one or multiple <<inputClock,`input clocks`>> of an FMU based on the defined <<clock>> properties via a <<fmi3ActivateModelPartition>> call for each <<clock>>.
 
 Allowed Function Calls::
@@ -892,7 +892,7 @@ It is recommended to call `fmi3Set{VariableType}` and `fmi3Get{VariableType}` in
 <<get-and-set-variable-values,fmi3Set{VariableType}>>, `fmi3SetRealInputDerivatives`::
 Is called before the start of the computation of a model partition (i.e. before call of <<fmi3ActivateModelPartition>>) and only for global variables and variables associated to the <<inputClock>> assigned to the model partition.
 +
-The restrictions related to variable <<causality>> and <<variability>> defined for `Step Mode` in mode `fmi3ModeCoSimulation` apply.
+The restrictions related to variable <<causality>> and <<variability>> defined for *Step Mode* in mode `fmi3ModeCoSimulation` apply.
 +
 If the function returns with `fmi3OK` or `fmi3Warning` the FMU stays in this state.
 In case the function returns `fmi3Fatal` the master can prematurely end all tasks related to the computation of model partitions of this FMU.
@@ -901,7 +901,7 @@ In case the function returns `fmi3Discard` or `fmi3Error` the master must wait u
 <<get-and-set-variable-values,fmi3Get{VariableType}>>, `fmi3GetRealOutputDerivatives`, <<fmi3GetDirectionalDerivative>>`::
 Is called after the end of the computation of a model partition (i.e. after return of <<fmi3ActivateModelPartition>>) and only for global variables and variables associated to the <<inputClock>> assigned to the model partition.
 +
-The restrictions related to variable <<causality>> and <<variability>> defined for `Step Mode` in mode `fmi3ModeCoSimulation` apply.
+The restrictions related to variable <<causality>> and <<variability>> defined for *Step Mode* in mode `fmi3ModeCoSimulation` apply.
 +
 If the function returns with `fmi3OK` or `fmi3Warning` the FMU stays in this state.
 In case the function returns `fmi3Fatal` the master can prematurely end all tasks related to the computation of model partitions of this FMU.
@@ -961,13 +961,13 @@ Additionally to the generally forbidden functions in this Co-Simulation mode as 
 In this state the master can retrieve information from the FMU between communication points.
 Functions called in this state must not return `fmi3Discard`.
 
-The FMU enters this state by calling <<fmi3CallbackIntermediateUpdate>>  within <<fmi3ActivateModelPartition>> and leaves the state towards state `Clock Activation Mode` if the function returns `fmi3OK` or `fmi3Warning`.
+The FMU enters this state by calling <<fmi3CallbackIntermediateUpdate>>  within <<fmi3ActivateModelPartition>> and leaves the state towards state *Clock Activation Mode* if the function returns `fmi3OK` or `fmi3Warning`.
 If the function returns `fmi3Error` the FMU enters state *Terminated*.
 If the function returns `fmi3Fatal` the FMU enters state *Fatal*.
 
 
 Forbidden Function Calls::
-The same functions which are not allowed to be called in `Clock Activation Mode` must not be called in this state. Additionally the following functions must not be called <<fmi3ActivateModelPartition>>, <<fmi3EnterConfigurationMode>>, <<fmi3Terminate>>.
+The same functions which are not allowed to be called in *Clock Activation Mode* must not be called in this state. Additionally the following functions must not be called <<fmi3ActivateModelPartition>>, <<fmi3EnterConfigurationMode>>, <<fmi3Terminate>>.
 
 Allowed Function Calls::
 For a <<outputClock>> only the first call of `fmi3GetClock` for a specific activation of this <<clock>> signals `fmi3True`.

--- a/docs/6___appendix.adoc
+++ b/docs/6___appendix.adoc
@@ -117,7 +117,7 @@ This section gives an overview about the changes with respect to versions 1.0 fo
 
 * The different modes of an FMU are now clearly signaled with respective function calls (`fmi2EnterInitializationMode`, `fmi2EnterEventMode`, `fmi2EnterContinuousTimeMode`).
 
-* The interfaces have been redesigned, in order that algebraic loops over connected FMUs with Real, Integer, or Boolean unknowns can now be handled reasonably not only in Continuous Time Mode, but also in Initialization and Event Mode. In FMI 1.0, algebraic loops in Initialization and Even Mode could not be handled.
+* The interfaces have been redesigned, in order that algebraic loops over connected FMUs with Real, Integer, or Boolean unknowns can now be handled reasonably not only in *Continuous-Time Mode*, but also in *Initialization Mode* and *Event Mode*. In FMI 1.0, algebraic loops in *Initialization Mode* and *Even Mode* could not be handled.
 
 * The termination of every global event iteration over connected FMUs must be reported by a new function call (`fmi2EnterContinuousTimeMode`).
 


### PR DESCRIPTION
Changes include:
 - Formatting to bold using **
 - capitalization
 - CamelCase to Space Separated
 - sometimes mode was capitalized when not a state name

Please also consider and comment issue #718.