### PR TITLE
Clarify inflow/outflow in terminals #772

### DIFF
--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -998,7 +998,12 @@ _For the sake of simplicity in the following latexmath:[\dot{m}_i] denotes an in
 
 latexmath:[0 = \sum{\dot{m}_i}]
 
-_Connecting a single <<output>> `outflow` to a single <<input>> `inflow`, or vice versa automatically fulfills the flow constraint, while connecting two single signals of the same flow type requires a negation of the signal.]_
+_Connecting a single <<output>> `outflow` to a single <<input>> `inflow`, or vice versa automatically fulfills the flow constraint, while connecting two single signals of the same flow type requires a negation of the signal.
+
+`inflow` and `outflow` is only used as a sign convention for scalar flow quantities which obey Kirchhoff's current law (sum up to zero).
+Other, none scalar, quantities which also sum up to zero, like a mechanical force in 3D space according to D'Alembert's principle, are not covered by this sign conversion.
+This is the case since Kirchhoff's current law only holds for scalars were a sign convention is sufficient.
+Other definitions are beyond the scope of this terminal specification and need clear definition in other specifications on top of this.]_
 
 ===== Terminal Stream Member Variable
 

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1001,8 +1001,8 @@ latexmath:[0 = \sum{\dot{m}_i}]
 _Connecting a single <<output>> `outflow` to a single <<input>> `inflow`, or vice versa automatically fulfills the flow constraint, while connecting two single signals of the same flow type requires a negation of the signal.
 
 `inflow` and `outflow` is only used as a sign convention for scalar flow quantities which obey Kirchhoff's current law (sum up to zero).
-Other, none scalar, quantities which also sum up to zero, like a mechanical force in 3D space according to D'Alembert's principle, are not covered by this sign conversion.
-This is the case since Kirchhoff's current law only holds for scalars were a sign convention is sufficient.
+Other, none scalar, quantities which also sum up to zero, like a mechanical force in 3D space according to D'Alembert's principle, are not covered by this sign convention.
+This is the case since Kirchhoff's current law only holds for scalars where a sign convention is sufficient.
 Other definitions are beyond the scope of this terminal specification and need clear definition in other specifications on top of this.]_
 
 ===== Terminal Stream Member Variable


### PR DESCRIPTION
inflow/outflow can only be used for scalars which sum up to zero. Other
quantities which also sum up to zero (at connection points) are not
covered by inflow/output.

This is now stated as non-nominative text.