### PR TITLE
rephrase-communication-interval

### DIFF
--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -424,7 +424,7 @@ If `toleranceDefined = fmi3True`, then the model is called with a numerical inte
 In such a case all numerical algorithms used inside the model (for example, to solve non-linear algebraic equations) should also operate with an error estimation of an appropriate smaller relative tolerance.
 
 `fmuType = fmi3CoSimulation`::
-If `toleranceDefined = fmi3True`, then the communication interval of the slave is controlled by error estimation.
+If `toleranceDefined = fmi3True`, then the communication step size of the slave is controlled by error estimation.
 In case the slave utilizes a numerical integrator with variable step size and error estimation, it is suggested to use `tolerance` for the error estimation of the internal integrator (usually as relative tolerance). +
 An FMU for Co-Simulation might ignore this argument.
 

--- a/docs/4_1_co-simulation_math.adoc
+++ b/docs/4_1_co-simulation_math.adoc
@@ -382,8 +382,8 @@ The activation of such a <<outputClock>> is not directly controlled by the Co-Si
 
 Intermediate variable access has three main uses:
 
-. *An FMU is able to produce valid output variables at intermediate points during a communication interval.*
-This is typically the result of an internal solver taking multiple integration steps at each communication interval.
+. *An FMU is able to produce valid output variables at intermediate points between two consecutive communication points.*
+This is typically the result of an internal solver taking multiple integration steps between two consecutive communication points.
 The FMU exposes intermediate output variables for the master whenever they are available.
 These can be used for e.g. extrapolation, interpolation, filtering or asynchronous co-simulation.
 


### PR DESCRIPTION
rephrase "communication interval" into "two consecutive communication points" because the term "communication interval" is not defined.