### PR TITLE
Clarify that parameters are not knowns in continous time mode

### DIFF
--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -2013,6 +2013,8 @@ Knowns latexmath:[\color{blue}{\mathbf{v}_{\text{known}}}] in *Event Mode* and *
 - <<independent>> variable (usually time; <<causality>> = <<independent>>).
 If an <<independent>> variable is not explicitly defined under variables, it is assumed that the unknown depends explicitly on the <<independent>> variable.
 
+_[<<parameter,`parameters`>> and <<tunable>> <<parameter,`parameters`>> must not be listed as knowns in this mode. This may change in a further FMI version which implies the possibility to calculate derivatives with respect to parameters.]_
+
 `Knowns` latexmath:[\color{blue}{\mathbf{v}_{\text{known}}}] in *Initialization Mode* (for elements <<InitialUnknown>>):
 
 - inputs (variables with <<causality>> = <<input>>)

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -2013,7 +2013,7 @@ Knowns latexmath:[\color{blue}{\mathbf{v}_{\text{known}}}] in *Event Mode* and *
 - <<independent>> variable (usually time; <<causality>> = <<independent>>).
 If an <<independent>> variable is not explicitly defined under variables, it is assumed that the unknown depends explicitly on the <<independent>> variable.
 
-_[<<parameter,`parameters`>> and <<tunable>> <<parameter,`parameters`>> must not be listed as knowns in this mode. This may change in a further FMI version which implies the possibility to calculate derivatives with respect to parameters.]_
+_[<<parameter,`parameters`>> and <<tunable>> <<parameter,`parameters`>> must not be listed as knowns in this mode. This may change in a future FMI version which implies the possibility to calculate derivatives with respect to parameters.]_
 
 `Knowns` latexmath:[\color{blue}{\mathbf{v}_{\text{known}}}] in *Initialization Mode* (for elements <<InitialUnknown>>):
 


### PR DESCRIPTION
Parameters and tunable parameters are NOT knowns in continous time mode,
event mode and cosimulation step mode. This would imply that derivatives
wrt parameters are possible in these modes.
Their is a working group for derivatives wrt parameters (for
optimization and sensitivity analysis) but this does not go into 3.0.