### PR TITLE
Add alias element to variable types.

### DIFF
--- a/.circleci/validate_xml.py
+++ b/.circleci/validate_xml.py
@@ -7,6 +7,7 @@ schema = etree.XMLSchema(file='schema/fmi3ModelDescription.xsd')
 parser = etree.XMLParser(schema=schema)
 
 xml_files = [
+    'alias.xml',
     'build_configuration.xml',
     'co_simulation.xml',
     'model_structure_example1.xml',

--- a/docs/examples/alias.xml
+++ b/docs/examples/alias.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fmiModelDescription
+  fmiVersion="3.0-dev"
+  modelName="MyLibrary.SpringMassDamper"
+  instantiationToken="{8c4e810f-3df3-4a00-8276-176fa3c9f9e0}"
+  description="Rotational Spring Mass Damper System"
+  version="1.0"
+  generationDateAndTime="2011-09-23T16:57:33Z"
+  variableNamingConvention="structured">
+  <CoSimulation
+    modelIdentifier="MyLibrary_SpringMassDamper"
+    canHandleVariableCommunicationStepSize="true"
+    canInterpolateInputs="true"/>
+  <UnitDefinitions>
+    <Unit name="rad">
+      <BaseUnit rad="1"/>
+      <DisplayUnit name="deg" factor="57.2957795130823"/>
+    </Unit>
+    <Unit name="rad/s">
+      <BaseUnit s="-1" rad="1"/>
+    </Unit>
+    <Unit name="kg.m2">
+      <BaseUnit kg="1" m="2"/>
+      <DisplayUnit name="g.m2" factor="1e-3"/>
+    </Unit>
+    <Unit name="N.m">
+      <BaseUnit kg="1" m="2" s="-2"/>
+      <DisplayUnit name="kN.m" factor="1e3"/>
+      <DisplayUnit name="mN.m" factor="1e-3"/>
+    </Unit>
+  </UnitDefinitions>
+  <TypeDefinitions>
+    <Float32 name="Modelica.SIunits.Inertia" quantity="MomentOfInertia" unit="kg.m2" min="0.0"/>
+    <Float64 name="Modelica.SIunits.Torque" quantity="Torque" unit="N.m"/>
+    <Float64 name="Modelica.SIunits.AngularVelocity" quantity="AngularVelocity" unit="rad/s"/>
+    <Float64 name="Modelica.SIunits.Angle" quantity="Angle" unit="rad"/>
+  </TypeDefinitions>
+  <DefaultExperiment startTime="0.0" stopTime="3.0" tolerance="0.0001"/>
+  <ModelVariables>
+    <Float32 name="inertia1.J" valueReference="1073741824"
+      description="Moment of load inertia" causality="parameter" variability="fixed"
+      declaredType="Modelica.SIunits.Inertia" start="1">
+      <Alias name="inertia1.AltJ" description="Alias 1" displayUnit="g.m2"/>
+    </Float32>
+    <Float64 name="torque.tau" valueReference="536870912"
+      description="Accelerating torque acting at flange (= -flange.tau)" causality="input"
+      declaredType="Modelica.SIunits.Torque" start="0">
+      <Alias name="torque.tau_1" description="Alias 1" displayUnit="kN.m"/>
+      <Alias name="torque.tau_2" description="Alias 2" displayUnit="mN.m"/>
+    </Float64>
+    <Float64 name="inertia1.phi" valueReference="805306368"
+      description="Absolute rotation angle of component" causality="output"
+      declaredType="Modelica.SIunits.Angle"/>
+    <Float64 name="inertia1.w" valueReference="805306369"
+      description="Absolute angular velocity of component (= der(phi))" causality="output"
+      declaredType="Modelica.SIunits.AngularVelocity"/>
+    <Float32 name="Float32" valueReference="1" start="-INF -3.402823e+38 -1.175494e-38 NaN 1.175494e-38 3.402823e+38 INF">
+      <Dimension start="7"/>
+      <Alias name="Float32_1" description="Alias 1"/>
+    </Float32>
+    <Float64 name="Float64" valueReference="2" start="-INF -1.79769e+308 -2.22507e-308 NaN 2.22507e-308 1.79769e+308 INF">
+      <Dimension start="7"/>
+    </Float64>
+    <Int8 name="Int8" valueReference="3" start="-128 127">
+      <Dimension start="2"/>
+      <Alias name="Int8_1" description="Alias 1"/>
+    </Int8>
+    <UInt8 name="UInt8" valueReference="4" start="0 255">
+      <Dimension start="2"/>
+      <Alias name="UInt8_1" description="Alias 1"/>
+    </UInt8>
+    <Int16 name="Int16" valueReference="5" start="-32768 32767">
+      <Dimension start="2"/>
+      <Alias name="Int16_1" description="Alias 1"/>
+    </Int16>
+    <UInt16 name="UInt16" valueReference="6" start="0 65535">
+      <Dimension start="2"/>
+      <Alias name="UInt16_1" description="Alias 1"/>
+    </UInt16>
+    <Int32 name="Int32" valueReference="7" start="-2147483648 2147483647">
+      <Dimension start="2"/>
+      <Alias name="Int32_1" description="Alias 1"/>
+    </Int32>
+    <UInt32 name="UInt32" valueReference="8" start="0 4294967295">
+      <Dimension start="2"/>
+      <Alias name="UInt32_1" description="Alias 1"/>
+    </UInt32>
+    <Int64 name="Int64" valueReference="9" start="-9223372036854775808 9223372036854775807">
+      <Dimension start="2"/>
+      <Alias name="Int64_1" description="Alias 1"/>
+    </Int64>
+    <UInt64 name="UInt64" valueReference="10" start="0 18446744073709551615">
+      <Dimension start="2"/>
+      <Alias name="UInt64_1" description="Alias 1"/>
+    </UInt64>
+    <Boolean name="Boolean" valueReference="11" start="true false 1 0">
+      <Dimension start="2"/>
+      <Dimension start="2"/>
+      <Alias name="Boolean_1" description="Alias 1"/>
+    </Boolean>
+    <String name="String" valueReference="12">
+      <Dimension start="2"/>
+      <Dimension start="1"/>
+      <Start value="foo"/>
+      <Start value="bar"/>
+      <Start value="z"/>
+      <Alias name="String_1" description="Alias 1"/>
+    </String>
+    <Binary name="Binary" valueReference="13" maxSize="28" start="3c3f 686572">
+      <Dimension start="2"/>
+      <Alias name="Binary_1" description="Alias 1"/>
+    </Binary>
+  </ModelVariables>
+  <ModelStructure>
+    <Output valueReference="805306368"/>
+    <Output valueReference="805306369"/>
+    <InitialUnknown valueReference="805306368"/>
+    <InitialUnknown valueReference="805306369"/>
+  </ModelStructure>
+</fmiModelDescription>

--- a/schema/fmi3Variable.xsd
+++ b/schema/fmi3Variable.xsd
@@ -36,9 +36,23 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------------
 		</xs:documentation>
 	</xs:annotation>
+	<xs:complexType name="fmi3Alias">
+		<xs:attribute name="name" type="xs:normalizedString" use="required"/>
+		<xs:attribute name="description" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="fmi3RealAlias">
+		<xs:complexContent>
+			<xs:extension base="fmi3Alias">
+				<xs:attribute name="displayUnit" type="xs:string"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
 	<xs:complexType name="fmi3Float64">
 		<xs:complexContent>
 			<xs:extension base="fmi3VariableBase">
+				<xs:sequence>
+					<xs:element name="Alias" type="fmi3RealAlias" minOccurs="0" maxOccurs="unbounded" />
+				</xs:sequence>
 				<xs:attributeGroup ref="fmi3Float64Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
@@ -56,6 +70,9 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	<xs:complexType name="fmi3Float32">
 		<xs:complexContent>
 			<xs:extension base="fmi3VariableBase">
+				<xs:sequence>
+					<xs:element name="Alias" type="fmi3RealAlias" minOccurs="0" maxOccurs="unbounded" />
+				</xs:sequence>
 				<xs:attributeGroup ref="fmi3Float32Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
@@ -73,6 +90,9 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	<xs:complexType name="fmi3Int8">
 		<xs:complexContent>
 			<xs:extension base="fmi3VariableBase">
+				<xs:sequence>
+					<xs:element name="Alias" type="fmi3Alias" minOccurs="0" maxOccurs="unbounded" />
+				</xs:sequence>
 				<xs:attributeGroup ref="fmi3Int8Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
@@ -89,6 +109,9 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	<xs:complexType name="fmi3UInt8">
 		<xs:complexContent>
 			<xs:extension base="fmi3VariableBase">
+				<xs:sequence>
+					<xs:element name="Alias" type="fmi3Alias" minOccurs="0" maxOccurs="unbounded" />
+				</xs:sequence>
 				<xs:attributeGroup ref="fmi3UInt8Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
@@ -105,6 +128,9 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	<xs:complexType name="fmi3Int16">
 		<xs:complexContent>
 			<xs:extension base="fmi3VariableBase">
+				<xs:sequence>
+					<xs:element name="Alias" type="fmi3Alias" minOccurs="0" maxOccurs="unbounded" />
+				</xs:sequence>
 				<xs:attributeGroup ref="fmi3Int16Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
@@ -121,6 +147,9 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	<xs:complexType name="fmi3UInt16">
 		<xs:complexContent>
 			<xs:extension base="fmi3VariableBase">
+				<xs:sequence>
+					<xs:element name="Alias" type="fmi3Alias" minOccurs="0" maxOccurs="unbounded" />
+				</xs:sequence>
 				<xs:attributeGroup ref="fmi3UInt16Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
@@ -137,6 +166,9 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	<xs:complexType name="fmi3Int32">
 		<xs:complexContent>
 			<xs:extension base="fmi3VariableBase">
+				<xs:sequence>
+					<xs:element name="Alias" type="fmi3Alias" minOccurs="0" maxOccurs="unbounded" />
+				</xs:sequence>
 				<xs:attributeGroup ref="fmi3Int32Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
@@ -153,6 +185,9 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	<xs:complexType name="fmi3UInt32">
 		<xs:complexContent>
 			<xs:extension base="fmi3VariableBase">
+				<xs:sequence>
+					<xs:element name="Alias" type="fmi3Alias" minOccurs="0" maxOccurs="unbounded" />
+				</xs:sequence>
 				<xs:attributeGroup ref="fmi3UInt32Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
@@ -169,6 +204,9 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	<xs:complexType name="fmi3Int64">
 		<xs:complexContent>
 			<xs:extension base="fmi3VariableBase">
+				<xs:sequence>
+					<xs:element name="Alias" type="fmi3Alias" minOccurs="0" maxOccurs="unbounded" />
+				</xs:sequence>
 				<xs:attributeGroup ref="fmi3Int64Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
@@ -185,6 +223,9 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	<xs:complexType name="fmi3UInt64">
 		<xs:complexContent>
 			<xs:extension base="fmi3VariableBase">
+				<xs:sequence>
+					<xs:element name="Alias" type="fmi3Alias" minOccurs="0" maxOccurs="unbounded" />
+				</xs:sequence>
 				<xs:attributeGroup ref="fmi3UInt64Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
@@ -201,6 +242,9 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	<xs:complexType name="fmi3Boolean">
 		<xs:complexContent>
 			<xs:extension base="fmi3VariableBase">
+				<xs:sequence>
+					<xs:element name="Alias" type="fmi3Alias" minOccurs="0" maxOccurs="unbounded" />
+				</xs:sequence>
 				<xs:attribute name="start">
 					<xs:simpleType>
 						<xs:list>
@@ -216,13 +260,14 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	<xs:complexType name="fmi3String">
 		<xs:complexContent>
 			<xs:extension base="fmi3VariableBase">
-				<xs:sequence maxOccurs="unbounded">
-					<xs:element name="Start">
+				<xs:sequence>
+					<xs:element name="Start" minOccurs="0" maxOccurs="unbounded">
 						<xs:complexType>
 							<xs:attribute name="value" type="xs:string">
 							</xs:attribute>
 						</xs:complexType>
 					</xs:element>
+					<xs:element name="Alias" type="fmi3Alias" minOccurs="0" maxOccurs="unbounded" />
 				</xs:sequence>
 			</xs:extension>
 		</xs:complexContent>
@@ -230,6 +275,9 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	<xs:complexType name="fmi3Binary">
 		<xs:complexContent>
 			<xs:extension base="fmi3VariableBase">
+				<xs:sequence>
+					<xs:element name="Alias" type="fmi3Alias" minOccurs="0" maxOccurs="unbounded" />
+				</xs:sequence>
 				<xs:attribute name="mimeType" type="xs:normalizedString" use="optional" default="application/octet-stream">
 				</xs:attribute>
 				<xs:attribute name="maxSize" type="xs:nonNegativeInteger" use="optional">
@@ -252,6 +300,9 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	<xs:complexType name="fmi3Enumeration">
 		<xs:complexContent>
 			<xs:extension base="fmi3EnumerationBase">
+				<xs:sequence>
+					<xs:element name="Alias" type="fmi3Alias" minOccurs="0" maxOccurs="unbounded" />
+				</xs:sequence>
 				<xs:attribute name="declaredType" type="xs:normalizedString" use="required">
 				</xs:attribute>
 				<xs:attribute name="quantity" type="xs:normalizedString"/>
@@ -272,6 +323,9 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	<xs:complexType name="fmi3Clock">
 		<xs:complexContent>
 			<xs:extension base="fmi3VariableBase">
+				<xs:sequence>
+					<xs:element name="Alias" type="fmi3Alias" minOccurs="0" maxOccurs="unbounded" />
+				</xs:sequence>
 				<xs:attributeGroup ref="fmi3ClockAttributes"/>
 				<xs:attribute name="start" type="xs:boolean"/>
 			</xs:extension>


### PR DESCRIPTION
Defines Alias variables for the XML and provides an example.
If these changes make sense, I will upload the adocs with the description and constraints on the Alias element.
Please do not merge the PR until I've uploaded the adocs with the description. I just need some extra pair of eyes on the XSD, so that there are no big issues with the way the Alias element has been defined.
Refer to Alias.xml for examples on how the Alias element is to be used.

Remark: I had to change the definition of fmi3String. Before, the number of occurrences of the Start element was controlled by the parent xs:sequence element. This made it cumbersume to add the Alias element (as I would need another xs:sequence element, because we don't want alternating sequences of Start and Alias elements).
I believe the new definition is equivalent, and I've checked all xml files against the new schema.
