### PR TITLE
Clarify the row-major serialization.

### DIFF
--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -507,6 +507,7 @@ Each variable must have a unique <<valueReference>>.
 
 Variables can be scalar or array variables.
 When getting or setting the values of array variables, the serialization of array variable values used in C-API function calls, as well as in the XML <<start>> attributes is defined as row major - i.e. dimension order from left to right for the C-API (e.g. `array[dim1][dim2]...[dimN]`), and document order in the XML attributes.
+For this serialization of array variables the array is considered to be dense. Hence, the dependencies of single elements, being get using `fmi3GetVariableDependencies`, is not honored by the serialization.
 
 _[Example: A 2D matrix_
 [latexmath]


### PR DESCRIPTION
The row-major serialization is always done on a dense view of the
arrays.
Hence, the dependencies given by fmi3GetVariableDependencies does not
influence the row-major serialization.
This may lead to many 0 values in setter/getter API calls for sparse
arrays.
But everything else will be quite complicated and even not possible for
the values in the XML file which are also serialized using row-major
format since the per element dependencies are not known statically in
the XML file.