### PR TITLE
Fixed clock variable and enumeration names.

### DIFF
--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -632,7 +632,7 @@ _This mode can also be requested by the calling environment with <<fmi3SetClock>
 ====== Communication Point Clocks
 
 In addition to the above definition also a simplified <<clock>> definition used only in FMI for Co-Simulation is available that can be used to define the communication points of model partitions of the model (in the following such partitions are called model partitions).
-Such <<clock,`clocks`>> are called Communication Point Clocks (CPClocks).
+Such <<clock,`clocks`>> are called Communication Point Clocks.
 These <<clock,`clocks`>> are not compatible to synchronous clocks theory and must not be used together with synchronous clocks in one model.
 
 A model partition is mathematically defined as:
@@ -655,7 +655,7 @@ This section gives a definition of the two clock variants.
 
 ====== Output Clocks
 
-An <<outputClock>> is a general <<clock>> that ticks when a time-, state- or step-event occurs in the continuous-model partition of the FMU (for CPClocks these <<outputClock>> tick events can occour in all model partitions) and are identified based on their <<clockReference>> (see 2.2.3).
+An <<outputClock>> is a general <<clock>> that ticks when a time-, state- or step-event occurs in the continuous-model partition of the FMU (for Communication Point Clocks these <<outputClock>> tick events can occour in all model partitions) and are identified based on their <<clockReference>> (see 2.2.3).
 It can be periodic or non-periodic.
 _[Example: If_ latexmath:[b = x > 0] _, and a state event is defined when b changes from `false` to `true`, and b is defined as <<outputClock>>, then this <<clock>> is active whenever x changes from negative to positive values.]_
 
@@ -782,7 +782,7 @@ include::../headers/fmi3FunctionTypes.h[tag=SetClock]
 Sets the <<clock>> activation status by providing the value references of the corresponding <<clock>> variables and their values.
 A <<clock>> with <<valueReference>>s[i] is activated at the current time instant if values[i] is set to `fmi3ClockActive`, otherwise the <<clock>> is deactivated.
 The clocked partition is evaluated in subactive mode (only output equations) if the argument subactive is non NULL and `subactive[i] = fmi3True`.
-The <<parameter>> `subactive` has no meaning for CommunicationPointClocks (`CPClock`) and is ignored for such <<clock,`clocks`>>.
+The <<parameter>> `subactive` has no meaning for Communication Point Clocks and is ignored for such <<clock,`clocks`>>.
 It is not allowed to call this function within the callback function `fmi3IntermediateUpdate()`.
 
 [[fmi3GetClock,`fmi3GetClock`]]

--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -780,9 +780,9 @@ include::../headers/fmi3FunctionTypes.h[tag=SetClock]
 ----
 
 Sets the <<clock>> activation status by providing the value references of the corresponding <<clock>> variables and their values.
-A <<clock>> with <<valueReference>>[i] is activated at the current time instant if value[i] is set to `fmi3True`, otherwise the <<clock>> is deactivated.
+A <<clock>> with <<valueReference>>s[i] is activated at the current time instant if values[i] is set to `fmi3ClockActive`, otherwise the <<clock>> is deactivated.
 The clocked partition is evaluated in subactive mode (only output equations) if the argument subactive is non NULL and `subactive[i] = fmi3True`.
-The <<parameter>> `subactive` has no meaning for CommunicationPointClocks (`fmi3CPClock`) and is ignored for such <<clock,`clocks`>>.
+The <<parameter>> `subactive` has no meaning for CommunicationPointClocks (`CPClock`) and is ignored for such <<clock,`clocks`>>.
 It is not allowed to call this function within the callback function `fmi3IntermediateUpdate()`.
 
 [[fmi3GetClock,`fmi3GetClock`]]
@@ -792,8 +792,8 @@ include::../headers/fmi3FunctionTypes.h[tag=GetClock]
 ----
 
 Inquires whether a set of <<clock,`clocks`>> is active by providing the value references of the corresponding <<clock>> varaibels.
