### PR TITLE
fixing two not-equal signs compared to FMI 2.0.1

### DIFF
--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1776,7 +1776,7 @@ This requirement leads naturally to the following restrictions:
 _For example, if variables `a` and `b` have <<causality>> = <<parameter>>, then the value references of `a` and `b` must be different._
 _However, if variable a has <<causality>> = <<parameter>> and `b` has <<causality>> = <<calculatedParameter>> and `b := a`, then `a` and `b` can have the same value reference.]_
 
-. At most one variable of the same alias set of variables with <<variability>> = <<constant>> can have a <<start>> attribute _[since <<start>> variables are independent initial values.]_
+. At most one variable of the same alias set of variables with <<variability>> &#8800; <<constant>> can have a <<start>> attribute _[since <<start>> variables are independent initial values.]_
 
 . A variable with <<variability>> = <<constant>> can only be aliased to another variable with <<variability>> = <<constant>>.
 It is then required that the <<start>> values of all aliased (constant) variables are identical.

--- a/docs/4_2_co-simulation_api.adoc
+++ b/docs/4_2_co-simulation_api.adoc
@@ -356,7 +356,7 @@ _[The allowed function calls in the respective states are summarized in the foll
 *1* for a variable with <<variability>> latexmath:[\neq] <<constant>> that has <<initial>> = <<exact>> or <<approx>> +
 *2* for a variable with <<causality>> = <<output>> or continuous-time states or state derivatives
 (if element `<Derivatives>` is present) +
-*3* for a variable with <<variability>> = <<constant>> that has <<initial>> = <<exact>>,
+*3* for a variable with <<variability>> &#8800; <<constant>> that has <<initial>> = <<exact>>,
 or <<causality>> = <<input>> +
 *6* for a variable with <<causality>> = <<input>> or (<<causality>> = <<parameter>> and <<variability>> = <<tunable>>) +
 *7* always, but retrieved values are usable for debugging only +


### PR DESCRIPTION
I compared all &#8800; signs from FMI 2.0.1 with the current 3.0 master and found two occurances that were wrong.

fixing #735 

