### PR TITLE
Unify headers and descriptions of state machines

### DIFF
--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -211,7 +211,7 @@ _[Typically, the nominal values of the continuous <<state,`states`>> are used to
 _Example:_ +
 `absoluteTolerance[i] = 0.01 * tolerance * x_nominal[i];` _]_
 
-==== State Machine of Calling Sequence [[state-machine-model-exchange]]
+==== State Machine for Model Exchange [[state-machine-model-exchange]]
 
 Every implementation of the FMI must support calling sequences of the functions according to the following state chart:
 
@@ -229,35 +229,35 @@ Note that the FMU can always determine in which state it is since every state is
 The transition conditions `external event`, `time event`, and `state event` are defined in <<math-model-exchange>>.
 Each state of the state machine corresponds to a certain phase of a simulation as follows:
 
-instantiated::
+===== State: instantiated
 In this state, <<start>> and guess values (= variables that have <<initial>> = <<exact>> or <<approx>>) set and <<variability>> latexmath:[\neq] <<constant>> can be set, this does not include inputs as they do not have an <<initial>> attribute.
 
-Configuration Mode::
+===== State: Configuration Mode
 In this state <<structuralParameter,`structural parameters`>> with <<variability>> = <<fixed>> or <<variability>> = <<tunable>> can be changed.
 This state is entered from state *Instantiated* by calling <<fmi3EnterConfigurationMode>> and left back to *Instantiated* by calling <<fmi3ExitConfigurationMode>>.
 <<fmi3EnterConfigurationMode>> can only be called if the FMU contains at least one <<structuralParameter,`structural parameter`>>
 
-Initialization Mode::
+===== State: Initialization Mode
 In this state, equations are active to determine all continuous-time states, as well as all <<output,`outputs`>> (and optionally other variables exposed by the exporting tool).
 The variables that can be retrieved by `fmi3Get{VariableType}` calls are (1) defined in the XML file as elements `<ModelStructure><InitialUnknown>` and (2) variables with <<causality>> = <<output>>.
 Variables with <<initial>> = <<exact>> and <<variability>> latexmath:[\neq] <<constant>>, as well as variables with <<causality>> = <<input>> can be set.
 
-Continuous-Time Mode::
+===== State: Continuous-Time Mode
 In this state, the continuous-time model equations are active and integrator steps are performed.
 The event time of a state event may be determined if a domain change of at least one event indicator is detected at the end of a completed integrator step.
 
-Event Mode::
+===== State: Event Mode
 If an event is triggered in *Continuous-Time Mode*, *Event Mode* is entered by calling <<fmi3EnterEventMode>>.
 In this mode all continuous-time and discrete-time equations are active and the unknowns at an event can be computed and retrieved.
 After an event is completely processed, <<fmi3NewDiscreteStates>> must be called and depending on the return argument, `newDiscreteStatesNeeded`, the state chart stays in *Event Mode* or switches to *Continuous-Time Mode*.
 When the *Initialization Mode* is terminated with <<fmi3ExitInitializationMode>>, then *Event Mode* is directly entered, and the continuous-time and discrete-time variables at the initial time are computed based on the initial continuous-time states determined in the *Initialization Mode*.
 
-Reconfiguration Mode::
+===== State: Reconfiguration Mode
 In this state <<structuralParameter,`structural parameters`>> with <<variability>> = <<tunable>> can be changed.
 This state is entered from state *Event Mode* by calling <<fmi3EnterConfigurationMode>> and left back to *Event Mode* by calling <<fmi3ExitConfigurationMode>>.
 <<fmi3EnterConfigurationMode>> can only be called if the FMU contains at least one <<structuralParameter,`structural parameter`>>
 
-Terminated::
+===== State: Terminated
 In this state, the solution at the final time of a simulation can be retrieved.
 
 Note that simulation backward in time is only allowed over continuous time intervals.

--- a/docs/4_2_basic_co-simulation_api.adoc
+++ b/docs/4_2_basic_co-simulation_api.adoc
@@ -120,7 +120,7 @@ include::../headers/fmi3FunctionTypes.h[tags=GetDoStepDiscardedStatus]
 
 * `lastSuccessfulTime` is the time instant at which the slave stopped the <<fmi3DoStep>> call.
 
-==== State Machine of Calling Sequence from Master to Slave in Co-Simulation Interface Types [[state-machine-co-simulation]]
+==== State Machine for Basic Co-Simulation [[state-machine-co-simulation]]
 
 The following state machine defines the supported calling sequences.
 
@@ -130,18 +130,18 @@ image::images/state-machine-co-simulation.svg[width=80%, align="center"]
 
 In this Co-Simulation interface the following functions must not be called: <<fmi3ActivateModelPartition>>, <<fmi3NewDiscreteStates>>, <<fmi3EnterEventMode>>, <<fmi3SetClock>>, <<fmi3GetClock>>, <<fmi3SetIntervalFraction>>, <<fmi3GetIntervalFraction>>, <<fmi3SetIntervalDecimal>>, <<fmi3GetIntervalDecimal>> including all functions that are specific to Model Exchange.
 
