### PR TITLE
valuereference is unique in FMI 3.0

### DIFF
--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -89,7 +89,7 @@ Typically, FMU functions are used as follows:
 // FMU is shipped with C source code, or with static link library
 #define FMI3_FUNCTION_PREFIX MyModel_
 #include "fmi3Functions.h"
-< usage of the FMU functions e.g. fmi3SetTime >
+< usage of the FMU functions e.g. MyModel_fmi3SetTime >
 
 // FMU is shipped with DLL/SharedObject
 #include "fmi3FunctionTypes.h"
@@ -159,8 +159,8 @@ include::../headers/fmi3PlatformTypes.h[tags=ValueReference]
 ----
 
 This is a handle to a (base type) variable value of the model.
-Handle and base type (such as `fmi3Float64`) uniquely identify the value of a variable.
-Variables of the same base type that have the same handle, always have identical values, but other parts of the variable definition might be different _[for example, min/max attributes]_.
+Handle uniquely identify the value of a variable.
+Variables that have the same handle, always have identical values, but other parts of the variable definition might be different _[for example, min/max attributes]_.
 
 All structured entities, such as records or arrays, are flattened into a set of scalar values of type `fmi3Float64`, `fmi3Int32` etc.
 An `fmi3ValueReference` references one such entity, record or array.


### PR DESCRIPTION
In fmi 3 the valueReference is unique across ALL variables not only across variables of the same base type.