### PR TITLE
Define the path of FMU and terminal icons.

### DIFF
--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1094,11 +1094,12 @@ For `fmi3Terminals` (terminals which are listed in the `Terminals` element) the 
 _[If the graphical representation is used for an <<input>> or <<output>> (e.g. a Real <<input>> `u`), then a `Terminal` has to be added to the `Terminals` element which has one `TerminalMemberVariable`._
 _The name of the `Terminal` and the name of the `TerminalMemberVariable` should be equal to the name of the <<input>> / <<output>>.]_
 
-The `iconSource_PNG` attribute is mandatory to simplify the import in other tools, so a PNG file has to be provided in any case. An additional SVG file can be provided with the attribute `iconSource_SVG`.
-Both attributes define the source of the image file as a relative URI according to RFC 3986.
+The `iconBaseName` attribute is mandatory. 
+This attribute defines the base name of the image file as a relative URI according to RFC 3986. 
 The base URI that this relative URI is resolved against is the URI of the `icon` folder in the FMU ZIP archive.
 Implementations are only REQUIRED to support relative URIs, excluding relative URIs that move beyond the baseURI (i.e. go "up" a level via ..).
 Implementations are NOT REQUIRED to support any absolute URIs and any specific URI schemes.
+The PNG file with the extension '.png' has to be provided. An additional SVG file with extension '.svg' is optional.
 
 _[Note that this specification is functionally equivalent to looking up image sources from the icon folder of the FMU ZIP Archive after dot removal from the path as per section 5.2.4 of RFC 3986.]_
 

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1085,6 +1085,9 @@ In the `Icon` element the FMU icon without terminals is defined, its extent and 
 The `iconSource_PNG` attribute is mandatory to simplify the import in other tools, so a PNG file has to be provided in any case.
 Optionally an SVG file can be provided.
 This enables high quality rendering and printing in importing tools.
+Both attributes define the relative path to the image file relative to the resource directory of the FMU where the files are placed by the exporting tool.
+The importing tool can then read these files relative to the absolute location provided by the parameter `fmuResourceLocation` of the `fmi3Instantiate` call.
+Note that the path separator in the XML file is the forward slash "/".
 
 ===== Terminals
 
