### PR TITLE
remove double and contradicting definition of value reference 

### DIFF
--- a/docs/6___appendix.adoc
+++ b/docs/6___appendix.adoc
@@ -527,9 +527,6 @@ This definition is slightly different from the usual standard definition of stat
 |_user interface_
 |The part of the simulation program that gives the user control over the simulation and allows watching results.
 
-|_value reference_
-|The value of a scalar variable of an FMU is identified with an Integer handle called _value reference_. This handle is defined in the `modelDescription.xml` file (as attribute <<valueReference>> in element `ScalarVariable`). Element <<valueReference>> might not be unique for all variables. If two or more variables of the same base data type (such as `fmi3Float64`) have the same <<valueReference>>, then they have identical values but other parts of the variable definition might be different (for example, min/max attributes).
-
 |_XML_
 |eXtensible Markup Language (http://www.w3.org/XML/[www.w3.org/XML], http://en.wikipedia.org/wiki/Xml[en.wikipedia.org/wiki/XML]) - An open standard to store information in text files in a structured form.
 |====


### PR DESCRIPTION
... from glossary.

The value reference is clearly defined in 2.2.10. 
Why should we define it also in the glossary?

The current definition in the glossary reflected the non-uniqueness of FMI 2.0.

Fixing also https://github.com/modelica/fmi-standard/issues/522