### PR TITLE
Some clarification of array variables regarding structured variable naming

### DIFF
--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -2240,6 +2240,7 @@ line feed (#xA) nor tab (#x9)
 Structured names are hierarchical using "." as a separator between hierarchies.
 A name consists of "pass:[_]", letters and digits or may consist of any characters enclosed in single apostrophes.
 A name may identify an array element on every hierarchical level using "[...]" to identify the respective array index.
+If an array is a leaf node of the variable hierarchy then the array can also be represented as a single variable of type array.
 A <<derivative>> of a variable is defined with `der(name)` for the first time derivative and `der(name,N)` for the N-th derivative.
 Examples:
 
@@ -2294,7 +2295,7 @@ vehicle.engine.inputSpeed
 vehicle.engine.temperature
 ----
 
-All array elements are given in a consecutive sequence of variables.
+All flattened array elements are given in a consecutive sequence of variables.
 Elements of multi-dimensional arrays are ordered according to "row major" order that is elements of the last index are given in sequence.
 
 _[For example, the vector `centerOfMass` in body `arm1` is mapped to the following variables:_


### PR DESCRIPTION
The section about structured variable naming describes the flattening of
arrays using the [...] syntax of structure variable naming.
Clarify that this flattening is possible but no longer required for leaf
node variables of the hierarchy when the new array are used.