### PR TITLE
Fixes #650. Adds explicit numbering html.

### DIFF
--- a/docs/docinfo.html
+++ b/docs/docinfo.html
@@ -73,7 +73,7 @@ document.addEventListener('keydown', (event) => {
             // Set to 'none' to use the tocify classes
             theme: "none",
             // Handle book (may contain h1) and article (only h2 deeper)
-            selectors: $( "#content" ).has( "h1" ).size() > 0 ? "h1,h2,h3,h4,h5" : "h2,h3,h4,h5",
+            selectors: $( "#content" ).has( "h1" ).size() > 0 ? "h1,h2,h3,h4,h5" : "h2,h3,h4,h5,h6",
             ignoreSelector: ".discrete"
         });
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,8 +1,9 @@
 = Functional Mock-up Interface for Model{nbsp}Exchange and Co-Simulation
 :sectnums:
+:sectnumlevels: 5
 :toc: left
 :toc-title: Contents
-:toclevels: 3
+:toclevels: 5
 :xrefstyle: short
 :docinfo: shared
 :docinfodir: docs


### PR DESCRIPTION
With this pull-request the TOC in the left side will show up to 5 levels (max according to asciidoctor https://asciidoctor.org/docs/user-manual/#table-of-contents-summary.

Additionally, the numbers will be shown in the text.

@andreas-junghanns you assigned yourself to this - I hope it is okay, that I created this pull-request.