### PR TITLE
Fixed variable names for getting dependencies

### DIFF
--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -994,7 +994,7 @@ If the capability attribute `providesDirectionalDerivative` is `true`, <<fmi3Get
 \Delta \mathbf{v}_{unknown} = \sum_i \frac{\partial \mathbf{h}}{\partial \mathbf{v}(i)_{known}}\Delta \mathbf{v}(i)_{known}
 ++++
 
-Accordingly, it computes the directional derivative vector latexmath:[\color{blue}{\Delta \mathbf{v}_{unknown}}] (`dvUnknown`) from the seed vector latexmath:[\color{blue}{\Delta \mathbf{v}_{known}}] (`dvKnown`)
+Accordingly, it computes the directional derivative vector latexmath:[\color{blue}{\Delta \mathbf{v}_{unknown}}] (`deltaUnknowns`) from the seed vector latexmath:[\color{blue}{\Delta \mathbf{v}_{known}}] (`deltaKnowns`)
 
 _[The variable relationships are different in different modes._
 _For example, during *Continuous-Time Mode*, a continuous-time output y does not depend on discrete-time <<input,`inputs`>> (because they are held constant between events)._
@@ -1160,7 +1160,7 @@ include::../headers/fmi3FunctionTypes.h[tags=GetNumberOfVariableDependencies]
 
 This function returns the number of <<dependencies>> for a given variable.
 
-- Argument `vr` specifies the <<valueReference>> of the variable for which the number of <<dependencies>> should be returned.
+- Argument `valueReference` specifies the <<valueReference>> of the variable for which the number of <<dependencies>> should be returned.
 - Argument `nDependencies` points to the `size_t` variable that will receive the number of <<dependencies>>.
 
 The actual <<dependencies>> (of type `fmi3DependencyKind`) can be retrieved by calling the function `fmi3GetVariableDependencies`:
@@ -1174,25 +1174,25 @@ include::../headers/fmi3FunctionTypes.h[tags=GetVariableDependencies]
 
 This function returns the dependency information for a single variable.
 
-- Argument `vrDependent` specifies the <<valueReference>> of the variable for which the dependencies should be returned.
+- Argument `dependent` specifies the <<valueReference>> of the variable for which the dependencies should be returned.
 
 - Argument `nDependencies` specifies the number of dependencies that the calling environment allocated space for in the result buffers, and should correspond to the returned by calling <<fmi3GetNumberOfVariableDependencies>>.
 
-- Argument `elementIndexDependent` must point to a buffer of `size_t` values of size `nDependencies` allocated by the calling environment.
+- Argument `elementIndicesOfDependent` must point to a buffer of `size_t` values of size `nDependencies` allocated by the calling environment.
 It is filled in by this function with the element index of the dependent variable that dependency information is provided for.
 The element indices start with 1. Using the element index 0 means all elements of the variable.
 (Note: If an array has more than one dimension the indices are serialized in the same order as defined for values).
 
-- Argument `vrIndependent` must point to a buffer of `fmi3ValueReference` values of size `nDependencies` allocated by the calling environment.
+- Argument `independents` must point to a buffer of `fmi3ValueReference` values of size `nDependencies` allocated by the calling environment.
 It is filled in by this function with the value reference of the <<independent>> variable that this dependency entry is dependent upon.
 
-- Argument `elementIndexIndependent` must point to a buffer of `size_t` values of size `nDependencies` allocated by the calling environment.
+- Argument `elementIndicesIndependents` must point to a buffer of `size_t` values of size `nDependencies` allocated by the calling environment.
 It is filled in by this function with the element index of the <<independent>> variable that this dependency entry is dependent upon.
 The element indices start with 1.
 Using the element index 0 means all elements of the variable.
 (Note: If an array has more than one dimension the indices are serialized in the same order as defined for values).
 
-- Argument `dependencyType` must point to a buffer of `fmi3DependencyKind` values of size `nDependencies` allocated by the calling environment.
+- Argument `dependencyKinds` must point to a buffer of `fmi3DependencyKind` values of size `nDependencies` allocated by the calling environment.
 It is filled in by this function with the enumeration value describing the dependency of this dependency entry.
 
 If this function is called before the <<fmi3ExitInitializationMode>> call, it returns the initial dependencies.


### PR DESCRIPTION
The variable names in the document for getting dependencies are
different than the names in the header files.