-===== State: Slave Setable FMU State [[state-slave-setable-fmu-state-co-simulation]]
+===== State: FMU State Setable [[state-fmu-state-setable-co-simulation]]
 
 In all states of this super state it is allowed to call <<fmi3GetFMUState>>, <<fmi3SetFMUState>>, <<fmi3FreeFMUState>>`, <<fmi3SerializedFMUStateSize>>, <<fmi3SerializeFMUState>>, `fmi3DeSerializeFMUState`, <<fmi3Reset>>, <<fmi3GetVersion>>, `fmi3SetDebugLogging` and <<fmi3FreeInstance>>.
 
 If any function returns with `fmi3Fatal` the FMU enters the terminal state.
 
-===== State: Slave Under Evaluation [[state-slave-under-evaluation-co-simulation]]
+===== State: Under Evaluation [[state-under-evaluation-co-simulation]]
 
 This super state is entered by the FMU when <<fmi3Instantiate>> is called.
 If any function returns `fmi3Error` the FMU enters state *Terminated*.
 
-===== State: Slave Initialized [[state-slave-initialized-co-simulation]]
+===== State: Initialized [[state-initialized-co-simulation]]
 
 This super state is entered by the FMU when <<fmi3ExitInitializationMode>> is called.
 If the function <<fmi3Terminate>> is called, the FMU enters state *Terminated*.

--- a/docs/5_2_hybrid_co-simulation_api.adoc
+++ b/docs/5_2_hybrid_co-simulation_api.adoc
@@ -141,7 +141,7 @@ Note that it is not allowed to call <<fmi3EnterEventMode>> or <<fmi3EnterStepMod
 _[Usually the Co-Simulation master should be able to derive (but is not forced to do so) the correct communication point times for <<inputClock,`input clocks`>> in advance and thus it should be able to set the proper `communicationStepSize` for <<fmi3DoStep>>._
 _This might not be possible if an aperiodic <<inputClock>> of an FMU depends on the ticking of an aperiodic <<outputClock>> of another FMU or other aperiodic tick sources.]_
 
-==== State Machine of Calling Sequence from Master to Slave in Hybrid Co-Simulation [[state-machine-calling-sequence-clocked-co-simulation]]
+==== State Machine for Hybrid Co-Simulation [[state-machine-calling-sequence-clocked-co-simulation]]
 
 The following state machine defines the supported calling sequences.
 
@@ -154,17 +154,17 @@ In this Co-Simulation interface the following functions must not be called: <<fm
 Unlike the state machine in section <<state-machine-co-simulation>> the entry state after *Initialization Mode* is the *Event Mode* in order to allow the FMU to handle the very first discrete event.
 Each state of the state machine corresponds to a certain phase of a simulation as follows:
 
-===== State: Slave Setable FMU State
+===== State: FMU State Setable
 
-This super state in Hybrid Co-Simulation does not differ from Basic Co-Simulation described in section <<state-slave-setable-fmu-state-co-simulation>>.
+This super state in Hybrid Co-Simulation does not differ from Basic Co-Simulation described in section <<state-fmu-state-setable-co-simulation>>.
 
-===== State: Slave Under Evaluation
+===== State: Under Evaluation
 
-This super state in Hybrid Co-Simulation does not differ from Basic Co-Simulation described in section <<state-slave-under-evaluation-co-simulation>>.
+This super state in Hybrid Co-Simulation does not differ from Basic Co-Simulation described in section <<state-under-evaluation-co-simulation>>.
 
-===== State: Slave Initialized
+===== State: Initialized
 
-This super state in Hybrid Co-Simulation does not differ from Basic Co-Simulation described in section <<state-slave-initialized-co-simulation>>.
+This super state in Hybrid Co-Simulation does not differ from Basic Co-Simulation described in section <<state-initialized-co-simulation>>.
 
 ===== State: Instantiated
 

--- a/docs/6_2_scheduled_co-simulation_api.adoc
+++ b/docs/6_2_scheduled_co-simulation_api.adoc
@@ -80,18 +80,18 @@ In Scheduled Co-Simulation the following functions must not be called: <<fmi3DoS
 
 The states *Configuration Mode*, *Instantiated*, *Initialization Mode*, and *Terminated* are handled in the same way as in Co-Simulation, with the exception that the generally not allowed functions of Scheduled Co-Simulation must not be called.
 
-===== State: Slave Settable FMU State
+===== State: Setable FMU State
 
 In all states of this super state it is allowed to call <<fmi3GetFMUState>>, `fmi3SetFMUState`, `fmi3FreeFMUState`, <<fmi3SerializedFMUStateSize>>, <<fmi3SerializeFMUState>>, <<fmi3DeSerializeFMUState>>, <<fmi3Reset>>, <<fmi3GetVersion>>, `fmi3SetDebugLogging` and <<fmi3FreeInstance>>.
 
 If any function returns with `fmi3Fatal` the FMU enters the terminal state.
 
-===== State: Slave Under Evaluation
+===== State: Under Evaluation
 
 This super state is entered by the FMU when <<fmi3Instantiate>> is called.
 If any function returns `fmi3Error` or `fmi3Discard` the FMU enters state *Terminated*.
 
-===== State: Slave Initialized
+===== State: Initialized
 
 This super state is entered by the FMU when `fmi3ExitInitializatoinMode` is called.
 If the function <<fmi3Terminate>> is called, the FMU enters state *Terminated* from all states of this super state.


### PR DESCRIPTION
These are a few minor changes all trying to unify the 4 state machine description formats and texts