### PR TITLE
Fixed array input parameter in C-API

### DIFF
--- a/headers/fmi3FunctionTypes.h
+++ b/headers/fmi3FunctionTypes.h
@@ -466,7 +466,7 @@ typedef fmi3Status fmi3SetClockTYPE(fmi3Instance instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     const fmi3Clock values[],
-                                    const fmi3Boolean *subactive);
+                                    const fmi3Boolean subactive[]);
 /* end::SetClock[] */
 
 /* tag::GetIntervalDecimal[] */


### PR DESCRIPTION
Array input parmeters use the notion "const TYPE varname[]" in FMI not
"const TYPE *varname".