### PR TITLE
Add missing XML types for new variable types #697

### DIFF
--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -27,21 +27,50 @@ The types used in the FMI schema files are:
 |_Mapping to C_
 
 |`double`
-|IEEE double-precision 64-bit floating point type _[In order to not loose precision,
-a number of this type should be stored on an XML file with at least 16 significant digits; for example, 2/3 should be stored as `0.6666666666666667`]_
+|IEEE 754 double-precision 64-bit floating point type _[An IEEE 754 double-precision floating point value can have up to 17 significant digits in its decimal representation.
+In order to not loose precision, either an appropriate minimal printer algorithm should be used, or alternatively a number of this type should be stored in XML files with at least 17 significant digits.]_
 |`double`
 
+|`single`
+|IEEE 754 single-precision 32-bit floating point type _[An IEEE 754 single-precision floating point value can have up to 9 significant digits in its decimal representation.
+In order to not loose precision, either an appropriate minimal printer algorithm should be used, or alternatively a number of this type should be stored in XML files with at least 9 significant digits.]_
+|`float`
+
+|`byte`
+|Integer number with maximum value 127 and minimum value -128 (8 bit signed integer)
+|`int8_t`
+
+|`unsignedByte`
+|Integer number with maximum value 255 and minimum value 0 (8 bit unsigned integer)
+|`uint8_t`
+
+|`short`
+|Integer number with maximum value 32767 and minimum value -32768 (16 bit signed integer)
+|`int16_t`
+
+|`unsignedShort`
+|Integer number with maximum value 65535 and minimum value 0 (16 bit unsigned integer)
+|`uint16_t`
+
 |`int`
-|Integer number with maximum value 2147483647 and minimum value -2147483648 (32 bit Integer)
-|`int`
+|Integer number with maximum value 2147483647 and minimum value -2147483648 (32 bit signed integer)
+|`int32_t`
 
 |`unsignedInt`
-|Integer number with maximum value 4294967295 and minimum value 0 (unsigned 32 bit Integer)
-|`unsigned int`
+|Integer number with maximum value 4294967295 and minimum value 0 (32 bit unsigned integer)
+|`uint32_t`
+
+|`long`
+|Integer number with maximum value 9223372036854775807 and minimum value -9223372036854775808 (64 bit signed integer)
+|`int64_t`
+
+|`unsignedLong`
+|Integer number with maximum value 18446744073709551615 and minimum value 0 (64 bit unsigned integer)
+|`uint64_t`
 
 |`boolean`
 |Boolean number. Legal literals: `false`, `true`, `0`, `1`
-|`char`
+|`int`
 
 |`string`
 |Any number of characters


### PR DESCRIPTION
Also clarifies and corrects recommendations for floating point significant digits to be in line with IEEE 754.