### PR TITLE
CI adaptions

### DIFF
--- a/.circleci/build_examples.sh
+++ b/.circleci/build_examples.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+ERROR=0
+
+echo
+echo "Validate XML"
+python3 /documents/.circleci/validate_xml.py || ERROR=1
+
+echo
+echo "Lint AsciiDoc files"
+# this script prints non-ascii characters to the console
+PYTHONIOENCODING=UTF-8 python3 /documents/.circleci/lint_docs.py || ERROR=1
+
+echo
+echo "Compile headers"
+gcc /documents/headers/fmi3Functions.h || ERROR=1
+
+echo
+echo "Run CMake generator"
+cmake /documents/docs/examples/c-code -Bbuild || ERROR=1
+
+echo
+echo "Build examples"
+cmake --build build || ERROR=1
+
+echo
+echo "Run examples"
+./build/jacobian || ERROR=1
+./build/co_simulation || ERROR=1
+./build/model_exchange || ERROR=1
+
+if [ $ERROR != 0 ]; then
+  echo
+  echo "!!!!! At least one test failed, see above !!!!!"
+else
+  echo
+  echo "All tests passed."
+fi
+exit $ERROR

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,46 +1,12 @@
 version: 2
 jobs:
   build_examples:
-    docker:
-      - image: debian:stretch
+    machine: true
     steps:
       - checkout
       - run:
-          name: Install sudo
-          command: apt-get update && apt-get install -y sudo && rm -rf /var/lib/apt/lists/*
-      - run:
-          name: Install GCC
-          command: apt-get update && apt-get install -y gcc g++
-      - run:
-          name: Install CMake
-          command: apt-get update && sudo apt-get install -y cmake
-      - run:
-          name: Install lxml
-          command: apt-get install -y python3-lxml
-      - run:
-          name: Validate XML
-          command: python3 .circleci/validate_xml.py
-      - run:
-          name: Lint AsciiDoc files
-          command: python3 .circleci/lint_docs.py
-          # this script prints non-ascii characters to the console
-          environment:
-            PYTHONIOENCODING: UTF-8
-      - run:
-          name: Compile headers
-          command: gcc ~/project/headers/fmi3Functions.h
-      - run:
-          name: Run CMake generator
-          command: cmake docs/examples/c-code -Bbuild
-      - run:
           name: Build examples
-          command: cmake --build build
-      - run:
-          name: Run examples
-          command: |
-            ./build/jacobian
-            ./build/co_simulation
-            ./build/model_exchange
+          command: ~/project/buildexamples.sh
   build_spec:
     machine: true
     steps:
@@ -50,13 +16,12 @@ jobs:
             - "33:26:15:d0:f2:e8:4f:d7:26:8b:b1:9b:a2:1c:ca:f2"
       - checkout
       - run:
-          name: Generate HTML
-          command: docker run -v ~/project/:/documents/ --name asciidoc-to-html asciidoctor/docker-asciidoctor asciidoctor --base-dir /documents/ --backend html5 --failure-level WARN --verbose docs/index.adoc
-      - run:
-          name: Validate HTML
+          name: Generate and validate HTML
           command: |
             if [ $CIRCLE_BRANCH = "master" ]; then
-              docker run -v ~/project/docs/:/documents/ 18fgsa/html-proofer /documents --only-4xx
+              ~/project/builddoc.sh checkLinks
+            else
+              ~/project/builddoc.sh
             fi
           no_output_timeout: 60m
       - run:

--- a/.circleci/validate_xml.py
+++ b/.circleci/validate_xml.py
@@ -1,8 +1,12 @@
 from lxml import etree
 import os
 
+top = os.path.abspath(__file__)
+top = os.path.dirname(top)
+top = os.path.dirname(top)
+
 print("Parsing the XSD schema")
-schema = etree.XMLSchema(file='schema/fmi3ModelDescription.xsd')
+schema = etree.XMLSchema(file=top + '/schema/fmi3ModelDescription.xsd')
 
 parser = etree.XMLParser(schema=schema)
 
@@ -22,4 +26,4 @@ xml_files = [
 
 for xml_file in xml_files:
     print("Parsing %s" % xml_file)
-    etree.parse(os.path.join('docs', 'examples', xml_file), parser)
+    etree.parse(os.path.join(top, 'docs', 'examples', xml_file), parser)

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ build/
 
 # custom automation scripts
 *.bat
+
+# keep docinfo
+!builddoc.bat
+!buildexamples.bat

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -19,21 +19,37 @@ If you havn't already done so https://help.github.com/articles/cloning-a-reposit
 
 or your favorite Git client. To build the HTML document you have two alternatives.
 
-`Alternative 1:` Docker (recommended)
+`Alternative 1:` Docker started using scripts (recommended)
 
 . Install https://www.docker.com/get-started[Docker]
 
-. Run the https://github.com/asciidoctor/docker-asciidoctor[Asciidoctor Docker Container]
+. Generate and check the HTML document (with debug messages enabled and without link checks which take very long time)
 +
-  docker run -it -v <fmi-standard>:/documents/ asciidoctor/docker-asciidoctor
+On Linux / MacOS / Systems with a shell run
++
+  builddoc.sh
++
+On Windows (Systems with Windows Batch = cmd) run
++
+  builddoc.bat
+
+`Alternative 2:` Docker
+
+. Install https://www.docker.com/get-started[Docker]
+
+. Generate the HTML document (with debug messages enabled) in the https://github.com/asciidoctor/docker-asciidoctor[Asciidoctor Docker Container]
++
+  docker run -v <fmi-standard>:/documents/ asciidoctor/docker-asciidoctor asciidoctor -B /documents/ -b html5 -v docs/index.adoc
 +
 where `<fmi-standard>` is the path to the cloned repository
 
-. Generate the HTML document (with debug messages enabled)
+. Check the generated HTML document (without link checks which take very long time) for errors in the https://github.com/gjtorikian/html-proofer[HTMLProofer Docker Container]
 +
-  asciidoctor -B /documents/ -b html5 -v docs/index.adoc
+  docker run -v <fmi-standard>/docs/:/documents/ 18fgsa/html-proofer /documents --only-4xx --checks-to-ignore LinkCheck
++
+where `<fmi-standard>` is the path to the cloned repository
 
-`Alternative 2:` Ruby and the AsciiDoctor gem
+`Alternative 3:` Ruby and the AsciiDoctor gem
 
 . https://www.ruby-lang.org/en/downloads/[Install Ruby]
 

--- a/builddoc.bat
+++ b/builddoc.bat
@@ -1,0 +1,8 @@
+set REPODIR=%~pd0
+
+docker run -v "%REPODIR%:/documents/" asciidoctor/docker-asciidoctor asciidoctor -B /documents/ -b html5 -v docs/index.adoc && ^
+if "_%1" == "_checkLinks" (
+  docker run -v "%REPODIR%docs\:/documents/" 18fgsa/html-proofer /documents --only-4xx
+) else (
+  docker run -v "%REPODIR%docs\:/documents/" 18fgsa/html-proofer /documents --only-4xx --checks-to-ignore LinkCheck
+)

--- a/builddoc.sh
+++ b/builddoc.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+REPODIR="$(cd "$(dirname "$0")"; pwd)"
+
+docker run -v "$REPODIR":/documents/ asciidoctor/docker-asciidoctor asciidoctor -B /documents/ -b html5 -v docs/index.adoc && \
+if [ "_$1" = "_checkLinks" ]; then
+  docker run -v "$REPODIR/docs/":/documents/ 18fgsa/html-proofer /documents --only-4xx
+else
+  docker run -v "$REPODIR/docs/":/documents/ 18fgsa/html-proofer /documents --only-4xx --checks-to-ignore LinkCheck
+fi

--- a/buildexamples.bat
+++ b/buildexamples.bat
@@ -1,0 +1,3 @@
+set REPODIR=%~pd0
+
+docker run -v "%REPODIR%:/documents/" fm12/build_examples /documents/.circleci/build_examples.sh 

--- a/buildexamples.sh
+++ b/buildexamples.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+REPODIR="$(cd "$(dirname "$0")"; pwd)"
+
+docker run -v "$REPODIR":/documents/ fm12/build_examples /documents/.circleci/build_examples.sh 

--- a/docker/build_examples/Dockerfile
+++ b/docker/build_examples/Dockerfile
@@ -1,0 +1,9 @@
+FROM debian:stretch
+
+RUN apt-get update && \
+  apt-get install -y \
+  gcc \
+  g++ \
+  cmake \
+  python3-lxml \
+  && rm -rf /var/lib/apt/lists/*

--- a/docker/build_examples/README.adoc
+++ b/docker/build_examples/README.adoc
@@ -1,0 +1,11 @@
+= Docker image to build examples
+
+If the Dockerfile in this directory is modified rebuild the docker image with
+
+  docker build -t fm12/build_examples .
+
+and push the docker image to DockerHub
+
+  docker push fm12/build_examples
+
+Note that you need appropriate write permission on DockerHub to push the image.


### PR DESCRIPTION
Create a docker image usable to build the examples.
Use this docker image for the example build in CI.
Added .sh/.bat scripts to build the doc and examples locally (with docker installed).
See CONTRIBUTING.adoc for details of the local build.

Required adaptions before a merge of this commit:
- Create a modelica or FMI organization on DockerHub (analog to the modelica organization on GitHub).
- Push the docker image build_examples to this DockerHub organization.
- Adapt the scripts to use this docker image (for now my DockerHub account "fm12" is used)
- Maybe automatically rebuild the docker image by CI and push it to DockerHub
  (The DockerHub login credentials needs to be configure in CI for this.)
  But the image should rarely be changed, so a pure manual update of the image is also possisble.