@@ -1095,6 +1098,7 @@ _[If the graphical representation is used for an <<input>> or <<output>> (e.g. a
 _The name of the `Terminal` and the name of the `TerminalMemberVariable` should be equal to the name of the <<input>> / <<output>>.]_
 
 The `iconSource_PNG` is mandatory for a terminal, optionally an SVG file can be provided.
+For the definition of the path of these attributes see the definition of the equal attributes in <<icon>>.
 The default connection stroke size and color can be provided, to define the intended connection line layout in the importing tool. The stroke size is given relative to the coordinate system extent.
 The stroke color is given in RGB values from 0 to 255. E.g.: `255 255 0`.
 

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1080,19 +1080,11 @@ Flipping of the FMU icon or a terminal can be realized by setting its attributes
 
 image::images/fmiModelDescription_GraphicalRepresentation_Icon_Schema.png[width=30%, pdfwidth=30%, align="center"]
 
-In the `Icon` element the FMU icon without terminals is defined, its extent and position.
-
-The `iconSource_PNG` attribute is mandatory to simplify the import in other tools, so a PNG file has to be provided in any case.
-Optionally an SVG file can be provided.
+The extent and position of the FMU icon are defined in the `Icon` element.
+The optional image file of the FMU icon is placed at the path `icon/icon.png` in ZIP archive of the FMU. The terminals should not be visible in the image. 
+Optionally an SVG file can be provided if also the PNG file is present.
 This enables high quality rendering and printing in importing tools.
-Both attributes define the source of the image file as a relative URI according to RFC 3986.
-The base URI that this relative URI is resolved against is the URI of the modelDescription.xml file.
-Implementations are only REQUIRED to support relative URIs, excluding relative URIs that move beyond the baseURI (i.e. go "up" a level via ..).
-Implementations are NOT REQUIRED to support any absolute URIs and any specific URI schemes.
-
-The additional files for the FMU icons must be placed in the `icon` folder in the FMU ZIP archive.
-
-_[Note that this specification is functionally equivalent to looking up image sources from the root of the FMU ZIP Archive after dot removal from the path as per section 5.2.4 of RFC 3986.]_
+This SVG file has to be placed at the path `icon/icon.svg` in the ZIP archive.
 
 ===== Terminals
 
@@ -1102,12 +1094,16 @@ For `fmi3Terminals` (terminals which are listed in the `Terminals` element) the 
 _[If the graphical representation is used for an <<input>> or <<output>> (e.g. a Real <<input>> `u`), then a `Terminal` has to be added to the `Terminals` element which has one `TerminalMemberVariable`._
 _The name of the `Terminal` and the name of the `TerminalMemberVariable` should be equal to the name of the <<input>> / <<output>>.]_
 
-The `iconSource_PNG` is mandatory for a terminal, optionally an SVG file can be provided.
-For the definition of the path of these attributes see the definition of the equal attributes in <<icon>>.
+The `iconSource_PNG` attribute is mandatory to simplify the import in other tools, so a PNG file has to be provided in any case. An additional SVG file can be provided with the attribute `iconSource_SVG`.
+Both attributes define the source of the image file as a relative URI according to RFC 3986.
+The base URI that this relative URI is resolved against is the URI of the `icon` folder in the FMU ZIP archive.
+Implementations are only REQUIRED to support relative URIs, excluding relative URIs that move beyond the baseURI (i.e. go "up" a level via ..).
+Implementations are NOT REQUIRED to support any absolute URIs and any specific URI schemes.
+
+_[Note that this specification is functionally equivalent to looking up image sources from the icon folder of the FMU ZIP Archive after dot removal from the path as per section 5.2.4 of RFC 3986.]_
+
 The default connection stroke size and color can be provided, to define the intended connection line layout in the importing tool. The stroke size is given relative to the coordinate system extent.
 The stroke color is given in RGB values from 0 to 255. E.g.: `255 255 0`.
-
-The additional files for the terminal icons must be placed in the `icon` folder in the FMU ZIP archive.
 
 The VendorAnnotations element can be used by vendors to store additional information for the graphical representation.
 _[It is suggested that Modelica tools store the Modelica annotation of the connector under the tool name `Modelica3Annotation` in the attribute `annotation` of an element `connector`._

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1090,6 +1090,8 @@ The base URI that this relative URI is resolved against is the URI of the modelD
 Implementations are only REQUIRED to support relative URIs, excluding relative URIs that move beyond the baseURI (i.e. go "up" a level via ..).
 Implementations are NOT REQUIRED to support any absolute URIs and any specific URI schemes.
 
+The additional files for the FMU icons must be placed in the `icon` folder in the FMU ZIP archive.
+
 _[Note that this specification is functionally equivalent to looking up image sources from the root of the FMU ZIP Archive after dot removal from the path as per section 5.2.4 of RFC 3986.]_
 
 ===== Terminals
@@ -1104,6 +1106,8 @@ The `iconSource_PNG` is mandatory for a terminal, optionally an SVG file can be 
 For the definition of the path of these attributes see the definition of the equal attributes in <<icon>>.
 The default connection stroke size and color can be provided, to define the intended connection line layout in the importing tool. The stroke size is given relative to the coordinate system extent.
 The stroke color is given in RGB values from 0 to 255. E.g.: `255 255 0`.
+
+The additional files for the terminal icons must be placed in the `icon` folder in the FMU ZIP archive.
 
 The VendorAnnotations element can be used by vendors to store additional information for the graphical representation.
 _[It is suggested that Modelica tools store the Modelica annotation of the connector under the tool name `Modelica3Annotation` in the attribute `annotation` of an element `connector`._

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1085,9 +1085,12 @@ In the `Icon` element the FMU icon without terminals is defined, its extent and 
 The `iconSource_PNG` attribute is mandatory to simplify the import in other tools, so a PNG file has to be provided in any case.
 Optionally an SVG file can be provided.
 This enables high quality rendering and printing in importing tools.
-Both attributes define the relative path to the image file relative to the resource directory of the FMU where the files are placed by the exporting tool.
-The importing tool can then read these files relative to the absolute location provided by the parameter `fmuResourceLocation` of the `fmi3Instantiate` call.
-Note that the path separator in the XML file is the forward slash "/".
+Both attributes define the source of the image file as a relative URI according to RFC 3986.
+The base URI that this relative URI is resolved against is the URI of the modelDescription.xml file.
+Implementations are only REQUIRED to support relative URIs, excluding relative URIs that move beyond the baseURI (i.e. go "up" a level via ..).
+Implementations are NOT REQUIRED to support any absolute URIs and any specific URI schemes.
+
+_[Note that this specification is functionally equivalent to looking up image sources from the root of the FMU ZIP Archive after dot removal from the path as per section 5.2.4 of RFC 3986.]_
 
 ===== Terminals
 

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1081,7 +1081,7 @@ Flipping of the FMU icon or a terminal can be realized by setting its attributes
 image::images/fmiModelDescription_GraphicalRepresentation_Icon_Schema.png[width=30%, pdfwidth=30%, align="center"]
 
 The extent and position of the FMU icon are defined in the `Icon` element.
-The optional image file of the FMU icon is placed at the path `icon/icon.png` in ZIP archive of the FMU. The terminals should not be visible in the image. 
+The optional image file of the FMU icon is placed at the path `icon/icon.png` in ZIP archive of the FMU. The terminals should not be visible in the image.
 Optionally an SVG file can be provided if also the PNG file is present.
 This enables high quality rendering and printing in importing tools.
 This SVG file has to be placed at the path `icon/icon.svg` in the ZIP archive.
@@ -1094,8 +1094,8 @@ For `fmi3Terminals` (terminals which are listed in the `Terminals` element) the 
 _[If the graphical representation is used for an <<input>> or <<output>> (e.g. a Real <<input>> `u`), then a `Terminal` has to be added to the `Terminals` element which has one `TerminalMemberVariable`._
 _The name of the `Terminal` and the name of the `TerminalMemberVariable` should be equal to the name of the <<input>> / <<output>>.]_
 
-The `iconBaseName` attribute is mandatory. 
-This attribute defines the base name of the image file as a relative URI according to RFC 3986. 
+The `iconBaseName` attribute is mandatory.
+This attribute defines the base name of the image file as a relative URI according to RFC 3986.
 The base URI that this relative URI is resolved against is the URI of the `icon` folder in the FMU ZIP archive.
 Implementations are only REQUIRED to support relative URIs, excluding relative URIs that move beyond the baseURI (i.e. go "up" a level via ..).
 Implementations are NOT REQUIRED to support any absolute URIs and any specific URI schemes.

--- a/docs/2_3_fmu_distribution.adoc
+++ b/docs/2_3_fmu_distribution.adoc
@@ -21,15 +21,17 @@ This ZIP file has the following structure:
 ----
 // Structure of ZIP file of an FMU
 modelDescription.xml          // description of FMU (required file)
-diagram.png                   // image file of a descriptive diagram view of the model (optional)
-icon.png                      // image file of icon without terminals (optional)
 documentation                 // directory containing the documentation (optional)
    index.html                 // entry point of the documentation
+   diagram.png                // image file of a descriptive diagram view of the model (optional)
+   diagram.svg                // if existing the diagram.png is required (optional)
    <other documentation files>
    licenses // Optional directory for licenses
       license.{txt,html}      // Entry point for license information
       <license files>         // For example BSD licenses
 icon                          // FMU and terminal icons (optional)
+   icon.png                   // image file of icon without terminals (optional)
+   icon.svg                   // if existing the icon.png is required (optional)
    // all terminal and fmu icons referenced in the graphical representation
 sources                       // directory containing the C sources (optional)
    // all needed C sources and C header files to compile and link the FMU

--- a/docs/2_3_fmu_distribution.adoc
+++ b/docs/2_3_fmu_distribution.adoc
@@ -21,13 +21,16 @@ This ZIP file has the following structure:
 ----
 // Structure of ZIP file of an FMU
 modelDescription.xml          // description of FMU (required file)
-model.png                     // image file of FMU icon (optional)
+diagram.png                   // image file of a descriptive diagram view of the model (optional)
+icon.png                      // image file of icon without terminals (optional)
 documentation                 // directory containing the documentation (optional)
    index.html                 // entry point of the documentation
    <other documentation files>
    licenses // Optional directory for licenses
       license.{txt,html}      // Entry point for license information
       <license files>         // For example BSD licenses
+icon                          // FMU and terminal icons (optional)
+   // all terminal and fmu icons referenced in the graphical representation
 sources                       // directory containing the C sources (optional)
    // all needed C sources and C header files to compile and link the FMU
    // with exception of: fmi3PlatformTypes.h, fmi3FunctionTypes.h and fmi3Functions.h

--- a/schema/fmi3ModelDescription.xsd
+++ b/schema/fmi3ModelDescription.xsd
@@ -161,8 +161,6 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 									<xs:attribute name="y1" type="xs:double" use="required"/>
 									<xs:attribute name="x2" type="xs:double" use="required"/>
 									<xs:attribute name="y2" type="xs:double" use="required"/>
-									<xs:attribute name="iconSource_PNG" type="xs:string" use="required"/>
-									<xs:attribute name="iconSource_SVG" type="xs:string" use="optional"/>
 								</xs:complexType>
 							</xs:element>
 							<xs:element name="Terminal" minOccurs="0" maxOccurs="unbounded">
@@ -181,8 +179,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 									<xs:attribute name="y1" type="xs:double" use="required"/>
 									<xs:attribute name="x2" type="xs:double" use="required"/>
 									<xs:attribute name="y2" type="xs:double" use="required"/>
-									<xs:attribute name="iconSource_PNG" type="xs:string" use="required"/>
-									<xs:attribute name="iconSource_SVG" type="xs:string" use="optional"/>
+									<xs:attribute name="iconBaseName" type="xs:string" use="required"/>
 								</xs:complexType>
 							</xs:element>
 						</xs:sequence>


### PR DESCRIPTION
A clear definition of the path of the attributes iconSource_PNG and
iconSource_SVG were missing.