### PR TITLE
Do not define two entries for "input" and "output" in the causalitiy …

### DIFF
--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1202,12 +1202,16 @@ Allowed values of this enumeration:
 <<initial>> must be <<approx>>, <<calculated>> or not present (meaning <<calculated>>).
 
 [[input,`input`]]
+[[inputClock,`input clock`]]
 - `input`: The variable value can be provided from another model or slave.
 It is not allowed to define <<initial>>.
+If the variable is of type `Clock` then it defines an <<inputClock>> being controlled by the master and the variability must be <<clock>>.
 
 [[output,`output`]]
+[[outputClock,`output clock`]]
 - `output`: The variable value can be used by another model or slave.
 The algebraic relationship to the <<input,`inputs`>> is defined via the <<dependencies>> attribute of `<fmiModelDescription><ModelStructure><Outputs><Unknown>`.
+If the variable is of type `Clock` then it defines an <<outputClock>> being controlled by the FMU and the variability must be <<clock>>.
 
 [[local,`local`]]
 - `local`: Local variable that is calculated from other variables or is a continuous-time <<state>> (see <<ModelStructure>>).
@@ -1242,16 +1246,6 @@ _Example:_
 _]_
 
 <<structuralParameter,`structural parameters`>> that are referenced in `Dimension` elements may have a `min` attribute with 0 but the <<start>> attribute, which is mandatory for <<structuralParameter,`structural parameters`>>, must have a value larger than 0 for <<structuralParameter,`structural parameters`>> used in `Dimension` elements. [This allows importing tools to ignore <<structuralParameter,`structural parameters`>> because that <<start>> value reflects the internal default setting of that <<structuralParameter,`structural parameter`>>].
-
-[[inputClock,`input clock`]]
-- `input`: the variable defines an <<inputClock>> that is controlled by the master.
-Variability must be <<clock>>.
-Only a variable of type `Clock` can have this <<causality>>.
-
-[[outputClock,`output clock`]]
-- `output`: the variable defines an <<outputClock>> that is controlled by the FMU.
-Variability must be <<clock>>.
-Only a variable of type `Clock` can have this <<causality>>.
 
 The default of <<causality>> is <<local>>. +
 A continuous-time <<state>> must have <<causality>> = <<local>> or <<output>>, see also <<ModelStructure>>.


### PR DESCRIPTION
…table

Each causaility should only be listed ones in the table.
Merged the two entries for "input" and "output".