### PR TITLE
Change the definition of Boolean and String to avoid using an abstract

### DIFF
--- a/schema/fmi3Type.xsd
+++ b/schema/fmi3Type.xsd
@@ -133,8 +133,20 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 					</xs:complexContent>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="Boolean" type="fmi3TypeDefinitionBase"/>
-			<xs:element name="String" type="fmi3TypeDefinitionBase"/>
+			<xs:element name="Boolean">
+				<xs:complexType>
+					<xs:complexContent>
+						<xs:extension base="fmi3TypeDefinitionBase" />
+					</xs:complexContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="String">
+				<xs:complexType>
+					<xs:complexContent>
+						<xs:extension base="fmi3TypeDefinitionBase" />
+					</xs:complexContent>
+				</xs:complexType>
+			</xs:element>
 			<xs:element name="Binary">
 				<xs:complexType>
 					<xs:complexContent>


### PR DESCRIPTION
Amended fmi3Type.xsd to avoid abstract type errors for Boolean and String.