### PR TITLE
Add hyphen to super-dense time

### DIFF
--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1332,7 +1332,7 @@ If `fmi3Set{VariableType}` is not called on a variable with <<causality>> = <<in
 Only for Model Exchange (if only Co-Simulation FMU, this attribute must not be present.
 If both Model Exchange and Co-Simulation FMU, this attribute is ignored for Co-Simulation): +
 Only for variables with <<variability>> = <<input>> : +
-If present with value equals `false`, then only one `fmi3Set{VariableType}` call is allowed at one super dense time instant (model evaluation) on this variable.
+If present with value equals `false`, then only one `fmi3Set{VariableType}` call is allowed at one super-dense time instant (model evaluation) on this variable.
 That is, this <<input>> is not allowed to appear in a (real) algebraic loop requiring multiple calls of `fmi3Set{VariableType}` on this variable _[for example, due to a Newton iteration]_. +
 _[This flag must be set by FMUs where (internal) discrete-time <<state,`states`>> are directly updated when assigned (xd := f(xd) instead of xd = f(previous(xd)), and at least one <<output>> depends on this <<input>> and on discrete <<state,`states`>>._ +
 _It is strongly recommended that such an FMU checks the fulfillment of the requirement by itself during run-time, because an environment might not be able to check it; usually, there is a generic mechanism to import an FMU in an environment, but the mechanism to connect FMUs together is unrelated to the import mechanism._
@@ -1896,7 +1896,7 @@ A Model Exchange FMU must expose all <<derivative,`derivatives`>> of its continu
 A Co- Simulation FMU does not need to expose these state derivatives.
 _[If a Co-Simulation FMU exposes its state derivatives, they are usually not utilized for the co-simulation, but, for example, to linearize the FMU at a communication point.]_
 
-The optional part defines in which way <<derivative,`derivatives`>> and <<output,`outputs`>> depend on <<input,`inputs`>>, and continuous-time <<state,`states`>> at the current super dense time instant (Model Exchange) or at the current communication point (Co-Simulation).
+The optional part defines in which way <<derivative,`derivatives`>> and <<output,`outputs`>> depend on <<input,`inputs`>>, and continuous-time <<state,`states`>> at the current super-dense time instant (Model Exchange) or at the current communication point (Co-Simulation).
 _[The listed <<dependencies>> declare the dependencies between whole (multi-dimensional-)variables and not individual elements of the variables.]_
 _[A simulation environment can utilize this information to improve the efficiency, for example, when connecting FMUs together, or when computing the partial derivative of the <<derivative,`derivatives`>> with respect to the <<state,`states`>> in the simulation engine.]_
 
@@ -1929,7 +1929,7 @@ _[Note that all <<output>> variables are listed here, especially <<discrete>> an
 _The ordering of the variables in this list is defined by the exporting tool._
 _Usually, it is best to order according to the declaration order in the source model, since then the `Outputs` list does not change if the declaration order of <<output,`outputs`>> in the source model is not changed._
 _This is for example, important for linearization, in order that the interpretation of the output vector does not change for a re-exported FMU.]_
-Attribute <<dependencies>> defines the dependencies of the <<output,`outputs`>> from the knowns at the current super dense time instant in Event and in *Continuous-Time Mode* (Model Exchange) and at the current communication point (Co-Simulation).
+Attribute <<dependencies>> defines the dependencies of the <<output,`outputs`>> from the knowns at the current super-dense time instant in Event and in *Continuous-Time Mode* (Model Exchange) and at the current communication point (Co-Simulation).
 The functional dependency is defined as (dependencies of variables that are fixed in Event and *Continuous-Time Mode* and at communication points are not shown): +
 [blue]#latexmath:[\color{blue}{(\mathbf{y}_c, \mathbf{y}_d) := \mathbf{f}_{output}(\mathbf{x}_c, \mathbf{u}_c, \mathbf{u}_d, t, \mathbf{p}_{tune})}]#
 
@@ -1950,7 +1950,7 @@ _[This is the default._
 _If an FMU supports both Model Exchange and Co-Simulation, then the `Derivatives` element might be present, since it is needed for Model Exchange._
 _If the above flag is set to `false` for the Co-Simulation case, then the `Derivatives` element is ignored for Co-Simulation._
 _If "inline integration" is used for a Co-Simulation slave, then the model still has continuous-time <<state,`states`>> and just a special solver is used (internally the implementation results in a discrete-time system, but from the outside, it is still a continuous-time system).]_ +
-Attribute <<dependencies>> defines the dependencies of the state derivatives from the knowns at the current super dense time instant in Event and in *Continuous-Time Mode* (Model Exchange) and at the current communication point (Co-Simulation).
+Attribute <<dependencies>> defines the dependencies of the state derivatives from the knowns at the current super-dense time instant in Event and in *Continuous-Time Mode* (Model Exchange) and at the current communication point (Co-Simulation).
 The functional dependency is defined as (dependencies of variables that are fixed in Event and *Continuous-Time Mode* and at communication points are not shown): +
 [blue]#latexmath:[\color{blue}{\dot{\mathbf{x}_c} := \mathbf{f}_{der}(\mathbf{x}_c, \mathbf{u}_c, \mathbf{u}_d, t, \mathbf{p}_{tune})}]#
 

--- a/docs/3_1_model_exchange_math.adoc
+++ b/docs/3_1_model_exchange_math.adoc
@@ -11,7 +11,7 @@ The <<independent>> variable time latexmath:[t \in \mathbb{T}] is a tuple latexm
 The real part latexmath:[t_R] of this tuple is the <<independent>> variable of the FMU for describing the continuous-time behavior of the model between events.
 In this phase latexmath:[t_I = 0].
 The integer part latexmath:[t_I] of this tuple is a counter to enumerate (and therefore distinguish) the events at the same continuous-time instant latexmath:[t_R].
-This time definition is also called "super dense time" in literature, see, for example, <<LZ07>>.
+This time definition is also called "super-dense time" in literature, see, for example, <<LZ07>>.
 An ordering is defined on latexmath:[\mathbb{\text{T}}] that leads to the notation below.
 _[The notation latexmath:[^{\bullet}t] is from <<BCP10,BCP10>>, adapted from non-standard analysis to super-dense time, in order to precisely define the value from the previous event iteration.]_
 
@@ -32,7 +32,7 @@ _[The notation latexmath:[^{\bullet}t] is from <<BCP10,BCP10>>, adapted from non
 ^|latexmath:[t^{+}]
 |latexmath:[{{(t}_{R},t_{I})}^{+} \Leftrightarrow (\lim_{\epsilon \rightarrow 0}{\left(t_{R} + \varepsilon \right),t_{Imax})}]
 |right limit at latexmath:[t].
-latexmath:[t_{Imax}] is the largest occurring integer index of super dense time
+latexmath:[t_{Imax}] is the largest occurring integer index of super-dense time
 
 ^|latexmath:[^-t]
 |latexmath:[^{-}{{(t}_{R},t_{I})} \Leftrightarrow (\lim_{\epsilon \rightarrow 0}{\left( t_{R} - \varepsilon \right),0)}]
@@ -173,7 +173,7 @@ In reality, a continuous-time <<state>> is however part of the <<output,`outputs
 ^|latexmath:[\mathbf{x}_d(t)] +
 latexmath:[^{\bullet}\mathbf{x}_d(t)]
 |latexmath:[\mathbf{x}_d(t)] is a vector of (internal) discrete-time variables (of any type) representing the discrete <<state,`states`>>. +
-latexmath:[{}^{\bullet}\mathbf{x}_d(t)] a is the value of latexmath:[\mathbf{x}_d(t)] at the previous super dense time instant, so latexmath:[{}^{\bullet}\mathbf{x}_d(t)=\mathbf{x}_d({}^{\bullet}t)].
+latexmath:[{}^{\bullet}\mathbf{x}_d(t)] a is the value of latexmath:[\mathbf{x}_d(t)] at the previous super-dense time instant, so latexmath:[{}^{\bullet}\mathbf{x}_d(t)=\mathbf{x}_d({}^{\bullet}t)].
 Given the <<previous>> values of the discrete-time <<state,`states`>>, latexmath:[{}^{\bullet}\mathbf{x}_d(t)], at the actual time instant latexmath:[t], all other discrete-time variables, especially the discrete <<state,`states`>> latexmath:[\mathbf{x}_d(t)], can be computed. +
 Discrete <<state,`states`>> are not visible in the interface of an FMU and are only introduced here to clarify the mathematical description.
 Formally, a discrete <<state>> is part of the <<output,`outputs`>> latexmath:[\mathbf{y}] or the <<local>> variables latexmath:[\mathbf{w}] of an FMU.
@@ -237,9 +237,9 @@ For an output argument, calling `fmi3Get{VariableType}` on such a variable retur
 * [lime]#*green*#: Functions marked in [lime]#green# are special functions to enter or leave a mode.
 * [blue]#*blue*#: Equations and functions marked in [blue]#blue# define the actual computations to be performed in the respective mode.
 
-_[In the following table the setting of the super dense time, (latexmath:[t_R], latexmath:[t_I]), is precisely described._
+_[In the following table the setting of the super-dense time, (latexmath:[t_R], latexmath:[t_I]), is precisely described._
 _Tools will usually not have such a representation of time._
-_However, super-dense time defines precisely when a new "model evaluation" starts and therefore which variable values belong to the same "model evaluation" at the same (super dense) time instant and should be stored together.]_
+_However, super-dense time defines precisely when a new "model evaluation" starts and therefore which variable values belong to the same "model evaluation" at the same (super-dense) time instant and should be stored together.]_
 
 .Mathematical description of an FMU for Model Exchange.
 [#table-math-model-exchange]
@@ -279,7 +279,7 @@ latexmath:[\mathbf{f}_{sim}]is also a function of the internal variables latexma
 `[blue]#fmi3GetDerivatives#`
 `[blue]#fmi3GetEventIndicators#`
 
-|[lime]#Increment super dense time and define with#
+|[lime]#Increment super-dense time and define with#
 `[lime]#newDiscreteStatesNeeded#` [lime]#whether a new event iteration is required.# +
 [blue]#latexmath:[\qquad]*if not*# `[blue]#newDiscreteStatesNeeded#`[blue]#*then* +
 latexmath:[\qquad \qquad T_{next}=T_{next}(\mathbf{x}_c,{}^\bullet\mathbf{x}_d, \mathbf{u_{c+d}}, \color{grey}t_{\color{grey} i}, \mathbf{p}_{tune}, \color{grey}{\mathbf{p}_{other})}]# +
@@ -388,7 +388,7 @@ _Furthermore, the discrete-time <<state,`states`>> are not updated by <<fmi3NewD
 
 State machines with one memory location for a state::
 _In such a system there is only one memory location for a discrete-time <<state>> and not two, and therefore a discrete-time <<state>> is updated in the statement where it is assigned (and not in <<fmi3NewDiscreteStates>>)._
-_As a result, <<fmi3NewDiscreteStates>> is basically just used to start a new (super dense) time instant._
+_As a result, <<fmi3NewDiscreteStates>> is basically just used to start a new (super-dense) time instant._
 _This is unproblematic, as long as no algebraic loops occur._
 _FMUs of this type can therefore not be used in real algebraic loops if the involved variables depend on a discrete-time <<state>>._
 _This restriction is communicated to the environment of the FMU by the `ScalarVariable` definition of the corresponding <<input>> with flag <<canHandleMultipleSetPerTimeInstant>> `= false` (so an <<input>> with this flag is not allowed to be called in an algebraic loop)._
@@ -468,7 +468,7 @@ In order to determine a state event, the event indicators *z* have to be inquire
 Once the event indicators signal a change of their domain, an iteration over time is performed between the previous and the actual completed integrator step, in order to determine the time instant of the domain change up to a certain precision. +
 After an event is triggered, the FMU needs to be switched to *Event Mode*.
 In this mode, systems of equations over connected FMUs might be solved (similarily as in *Continuous-Time Mode*).
-Once convergence is reached, <<fmi3NewDiscreteStates>> must be called to increment super dense time (and conceptually update the discrete-time <<state,`states`>> defined internally in the FMU by latexmath:[^{\bullet}\mathbf{x}_d := \mathbf{x}_d]).
+Once convergence is reached, <<fmi3NewDiscreteStates>> must be called to increment super-dense time (and conceptually update the discrete-time <<state,`states`>> defined internally in the FMU by latexmath:[^{\bullet}\mathbf{x}_d := \mathbf{x}_d]).
 Depending on the discrete-time model, a new event iteration might be needed (for example, because the FMU describes internally a state machine
 and transitions are still able to fire, but new <<input,`inputs`>> shall be taken into account). +
 The function calls in the table above describe precisely which input arguments are needed to compute the desired output argument(s).

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -89,8 +89,8 @@ include::../headers/fmi3FunctionTypes.h[tags=NewDiscreteStates]
 include::../headers/fmi3FunctionTypes.h[tags=EventInfo]
 ----
 
-The FMU is in *Event Mode* and the super dense time is incremented by this call. +
-If the super dense time before a call to <<fmi3NewDiscreteStates>> was latexmath:[(t_R,t_I)], then the time instant after the call is latexmath:[(t_R,t_I)]. +
+The FMU is in *Event Mode* and the super-dense time is incremented by this call. +
+If the super-dense time before a call to <<fmi3NewDiscreteStates>> was latexmath:[(t_R,t_I)], then the time instant after the call is latexmath:[(t_R,t_I)]. +
 If return argument `pass:[fmi3eventInfo->newDiscreteStatesNeeded] = fmi3True`, the FMU should stay in *Event Mode*, and the FMU requires to set new inputs to the FMU (`fmi3Set{VariableType}` on <<input,`inputs`>>) to compute and get the <<output,`outputs`>> (`fmi3Get{VariableType}` on <<output,`outputs`>>) and to call <<fmi3NewDiscreteStates>> again.
 Depending on the connection with other FMUs, the environment shall
 

--- a/docs/4_1_basic_co-simulation_math.adoc
+++ b/docs/4_1_basic_co-simulation_math.adoc
@@ -156,7 +156,7 @@ Algebraic equations are solved in this mode.
 This mode is used to compute the values of all continuous-time and discrete-time variables at communication points by numerically solving ordinary differential, algebraic and discrete equations.
 If the slave is connected in loops with other models, no iterations over the FMU equations are possible.
 
-_[Note that for a Co-Simulation FMU, no super dense time description is used at communication points.]_
+_[Note that for a Co-Simulation FMU, no super-dense time description is used at communication points.]_
 
 The equations are defined in <<table-math-basic-co-simulation>> can be evaluated in the respective mode.
 The following color coding is used in the table:

--- a/docs/5_2_hybrid_co-simulation_api.adoc
+++ b/docs/5_2_hybrid_co-simulation_api.adoc
@@ -45,7 +45,7 @@ In this case, `earlyReturnTime` argument of <<fmi3DoEarlyReturn>> is ignored.
 If `canReturnEarly` is `fmi3False` the FMU will not do the early return, regardless of the master request.
 
 Note that only the first discontinuity event at a Newtonian time instant shall be signaled that way.
-But in *Event Mode*, there may be an event iteration at a Newtonian time instant and have super dense time instants.
+But in *Event Mode*, there may be an event iteration at a Newtonian time instant and have super-dense time instants.
 
 Based on the information delivered in <<fmi3IntermediateUpdateInfo>>, additional information about the discontinuity at that time instant can be obtained from the <<fmi3EventInfo>> structure after calling  <<fmi3NewDiscreteStates>>  and/or <<fmi3GetClock>>.
 

--- a/docs/8___appendix.adoc
+++ b/docs/8___appendix.adoc
@@ -518,7 +518,7 @@ This definition is slightly different from the usual standard definition of stat
 |_step event_
 |_Event_ that might occur at a completed integrator step. Since this event type is not defined by a precise time or condition, it is usually not defined by a user. A program may use it, for example, to dynamically switch between different states. A step event is handled much more efficiently than a _state event_, because the event is just triggered after performing a check at a completed integrator step, whereas a search procedure is needed for a state event.
 
-|_super dense time_
+|_super-dense time_
 |A precise definition of time taking into account iterations at an event. For an _FMU_, the <<independent>> variable time latexmath:[t \in \mathbb{T}] is a tuple latexmath:[t = (t_R, t_I)] where latexmath:[t_R \in  \mathbb{R}, t_I \in \mathbb{N} = \{0,1,2,\ldots\}]. The real part latexmath:[t_R] of this tuple is the <<independent>> variable of the FMU for describing the continuous-time behavior of the model between events. In this phase latexmath:[t_I = 0]. The integer part latexmath:[t_I] of this tuple is a counter to enumerate (and therefore distinguish) the events at the same continuous-time instant latexmath:[t_R].
 
 |_time event_


### PR DESCRIPTION
Simple adding '-' to "super-dense time" wherever missing