### PR TITLE
Review section 2.2  to 2.2.6

### DIFF
--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -705,7 +705,7 @@ where:
 |latexmath:[t_0]
 |The time instant in seconds at which the <<clock>> ticks the first time (= the base <<clock>> starts at the start of the simulation tstart or when the controller is switched on plus an offset time toffset (xml-attributes `shiftCounter` and `resolution`).
 
-|latexmath:[t_{i+1}]
+|latexmath:[t_{i-1}]
 |The previous time instant in seconds, where the <<clock>> ticked.
 
 |latexmath:[\Delta T > 0]

--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -782,7 +782,7 @@ include::../headers/fmi3FunctionTypes.h[tag=SetClock]
 Sets the <<clock>> activation status by providing the value references of the corresponding <<clock>> variables and their values.
 A <<clock>> with <<valueReference>>[i] is activated at the current time instant if value[i] is set to `fmi3True`, otherwise the <<clock>> is deactivated.
 The clocked partition is evaluated in subactive mode (only output equations) if the argument subactive is non NULL and `subactive[i] = fmi3True`.
-The <<parameter>> `subactive` has no meaning for CommunicationPointClocks (`fmi3CPClock`) and is ignored for such <<clock,`clocks`>>.
+The <<parameter>> `subactive` has no meaning for CommunicationPointClocks (`CPClock`) and is ignored for such <<clock,`clocks`>>.
 It is not allowed to call this function within the callback function `fmi3IntermediateUpdate()`.
 
 [[fmi3GetClock,`fmi3GetClock`]]

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -690,9 +690,9 @@ The variable sub type `fmi3Clock` provides additional attributes for defining <<
 
 |`clockType`
 |The type of <<clock,`clocks`>> is defined based on the mandatory attribute `clockType`.
-If the properties of a <<clock>> adhere to synchronous clock theory it is defined with clockType = `STClock`.
+If the properties of a <<clock>> adhere to synchronous clock theory it is defined with clockType = `synchronousTime`.
 As an additional option for FMI for Co-Simulation discrete parts (that do not necessarily apply to synchronous clock theory) or continuous parts of the FMU can be associated to model partitions via <<clock,`clocks`>> whose ticks define the sampling points (i.e. communication points) for the variables of these model partitions.
-Clocks that are defined for such cases have the clockType attribute value `CPClock` and have to be ignored for FMI for Model Exchange.
+Clocks that are defined for such cases have the clockType attribute value `communicationPoint` and have to be ignored for FMI for Model Exchange.
 It is not allowed to include <<clock,`clocks`>> of different `clockType` in one FMU.
 `clockType` is a required attribute.
 
@@ -704,7 +704,6 @@ No ordering is defined for <<clock,`clocks`>> of the same priority.
 If a computational order information is needed, different priorities have to be defined.
 //TODO: Are 100 different priority levels enough?
 The minimum value is 0 (max priority).
-The maximum value is 99 (min priority).
 
 _[For periodic <<clock,`clocks`>> it is recommended to derive the priorities based on a rate monotonic scheduling scheme (smallest period leads to highest priority (smallest priority value)).]_
 
@@ -724,7 +723,7 @@ If the optional attribute `strict` is set to `false` another interval or offset 
 It is not allowed to set `strict` to `true` if `periodic = false`.
 
 |`intervalCounter`, `shiftCounter`, `resolution`
-|The interval of <<output>> or <<input>> periodic <<clock,`clocks`>> is defined with unsignedLong valued `intervalCounter` and `resolution`
+|The interval of <<output>> or <<input>> periodic <<clock,`clocks`>> is a rational number defined with unsignedLong valued `intervalCounter` and `resolution`
 
 `interval = intervalCounter / resolution`.
 
@@ -1348,15 +1347,15 @@ The optional attribute <<clockReference>> is used to define the <<clock,`clocks`
 This attribute can be used in all variable sub types with restrictions based on the `clockType`  attribute.
 The <<clockReference>> holds only <<valueReference>> information for variables with base type `fmi3Clock`.
 
-Clock (`clockType = STClock`): If present, the variable is a clocked variable associated uniquely with the <<clock>> referenced by <<valueReference>> and defined in element ModelVariables.
+Clock (`clockType = synchronousTime`): If present, the variable is a clocked variable associated uniquely with the <<clock>> referenced by <<valueReference>> and defined in element ModelVariables.
 It is not possible to associate more than one <<clock>> to a variable.
 
-Communication Point Clock (`clockType = CPClock`): If present, the variable is associated with the <<clock>> referenced by <<valueReference>> and defined in element `ModelVariables`.
+Communication Point Clock (`clockType = communicationPoint`): If present, the variable is associated with the <<clock>> referenced by <<valueReference>> and defined in element `ModelVariables`.
 It is possible to associate multiple <<clock,`clocks`>> to a variable.
 Variables that are assigned to a Communication Point Clock are not necessarily `clocked` in the sense of synchronous time clock theory. Such variables can also be continuous-time or discrete-time variables.
 
-If <<outputClock,`output clocks`>> and <<inputClock,`input clocks`>> of `clockType = CPClock` are defined in the `modelDescription.xml` it is possible to define a tick relationship from a <<outputClock>> to an aperiodic <<inputClock>> based on <<clockReference>> (<<clock-relationships-for-communication-point-clocks>>).
-This is done for aperiodic <<inputClock,`input clocks`>> that have the clockType = `CPClock` via providing a list of <<valueReference>> of <<outputClock,`output clocks`>> of the same FMU.
+If <<outputClock,`output clocks`>> and <<inputClock,`input clocks`>> of `clockType = communicationPoint` are defined in the `modelDescription.xml` it is possible to define a tick relationship from a <<outputClock>> to an aperiodic <<inputClock>> based on <<clockReference>> (<<clock-relationships-for-communication-point-clocks>>).
+This is done for aperiodic <<inputClock,`input clocks`>> that have the clockType = `communicationPoint` via providing a list of <<valueReference>> of <<outputClock,`output clocks`>> of the same FMU.
 If a <<outputClock>> of this <<valueReference>> list ticks the master has to create a tick for the associated aperiodic <<inputClock>> at the same time instant.
 It is not allowed to combine <<outputClock,`output clocks`>> with periodic or strict periodic <<inputClock,`input clocks`>> based on <<clockReference>>.
 

--- a/docs/4_3_co-simulation_schema.adoc
+++ b/docs/4_3_co-simulation_schema.adoc
@@ -136,7 +136,7 @@ _[If <<dependencies>> (`fmi3VariableDependency`) are defined in the `ModelStruct
 If <<dependencies>> are defined for variables across model partitions, such variables can not be assigned to a <<clock>> via <<clockReference>>.
 
 For FMI for Co-Simulation, variables that are assigned to a model partition of the model based on <<clockReference>> are not necessarily `clocked`.
-Such variables can be Continuous-time or Discrete-time variables if the <<clock>> is of `clockType = CPClock`.
+Such variables can be Continuous-time or Discrete-time variables if the <<clock>> is of `clockType = communicationPoint`.
 
 ===== Capability Flags [[xml-flags-clocked-co-simulation]]
 


### PR DESCRIPTION
- Fixed the naming of clockType's in the document
- Fixed previous time of periodic clocks