### PR TITLE
Fixed code example describing Jacobian construction using fmi2GetDirectionalDerivative

### DIFF
--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -965,7 +965,7 @@ dvKnown[1] = {1.0}; //seed vector for fmi2GetDirectionalDerivative
    M_fmi2SetReal/Integer/Boolean/String(m, ...)
    // Construct the Jacobian elements J[:,:] columnwise
 for i in 1:nx loop
-  M_fmi2GetDirectionalDerivative(m, x_ref[i], 1, xd_ref, nx, dvKnown, ci);
+  M_fmi2GetDirectionalDerivative(m, xd_ref, nx, x_ref[i], 1, dvKnown, ci);
   J[:,i] = ci;    // ci is an auxiliary vector of nx elements
                   // (it holds the i-th column of the Jacobian)
 end for;


### PR DESCRIPTION
In function call, the vectors of value references for states and state derivatives were in the wrong order with respect to function's signature. This resulted in a misleading example which, if followed, made fmi2GetDirectionalDerivative terminating with an error.