### PR TITLE
Prefer usable over useable

### DIFF
--- a/docs/4_2_basic_co-simulation_api.adoc
+++ b/docs/4_2_basic_co-simulation_api.adoc
@@ -359,7 +359,7 @@ or <<causality>> = <<input>> +
 *6* for a variable with <<causality>> = <<input>> or (<<causality>> = <<parameter>> and <<variability>> = <<tunable>>) +
 *7* always, but retrieved values are usable for debugging only +
 *8* always, but if status is other than `fmi3Terminated`,
-retrieved values are useable for debugging only ]_
+retrieved values are usable for debugging only ]_
 
 ==== Code Example for fmi3CoSimulation
 

--- a/docs/6_2_scheduled_co-simulation_api.adoc
+++ b/docs/6_2_scheduled_co-simulation_api.adoc
@@ -274,7 +274,7 @@ or <<causality>> = <<input>> +
 *6* for a variable with <<causality>> = <<input>> or (<<causality>> = <<parameter>> and <<variability>> = <<tunable>>) +
 *7* always, but retrieved values are usable for debugging only +
 *8* always, but if status is other than `fmi3Terminated`,
-retrieved values are useable for debugging only ]_
+retrieved values are usable for debugging only ]_
 
 ==== Preemption Support [[preemption-support]]
 


### PR DESCRIPTION
Minor spelling issue: There was both "usable" and "useable" used in subsequent comments.