-A <<clock>> with <<valueReference>>[i] is active at the current time instant if `value[i] = fmi3True`, otherwise the <<clock>> is not active. It is allowed to call this function within the callback function `fmi3IntermediateUpdate()`.
-It is required for an FMU to directly internally set back the activation <<state>> of an <<outputClock>> latexmath:[i] to `fmi3False` if the function <<fmi3GetClock>> is called for a <<clock>> latexmath:[i] and the interface is set to `fmi3ScheduledExecutionSimulation`.
+A <<clock>> with <<valueReference>>s[i] is active at the current time instant if `values[i] = fmi3ClockActive`, otherwise the <<clock>> is not active. It is allowed to call this function within the callback function `fmi3IntermediateUpdate()`.
+It is required for an FMU to directly internally set back the activation <<state>> of an <<outputClock>> latexmath:[i] to `fmi3ClockInactive` if the function <<fmi3GetClock>> is called for a <<clock>> latexmath:[i] and the interface is set to `fmi3ScheduledExecutionSimulation`.
 _[This is required to allow preemption.]_
 // TODO: add xref to 4.4.5
 

--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -579,6 +579,7 @@ For Co-Simulation FMUs, additional functions are defined in <<transfer-of-input-
 The value of a variable may only be accessed with the respective `fmi3Get/Set{VariableType}` for its type.
 
 ==== Operation on Clocks [[operation-on-clocks]]
+
 In the following section the operations on <<clock,`clocks`>> are described.
 Clocks are defined for the evaluation of *clocked model partitions* and the related definition of suitable *communication points*.
 Two types of <<clock,`clocks`>> are available, designed to address similar use cases with differences in details.

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -692,7 +692,7 @@ The variable sub type `fmi3Clock` provides additional attributes for defining <<
 |The type of <<clock,`clocks`>> is defined based on the mandatory attribute `clockType`.
 If the properties of a <<clock>> adhere to synchronous clock theory it is defined with clockType = `STClock`.
 As an additional option for FMI for Co-Simulation discrete parts (that do not necessarily apply to synchronous clock theory) or continuous parts of the FMU can be associated to model partitions via <<clock,`clocks`>> whose ticks define the sampling points (i.e. communication points) for the variables of these model partitions.
-Clocks that are defined for such cases have the clockType attribute value `CPClock` and have to be ignored for FMI for Model Exchange.
+Clocks that are defined for such cases have the `clockType` attribute value `communicationPoint` and have to be ignored for FMI for Model Exchange.
 It is not allowed to include <<clock,`clocks`>> of different `clockType` in one FMU.
 `clockType` is a required attribute.
 
@@ -1351,12 +1351,12 @@ The <<clockReference>> holds only <<valueReference>> information for variables w
 Clock (`clockType = STClock`): If present, the variable is a clocked variable associated uniquely with the <<clock>> referenced by <<valueReference>> and defined in element ModelVariables.
 It is not possible to associate more than one <<clock>> to a variable.
 
-Communication Point Clock (`clockType = CPClock`): If present, the variable is associated with the <<clock>> referenced by <<valueReference>> and defined in element `ModelVariables`.
+Communication Point Clock (`clockType = communicationPoint`): If present, the variable is associated with the <<clock>> referenced by <<valueReference>> and defined in element `ModelVariables`.
 It is possible to associate multiple <<clock,`clocks`>> to a variable.
 Variables that are assigned to a Communication Point Clock are not necessarily `clocked` in the sense of synchronous time clock theory. Such variables can also be continuous-time or discrete-time variables.
 
-If <<outputClock,`output clocks`>> and <<inputClock,`input clocks`>> of `clockType = CPClock` are defined in the `modelDescription.xml` it is possible to define a tick relationship from a <<outputClock>> to an aperiodic <<inputClock>> based on <<clockReference>> (<<clock-relationships-for-communication-point-clocks>>).
-This is done for aperiodic <<inputClock,`input clocks`>> that have the clockType = `CPClock` via providing a list of <<valueReference>> of <<outputClock,`output clocks`>> of the same FMU.
+If <<outputClock,`output clocks`>> and <<inputClock,`input clocks`>> of `clockType = communicationPoint` are defined in the `modelDescription.xml` it is possible to define a tick relationship from a <<outputClock>> to an aperiodic <<inputClock>> based on <<clockReference>> (<<clock-relationships-for-communication-point-clocks>>).
+This is done for aperiodic <<inputClock,`input clocks`>> that have the clockType = `communicationPoint` via providing a list of <<valueReference>> of <<outputClock,`output clocks`>> of the same FMU.
 If a <<outputClock>> of this <<valueReference>> list ticks the master has to create a tick for the associated aperiodic <<inputClock>> at the same time instant.
 It is not allowed to combine <<outputClock,`output clocks`>> with periodic or strict periodic <<inputClock,`input clocks`>> based on <<clockReference>>.
 

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -690,7 +690,7 @@ The variable sub type `fmi3Clock` provides additional attributes for defining <<
 
 |`clockType`
 |The type of <<clock,`clocks`>> is defined based on the mandatory attribute `clockType`.
