### PR TITLE
The valueReference handle is globally unique in FMI 3.0

### DIFF
--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -159,8 +159,8 @@ include::../headers/fmi3PlatformTypes.h[tags=ValueReference]
 ----
 
 This is a handle to a (base type) variable value of the model.
-Handle and base type (such as `fmi3Float64`) uniquely identify the value of a variable.
-Variables of the same base type that have the same handle, always have identical values, but other parts of the variable definition might be different _[for example, min/max attributes]_.
+A handle uniquely identifies the value of a variable.
+Variables that have the same handle, always have identical values, but other parts of the variable definition might be different _[for example, min/max attributes]_.
 
 All structured entities, such as records or arrays, are flattened into a set of scalar values of type `fmi3Float64`, `fmi3Int32` etc.
 An `fmi3ValueReference` references one such entity, record or array.


### PR DESCRIPTION
Compared to FMI 2.0 in 3.0 the valueReference handle now identifies a
variable uniquely. In FMI 2.0 only valueReference and type were globally
unique.