### PR TITLE
Fixed specification text to map xsd files and examples.

### DIFF
--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1139,8 +1139,8 @@ image::images/ModelVariables_schema.png[width=100%, align="center"]
 The `ModelVariables` element consists of an ordered set of variable elements (see figure above).
 Variable elements can uniformly represent variables of primitive (atomic) types, like single real or integer variables, or as well as arrays of an arbitrary (but fixed) number of dimensions. The schema definition is present in a separate file `fmi3Variable.xsd`.
 
-Variable elements representing array variables must contain a `Dimensions` element specifying the array dimensions.
-The `Dimensions` element contains a sequence of `Dimension` elements, each specifying the size of one dimension of the array:
+Variable elements representing array variables must contain at least one `Dimension` element.
+Each `Dimension` element specifies the size of one dimension of the array:
 
 - If the <<start>> attribute of the `Dimension` element is present, it defines a constant unsigned 32-bit integer size for this dimension.
 The <<variability>> of the dimension size is <<constant>> in this case.


### PR DESCRIPTION
Their is no "Dimensions" element with child "Dimension" elements for each
dimension of an array variable.
The "Dimension" elements are just a sequence of elements without an
seperate parent element.