-If the properties of a <<clock>> adhere to synchronous clock theory it is defined with clockType = `STClock`.
+If the properties of a <<clock>> adhere to synchronous clock theory it is defined with `clockType = synchronousTime`.
 As an additional option for FMI for Co-Simulation discrete parts (that do not necessarily apply to synchronous clock theory) or continuous parts of the FMU can be associated to model partitions via <<clock,`clocks`>> whose ticks define the sampling points (i.e. communication points) for the variables of these model partitions.
 Clocks that are defined for such cases have the `clockType` attribute value `communicationPoint` and have to be ignored for FMI for Model Exchange.
 It is not allowed to include <<clock,`clocks`>> of different `clockType` in one FMU.

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -692,7 +692,7 @@ The variable sub type `fmi3Clock` provides additional attributes for defining <<
 |The type of <<clock,`clocks`>> is defined based on the mandatory attribute `clockType`.
 If the properties of a <<clock>> adhere to synchronous clock theory it is defined with `clockType = synchronousTime`.
 As an additional option for FMI for Co-Simulation discrete parts (that do not necessarily apply to synchronous clock theory) or continuous parts of the FMU can be associated to model partitions via <<clock,`clocks`>> whose ticks define the sampling points (i.e. communication points) for the variables of these model partitions.
-Clocks that are defined for such cases have the `clockType` attribute value `communicationPoint` and have to be ignored for FMI for Model Exchange.
+Clocks that are defined for such cases have `clockType = communicationPoint` and have to be ignored for Model Exchange.
 It is not allowed to include <<clock,`clocks`>> of different `clockType` in one FMU.
 `clockType` is a required attribute.
 
@@ -1356,7 +1356,7 @@ It is possible to associate multiple <<clock,`clocks`>> to a variable.
 Variables that are assigned to a Communication Point Clock are not necessarily `clocked` in the sense of synchronous time clock theory. Such variables can also be continuous-time or discrete-time variables.
 
 If <<outputClock,`output clocks`>> and <<inputClock,`input clocks`>> of `clockType = communicationPoint` are defined in the `modelDescription.xml` it is possible to define a tick relationship from a <<outputClock>> to an aperiodic <<inputClock>> based on <<clockReference>> (<<clock-relationships-for-communication-point-clocks>>).
-This is done for aperiodic <<inputClock,`input clocks`>> that have the clockType = `communicationPoint` via providing a list of <<valueReference>> of <<outputClock,`output clocks`>> of the same FMU.
+This is done for aperiodic <<inputClock,`input clocks`>> that have the `clockType = communicationPoint` via providing a list of <<valueReference>> of <<outputClock,`output clocks`>> of the same FMU.
 If a <<outputClock>> of this <<valueReference>> list ticks the master has to create a tick for the associated aperiodic <<inputClock>> at the same time instant.
 It is not allowed to combine <<outputClock,`output clocks`>> with periodic or strict periodic <<inputClock,`input clocks`>> based on <<clockReference>>.
 

--- a/docs/4_3_co-simulation_schema.adoc
+++ b/docs/4_3_co-simulation_schema.adoc
@@ -136,7 +136,7 @@ _[If <<dependencies>> (`fmi3VariableDependency`) are defined in the `ModelStruct
 If <<dependencies>> are defined for variables across model partitions, such variables can not be assigned to a <<clock>> via <<clockReference>>.
 
 For FMI for Co-Simulation, variables that are assigned to a model partition of the model based on <<clockReference>> are not necessarily `clocked`.
-Such variables can be Continuous-time or Discrete-time variables if the <<clock>> is of `clockType = CPClock`.
+Such variables can be Continuous-time or Discrete-time variables if the <<clock>> is of `clockType = communicationPoint`.
 
 ===== Capability Flags [[xml-flags-clocked-co-simulation]]
 


### PR DESCRIPTION
Adapted the clock variable names in the document according the header
files. Clock activitiy is also not given by fmi3True/fmi3False but by
fmi3ClockActive/fmi3ClockInactive.