### PR TITLE
Clarify the integer type of Dimensions' start attributes

### DIFF
--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1139,11 +1139,11 @@ Variable elements can uniformly represent variables of primitive (atomic) types,
 Variable elements representing array variables must contain a `Dimensions` element specifying the array dimensions.
 The `Dimensions` element contains a sequence of `Dimension` elements, each specifying the size of one dimension of the array:
 
-- If the `<<start>> attribute of the `Dimension` element is present, it defines a constant size for this dimension, namely the integer value of the <<start>> attribute.
+- If the <<start>> attribute of the `Dimension` element is present, it defines a constant `fmi3Uint32` size for this dimension.
 The <<variability>> of the dimension size is <<constant>> in this case.
 
 - If the <<valueReference>> attribute of the `Dimension` element is present, it defines the size of this dimension to be the value of the variable with the value reference given by the <<valueReference>> attribute.
-The referenced variable must be a variable of integer type, and must either be a constant (i.e. with <<variability>> = <<constant>>) or a <<structuralParameter,`structural parameter`>>(i.e. with <<causality>> = <<structuralParameter>>).
+The referenced variable must be a variable of `fmi3Uint32` type, and must either be a constant (i.e. with <<variability>> = <<constant>>) or a <<structuralParameter,`structural parameter`>>(i.e. with <<causality>> = <<structuralParameter>>).
 The <<variability>> of the dimension size is in this case the <<variability>> of the referenced variable.
 
 These two options are mutually exclusive, i.e. for each `Dimension` element either a <<start>> attribute or an <<valueReference>> attribute can be supplied, but not both.

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1139,7 +1139,7 @@ Variable elements can uniformly represent variables of primitive (atomic) types,
 Variable elements representing array variables must contain a `Dimensions` element specifying the array dimensions.
 The `Dimensions` element contains a sequence of `Dimension` elements, each specifying the size of one dimension of the array:
 
-- If the <<start>> attribute of the `Dimension` element is present, it defines a constant `fmi3Uint32` size for this dimension.
+- If the <<start>> attribute of the `Dimension` element is present, it defines a constant unsigned 32-bit integer size for this dimension.
 The <<variability>> of the dimension size is <<constant>> in this case.
 
 - If the <<valueReference>> attribute of the `Dimension` element is present, it defines the size of this dimension to be the value of the variable with the value reference given by the <<valueReference>> attribute.

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1143,7 +1143,7 @@ The `Dimensions` element contains a sequence of `Dimension` elements, each speci
 The <<variability>> of the dimension size is <<constant>> in this case.
 
 - If the <<valueReference>> attribute of the `Dimension` element is present, it defines the size of this dimension to be the value of the variable with the value reference given by the <<valueReference>> attribute.
-The referenced variable must be a variable of `fmi3Uint32` type, and must either be a constant (i.e. with <<variability>> = <<constant>>) or a <<structuralParameter,`structural parameter`>>(i.e. with <<causality>> = <<structuralParameter>>).
+The referenced variable must be a variable of `UInt32` type, and must either be a constant (i.e. with <<variability>> = <<constant>>) or a <<structuralParameter,`structural parameter`>>(i.e. with <<causality>> = <<structuralParameter>>).
 The <<variability>> of the dimension size is in this case the <<variability>> of the referenced variable.
 
 These two options are mutually exclusive, i.e. for each `Dimension` element either a <<start>> attribute or an <<valueReference>> attribute can be supplied, but not both.


### PR DESCRIPTION
The integer type of start and valueReference attributes of Dimensions are expected to be the same, xs:unsignedInt, ie. fmi3Uint32.

Fixes #733 