### PR TITLE
Arrays are no longer flattend to variables.

### DIFF
--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -162,8 +162,9 @@ This is a handle to a (base type) variable value of the model.
 Handle and base type (such as `fmi3Float64`) uniquely identify the value of a variable.
 Variables of the same base type that have the same handle, always have identical values, but other parts of the variable definition might be different _[for example, min/max attributes]_.
 
-Structured entities, such as records, are flattened into a set of values of type `fmi3Float64`, `fmi3Int32` etc.
-An `fmi3ValueReference` references one such value.
+Structured entities, such as records, must be flattened into a set of values (scalars or arrays) of type `fmi3Float64`, `fmi3Int32` etc.
+Arrays may be flattened into a set of scalars or represented directly as array values.
+An `fmi3ValueReference` references one such value (scalar or array).
 The coding of `fmi3ValueReference` is a "secret" of the environment that generated the FMU.
 The interface to the equations only provides access to variables via this handle.
 Extracting concrete information about a variable is specific to the used environment that reads the Model Description File in which the value handles are defined.

--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -162,8 +162,8 @@ This is a handle to a (base type) variable value of the model.
 Handle and base type (such as `fmi3Float64`) uniquely identify the value of a variable.
 Variables of the same base type that have the same handle, always have identical values, but other parts of the variable definition might be different _[for example, min/max attributes]_.
 
-All structured entities, such as records or arrays, are flattened into a set of scalar values of type `fmi3Float64`, `fmi3Int32` etc.
-An `fmi3ValueReference` references one such entity, record or array.
+Structured entities, such as records, are flattened into a set of values of type `fmi3Float64`, `fmi3Int32` etc.
+An `fmi3ValueReference` references one such value.
 The coding of `fmi3ValueReference` is a "secret" of the environment that generated the FMU.
 The interface to the equations only provides access to variables via this handle.
 Extracting concrete information about a variable is specific to the used environment that reads the Model Description File in which the value handles are defined.


### PR DESCRIPTION
FMI 3.0 has arrays as "native" variables. Structures are still flattend
to single variables.