### PR TITLE
Clarify the number of states/event indicators (#741)

### DIFF
--- a/docs/1___overview.adoc
+++ b/docs/1___overview.adoc
@@ -228,8 +228,6 @@ Properties that might be additionally needed for trajectory optimization, for ex
 
 - No explicit definition of the variable hierarchy in the XML file.
 
-- The number of states and number of event indicators are fixed for an FMU and cannot be changed.
-
 === Acknowledgements
 
 Until Dec. 2011, this work was carried out within the ITEA2 MODELISAR project (project number: ITEA2-07006, https://itea3.org/project/modelisar.html).

--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -1190,6 +1190,7 @@ include::../headers/fmi3FunctionTypes.h[tags=GetNumberOfEventIndicators]
 This function returns the number of event indicators.
 The dependency of the number of event indicators on <<structuralParameter,`structural parameters`>> must be specified in the `ModelStructure` in the element `NumberOfEventIndicators`.
 This element is optional but necessary if the number of event indicators depends on <<structuralParameter,`structural parameters`>>.
+The attribute `dependencies` of this element holds a list of `valueReferences` of <<structuralParameter,`structural parameters`>> having an influence on the number of event indicators.
 If the `NumberOfEventIndicators` element is not present or its <<dependencies>> list is empty, the number of event indicators does not depend on <<structuralParameter,`structural parameters`>>, i.e. it is constant.
 
 The `numberOfEventIndicators` attribute of the `fmiModelDescription` element holds the number of event indicators if all <<structuralParameter,`structural parameters`>> are unchanged, i.e. set to their <<start>> value.
@@ -1206,6 +1207,12 @@ include::../headers/fmi3FunctionTypes.h[tags=GetNumberOfContinuousStates]
 ----
 
 This function returns the number of <<state,`states`>>.
+The dependency of the number of states on <<structuralParameter,`structural parameters`>> is implicitly given in the `modelDescription.xml` file.
+_[All state derivative variables are listed as elements `Derivative` in `ModelStrcture`._
+_Each state derivative variable maps to the corresponding state variable by the `derivative` attribute._
+_If the state variable is an array variable and the `Dimension` element maps to a dependent variable than this dependent variable is a dependency for the number of states.]_
+If all <<structuralParameter,`structural parameters`>> are unchanged then this dependency information can be used to calculate the initial number of states just using information given in the XML file without the need to call this C-API function.
+_[Therefore their is no `numberOfStates` attribute as it is for `numberOfEventIndicators`.]_
 
 - Argument `nz` points to the `size_t` variable that will receive the number of <<state,`states`>>.
 

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1940,7 +1940,6 @@ _If a <<state>> or a <<derivative>> of a <<state>> shall not be exposed from the
 _The ordering of the variables in this list is defined by the exporting tool._
 _Usually, it is best to order according to the declaration order of the <<state,`states`>> in the source model, since then the <Derivatives> list does not change if the declaration order of states in the source model is not changed._
 _This is for example, important for linearization, in order that the interpretation of the state vector does not change for a re-exported FMU.]_
-The number of Unknown elements in the Derivatives element uniquely define the number of continuous time state variables, as required by the corresponding Model Exchange functions (integer argument `nx` of <<fmi3GetContinuousStates>>, <<fmi3SetContinuousStates>>, <<fmi3GetDerivatives>>, <<fmi3GetNominalsOfContinuousStates>> see hereafter) that require it.
 
 The corresponding continuous-time <<state,`states`>> are defined by attribute <<derivative>> of the corresponding variable state derivative element.
 _[Note that higher order derivatives must be mapped to first order derivatives but the mapping definition can be preserved due to attribute <<derivative>>._

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -68,8 +68,8 @@ _[These arguments are not mutually exclusive and may all be `fmi3False` if the c
 
 `stepEvent`:: A step event occurred.
 
-`rootsFound`:: Array of length `nEventIndicators`. For `i = 1, ..., nEventIndicators, rootsFound[i]` latexmath:[\neq] `0` if the event indicator latexmath:[z_i] has a root, and `rootsFound[i] == 0` if not.
-For the components latexmath:[z_i] for which a root was found, the sign of `rootsFound[i]` indicates the direction of the zero-crossing.
+`rootsFound`:: Array of length `nEventIndicators`. For `i = 1, ..., nEventIndicators, rootsFound[i-1]` latexmath:[\neq] `0` if the event indicator latexmath:[z_i] has a root, and `rootsFound[i-1] == 0` if not.
+For the components latexmath:[z_i] for which a root was found, the sign of `rootsFound[i-1]` indicates the direction of the zero-crossing.
 A value of `+1` indicates that latexmath:[z_i] is increasing, while a value of `-1` indicates a decreasing latexmath:[z_i].
 If `nEventIndicators == 0` the value of `rootsFound` is not defined.
 


### PR DESCRIPTION
fixing #741 
Getting the number of states and event indicators cannot be done
consistently since every state is also present as a variable but event
indicators are not.
Now a clear defintion is given how the static number of states/events
can be get without using C-API function calls and also how to get the
dependent structural parameter the number of states/events depends on.