### PR TITLE
Adapted variables names in document to header files

### DIFF
--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -945,17 +945,17 @@ include::../headers/fmi3FunctionTypes.h[tags=GetDirectionalDerivative]
 
 This function computes the directional derivatives of an FMU.
 
-- Argument `vrUnknown` contains the <<valueReference>>pass:[s] of the unknown variables.
-The number of <<valueReference>>pass:[s] is given by the argument `nUnknown`.
+- Argument `unknowns` contains the <<valueReference>>pass:[s] of the unknown variables.
+The number of <<valueReference>>pass:[s] is given by the argument `nUnknowns`.
 
-- Argument `vrKnown` contains the <<valueReference>>pass:[s] of the known variables.
-The number of <<valueReference>>pass:[s] is given by the argument `nKnown`.
+- Argument `knowns` contains the <<valueReference>>pass:[s] of the known variables.
+The number of <<valueReference>>pass:[s] is given by the argument `nKnowns`.
 
-- Arguments `dvKnown` and `dvUnknown` contain the serialized values of the referenced variables (serialization of values as defined in <<get-and-set-variable-values>>).
+- Arguments `deltaKnowns` and `deltaUnknowns` contain the serialized values of the referenced variables (serialization of values as defined in <<get-and-set-variable-values>>).
 
-- Argument `nDvKnown` provides the number of values in `dvKnown` which is only equal to `nKnown` if all <<valueReference>>pass:[s] of `vrKnown` point to variables.
+- Argument `nDeltaKnowns` provides the number of values in `deltaKnowns` which is only equal to `nKnowns` if all <<valueReference>>pass:[s] of `knowns` point to scalar variables.
 
-- Argument `nDvUnknown` provides the number of values in `dvUnknown` which is only equal to `nUnknown` if all <<valueReference>>pass:[s] of `vrUnknown` point to variables.
+- Argument `nDeltaUnknowns` provides the number of values in `deltaUnknowns` which is only equal to `nUnknowns` if all <<valueReference>>pass:[s] of `unknowns` point to scalar variables.
 
 An FMU has different modes and in every mode an FMU might be described by different equations and different unknowns.
 The precise definitions are given in the mathematical descriptions of Model Exchange (<<math-model-exchange>>) and Co-Simulation (<<math-co-simulation>>).
@@ -994,7 +994,7 @@ If the capability attribute `providesDirectionalDerivative` is `true`, <<fmi3Get
 \Delta \mathbf{v}_{unknown} = \sum_i \frac{\partial \mathbf{h}}{\partial \mathbf{v}(i)_{known}}\Delta \mathbf{v}(i)_{known}
 ++++
 
-Accordingly, it computes the directional derivative vector latexmath:[\color{blue}{\Delta \mathbf{v}_{unknown}}] (`dvUnknown`) from the seed vector latexmath:[\color{blue}{\Delta \mathbf{v}_{known}}] (`dvKnown`)
+Accordingly, it computes the directional derivative vector latexmath:[\color{blue}{\Delta \mathbf{v}_{unknown}}] (`deltaUnknowns`) from the seed vector latexmath:[\color{blue}{\Delta \mathbf{v}_{known}}] (`deltaKnowns`)
 
 _[The variable relationships are different in different modes._
 _For example, during *Continuous-Time Mode*, a continuous-time output y does not depend on discrete-time <<input,`inputs`>> (because they are held constant between events)._


### PR DESCRIPTION
For directional derivatives the variable names in the document are
different compared to the names in the header files.