### PR TITLE
Define the mapping from terminal coordinates to image coordinates.

### DIFF
--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1086,6 +1086,9 @@ The `iconSource_PNG` attribute is mandatory to simplify the import in other tool
 Optionally an SVG file can be provided.
 This enables high quality rendering and printing in importing tools.
 
+The point (`x1`, `y1`) maps to the left lower corner of the PNG image or SVG viewport.
+The point (`x2`, `y2`) maps to the right upper corner of the PNG image or SVG viewport.
+
 ===== Terminals
 
 image::images/fmiModelDescription_GraphicalRepresentation_Terminal_Schema.png[width=50%, pdfwidth=50%, align="center"]

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1769,8 +1769,7 @@ _The FMU internally carries out event handling if necessary.]_
 
 ===== Aliasing of Variables [[aliasing-of-variables]]
 
-Variables with the same <<valueReference>> are called "alias variables".
-The variables that share the same <<valueReference>> are called "alias set".
+Variables of the same base type (like `fmi3Float64`) that have identical <<valueReference>> definitions are called alias variables.
 The main purpose of alias variables is to enhance efficiency.
 If two variables `a` and `b` are alias variables, then this is only allowed if the behavior of the FMU would be exactly the same if `a` and `b` were not treated as alias variables (that is, had different <<valueReference>>pass:[s]).
 This requirement leads naturally to the following restrictions:
@@ -1785,8 +1784,6 @@ _However, if variable a has <<causality>> = <<parameter>> and `b` has <<causalit
 It is then required that the <<start>> values of all aliased (constant) variables are identical.
 
 . All variables of the same alias set must all have either no `<Unit>` element defined, or all of them must have the same `<Unit name>` and the same `<Unit><BaseUnit>` definitions.
-
-. All variables of the same alias set must have the same dimensions.
 
 The aliasing of variables only means that the `value` of the variables is always identical.
 However, aliased variables may have different attributes, such as `min/max/nominal` values or description texts.

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1059,7 +1059,7 @@ image::images/fmiModelDescription_GraphicalRepresentation_CoordinateSystem_Schem
 
 The `CoordinateSystem` element and its defined extent is used as reference for other graphical items. It also provides a scaling factor to millimeter.
 
-The coordinate system is defined by the coordinates of two points, the left lower (`x1`, `y1`) corner and the right upper (`x2`, `y2`) corner, where the coordinates of the first point shall be less than the coordinates of the second point _[a first quadrant coordinate system]_.
+The coordinate system is defined by the coordinates of two points, the lower left (`x1`, `y1`) corner and the upper right (`x2`, `y2`) corner, where the coordinates of the first point shall be less than the coordinates of the second point _[a first quadrant coordinate system]_.
 The x-axis directed to the right, the y-axis is directed upwards.
 
 _[The exporting tool should define how the coordinate system unit relates to mm display or print out size._

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1766,7 +1766,8 @@ _The FMU internally carries out event handling if necessary.]_
 
 ===== Aliasing of Variables [[aliasing-of-variables]]
 
-Variables of the same base type (like `fmi3Float64`) that have identical <<valueReference>> definitions are called alias variables.
+Variables with the same <<valueReference>> are called "alias variables".
+The variables that share the same <<valueReference>> are called "alias set".
 The main purpose of alias variables is to enhance efficiency.
 If two variables `a` and `b` are alias variables, then this is only allowed if the behavior of the FMU would be exactly the same if `a` and `b` were not treated as alias variables (that is, had different <<valueReference>>pass:[s]).
 This requirement leads naturally to the following restrictions:
@@ -1781,6 +1782,8 @@ _However, if variable a has <<causality>> = <<parameter>> and `b` has <<causalit
 It is then required that the <<start>> values of all aliased (constant) variables are identical.
 
 . All variables of the same alias set must all have either no `<Unit>` element defined, or all of them must have the same `<Unit name>` and the same `<Unit><BaseUnit>` definitions.
+
+. All variables of the same alias set must have the same dimensions.
 
 The aliasing of variables only means that the `value` of the variables is always identical.
 However, aliased variables may have different attributes, such as `min/max/nominal` values or description texts.


### PR DESCRIPTION
Precisely define how PNG and SVG images are mapped to the coordinate definition of terminals: For PNG just the corners are used for SVG the viewport corners are used.
