### PR TITLE
Fixed constness of parameters in fmi3SetIntervalDecimal and fmi3SetIntervalFraction

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -300,7 +300,7 @@ To reference a function, type, definition or parameter use its name as xref and 
 typedef fmi3Status fmi3SetIntervalDecimalTYPE(fmi3Instance instance,
                                               const fmi3ValueReference valueReferences[],
                                               size_t nValueReferences,
-                                              fmi3Float64 interval[]);
+                                              const fmi3Float64 interval[]);
 ----
 
 A clock interval is set by the environment for the current time instant by the function <<fmi3SetIntervalDecimal>>.

--- a/docs/examples/c-code/VanDerPol/sources/fmi3Functions.c
+++ b/docs/examples/c-code/VanDerPol/sources/fmi3Functions.c
@@ -634,7 +634,7 @@ fmi3Status fmi3GetIntervalDecimal(fmi3Instance instance,
 
 fmi3Status fmi3SetIntervalDecimal(fmi3Instance instance,
                                       const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                  fmi3Float64 interval[]) {
+                                  const fmi3Float64 interval[]) {
     NOT_IMPLEMENTED
 }
 
@@ -646,7 +646,7 @@ fmi3Status fmi3GetIntervalFraction(fmi3Instance instance,
 
 fmi3Status fmi3SetIntervalFraction(fmi3Instance instance,
                                    const fmi3ValueReference valueReferences[], size_t nValueReferences,
-                                   fmi3UInt64 intervalCounter[], fmi3UInt64 resolution[]) {
+                                   const fmi3UInt64 intervalCounter[], const fmi3UInt64 resolution[]) {
     NOT_IMPLEMENTED
 }
 

--- a/headers/fmi3FunctionTypes.h
+++ b/headers/fmi3FunctionTypes.h
@@ -488,15 +488,15 @@ typedef fmi3Status fmi3GetIntervalFractionTYPE(fmi3Instance instance,
 typedef fmi3Status fmi3SetIntervalDecimalTYPE(fmi3Instance instance,
                                               const fmi3ValueReference valueReferences[],
                                               size_t nValueReferences,
-                                              fmi3Float64 interval[]);
+                                              const fmi3Float64 interval[]);
 /* end::SetIntervalDecimal[] */
 
 /* tag::SetIntervalFraction[] */
 typedef fmi3Status fmi3SetIntervalFractionTYPE(fmi3Instance instance,
                                                const fmi3ValueReference valueReferences[],
                                                size_t nValueReferences,
-                                               fmi3UInt64 intervalCounter[],
-                                               fmi3UInt64 resolution[]);
+                                               const fmi3UInt64 intervalCounter[],
+                                               const fmi3UInt64 resolution[]);
 /* end::SetIntervalFraction[] */
 
 /* tag::NewDiscreteStates[] */


### PR DESCRIPTION
Missing const for input parameters