### PR TITLE
Fixed the description of causality indpendent.

### DIFF
--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1215,10 +1215,9 @@ It is not allowed to use the variable value in another model or slave.
 
 [[independent,`independent`]]
 - `independent`: The independent variable (usually `time`).
-All variables are a function of this <<independent>> variable.
 <<variability>> must be <<continuous>>.
 At most one variable of an FMU can be defined as <<independent>>.
-If no variable is defined as <<independent>>, it is implicitly present with name = `time` and `unit = s`.
+If no variable is defined as <<independent>>, it is implicitly present with `unit = s`.
 If one variable is defined as <<independent>>, it must be defined as `Real` without a <<start>> attribute.
 It is not allowed to call function `fmi3SetReal` on an <<independent>> variable.
 Instead, its value is initialized with <<fmi3SetupExperiment>> and after initialization set by <<fmi3SetTime>> for Model Exchange and by arguments `currentCommunicationPoint` and `communicationStepSize` of <<fmi3DoStep>> for Co-Simulation.


### PR DESCRIPTION
Removed "All variables are a function of this <<independent>> variable."
since this is not true. E.g. a constant variable is not a function of
the independent.
Moreover this will implicitly mean that in ModelStructure this
independent variable is always a dependent variable of each other variable.

Removed the text that an implicilty defined independent variable has the
name = `time`. Since the name of all variables must be unique this would
mean that we need to disallow name = `time` of all other variables when
no independent variable is defined explicitly.