### PR TITLE
Remove [] from argument names

### DIFF
--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -846,13 +846,13 @@ include::../headers/fmi3FunctionTypes.h[tag=SetClock]
 
 Sets <<clock,`clocks`>> activation status by providing the value references of the corresponding <<clock>> variables and their values.
 
-* Argument `valueReferences[]` points to an array of value references of clocks to be activated or deactivated at the current time instant depending on
+* Argument `valueReferences` points to an array of value references of clocks to be activated or deactivated at the current time instant depending on
 
-* argument `values[]` content: if the nth element is `fmi3ClockActive` the nth clock is activated, otherwise deactivated.
+* argument `values` content: if the nth element is `fmi3ClockActive` the nth clock is activated, otherwise deactivated.
 
-* Argument `nValueReferences` indicates the size of the parallel arrays `valueReferences[]` and `values[]` (and potentially `subactive[]`).
+* Argument `nValueReferences` indicates the size of the parallel arrays `valueReferences` and `values` (and potentially `subactive`).
 
-* Argument `subactive[]` requires evaluation of a clocked partition in subactive mode (only output equations) if the argument subactive is non NULL and `subactive[i] = fmi3True`. `subactive[i]` has no meaning for Communication Point Clocks and is ignored for such <<clock,`clocks`>>.
+* Argument `subactive` requires evaluation of a clocked partition in subactive mode (only output equations) if the argument subactive is non NULL and `subactive[i] = fmi3True`. `subactive[i]` has no meaning for Communication Point Clocks and is ignored for such <<clock,`clocks`>>.
 It is not allowed to call this function within the callback function `fmi3IntermediateUpdate`.
 
 [[fmi3GetClock,`fmi3GetClock`]]
@@ -863,11 +863,11 @@ include::../headers/fmi3FunctionTypes.h[tag=GetClock]
 
 Inquires whether a set of <<clock,`clocks`>> is active by providing the value references of the corresponding <<clock>> variables.
 
-* Argument `valueReferences[]` contains a list of value references to <<clock,`clocks`>> of the size indicated by
+* Argument `valueReferences` contains a list of value references to <<clock,`clocks`>> of the size indicated by
 
 * argument `nValueReferences`.
 
-* Argument `values[]` will return the activation status at the current time instant of the <<clock,`clocks`>> referenced by `valueReferences[]`.
+* Argument `values` will return the activation status at the current time instant of the <<clock,`clocks`>> referenced by `valueReferences`.
 If `values[i] = fmi3ClockActive` the <<clock>> is currently active, otherwise the <<clock>> is not active.
 
 It is allowed to call this function within the callback function `fmi3IntermediateUpdate`.
@@ -1094,14 +1094,14 @@ include::../headers/fmi3FunctionTypes.h[tags=GetAdjointDerivative]
 
 Both functions have the same parameters:
 
-* Argument `unknowns[]` contains value references to the unknowns.
-* Argument `nUnknowns` contains the length of argument `unknowns[]`.
-* Argument `knowns[]` contains value references of the knowns.
-* Argument `nKnowns` contains the length of argument `knowns[]`.
-* Argument `seed[]` contains the components of the seed vector.
-* Argument `nSeed` contains the length of `seed[]`.
-* Argument `sensitivity[]` contains the components of the sensitivity vector.
-* Argument `nSensitivity` contains the length of `sensitivity[]`.
+* Argument `unknowns` contains value references to the unknowns.
+* Argument `nUnknowns` contains the length of argument `unknowns`.
+* Argument `knowns` contains value references of the knowns.
+* Argument `nKnowns` contains the length of argument `knowns`.
+* Argument `seed` contains the components of the seed vector.
+* Argument `nSeed` contains the length of `seed`.
+* Argument `sensitivity` contains the components of the sensitivity vector.
+* Argument `nSensitivity` contains the length of `sensitivity`.
 
 _[Note that array variables will be serialized, so `nSeed` is only equal to `nKnowns` in the case of directional derivatives resp. equal to `nUnknowns` in the case of adjoint derivatives, if all value references of `knowns` resp. `unknowns` point to scalar variables._
 _Likewise `nSensitivity` is only equal to `nUnknowns` resp. `nKnowns` if all value references of `unknowns` resp. `knowns` point to scalar variables.]_

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -35,7 +35,7 @@ Set a new (continuous) state vector and re-initialize caching of variables that 
 
 * Argument `nx` is the length of
 
-* argument `x[]`
+* argument `x`
 
 and is provided for checking purposes (variables that depend solely on<<constant,`constants`>>, <<parameter,`parameters`>>, time, and <<input,`inputs`>> do not need to be newly computed in the sequel, but the previously computed values can be reused).
 Note that the continuous <<state,`states`>> might also be changed in *Event Mode*.
@@ -74,12 +74,12 @@ _[These arguments are not mutually exclusive and may all be `fmi3False` if the c
 
 * Argument `stepEvent` signals with `fmi3True` that a step event occurred.
 
-* Argument `rootsFound[]` is an array of length `nEventIndicators`. For `i = 1, ..., nEventIndicators, rootsFound[i-1]` latexmath:[\neq] `0` if the event indicator latexmath:[z_i] has a root, and `rootsFound[i-1] == 0` if not.
+* Argument `rootsFound` is an array of length `nEventIndicators`. For `i = 1, ..., nEventIndicators, rootsFound[i-1]` latexmath:[\neq] `0` if the event indicator latexmath:[z_i] has a root, and `rootsFound[i-1] == 0` if not.
 For the components latexmath:[z_i] for which a root was found, the sign of `rootsFound[i-1]` indicates the direction of the zero-crossing.
 A value of `+1` indicates that latexmath:[z_i] is increasing, while a value of `-1` indicates a decreasing latexmath:[z_i].
 If `nEventIndicators == 0` the value of `rootsFound` is not defined.
 
-* Argument `nEventIndicators` contains the number of event indicators (length of `rootsFound[]`) or `0` if the caller cannot provide this information.
+* Argument `nEventIndicators` contains the number of event indicators (length of `rootsFound`) or `0` if the caller cannot provide this information.
 
 * Argument `timeEvent` signals with `fmi3True` that a time event occurred.
 

--- a/docs/4_2_basic_co-simulation_api.adoc
+++ b/docs/4_2_basic_co-simulation_api.adoc
@@ -25,15 +25,15 @@ include::../headers/fmi3FunctionTypes.h[tags=GetOutputDerivatives]
 Both functions have the same arguments:
 
 --
-* Argument `valueReferences[]` is a vector of value references that define the variables whose <<derivative,`derivatives`>> shall be set or get.
+* Argument `valueReferences` is a vector of value references that define the variables whose <<derivative,`derivatives`>> shall be set or get.
 
-* Argument `nValueReferences` is the dimension of the arguments `valueReferences[]` and `orders[]`.
+* Argument `nValueReferences` is the dimension of the arguments `valueReferences` and `orders`.
 
-* Argument `orders[]` contains the orders of the respective <<derivative>> (1 means the first <<derivative>>, 0 is not allowed).
+* Argument `orders` contains the orders of the respective <<derivative>> (1 means the first <<derivative>>, 0 is not allowed).
 
-* Argument `values[]` is a vector with the values of the <<derivative,`derivatives`>>.
+* Argument `values` is a vector with the values of the <<derivative,`derivatives`>>.
 
-* Argument `nValues` is the size of the argument `values[]`.
+* Argument `nValues` is the size of the argument `values`.
 --
 
 <<fmi3SetInputDerivatives>>::


### PR DESCRIPTION
Someone already dropped some of the [] but not consistently. I tried to catch the rest.