### PR TITLE
Fixed C-API call example for static FMU libs

### DIFF
--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -89,7 +89,7 @@ Typically, FMU functions are used as follows:
 // FMU is shipped with C source code, or with static link library
 #define FMI3_FUNCTION_PREFIX MyModel_
 #include "fmi3Functions.h"
-< usage of the FMU functions e.g. fmi3SetTime >
+< usage of the FMU functions e.g. MyModel_fmi3SetTime >
 
 // FMU is shipped with DLL/SharedObject
 #include "fmi3FunctionTypes.h"


### PR DESCRIPTION
For static FMU libs the c function name is prefixed with the modelidentifier.