### PR TITLE
Input approximation

### DIFF
--- a/docs/4_1_basic_co-simulation_math.adoc
+++ b/docs/4_1_basic_co-simulation_math.adoc
@@ -196,7 +196,7 @@ For an output argument, calling `fmi3Get{VariableType}` on such a variable retur
 
 |Set continuous-time and discrete-time <<input,`inputs`>> latexmath:[\mathbf{u}_{c+d}(tc_0)] and optionally the coefficients for continuous-time <<input,`inputs`>> approximation latexmath:[\mathbf{u}_{c}^{(j)}(tc_0)]
 |`fmi3Set{VariableType}` +
-`fmi3SetInputApproximation`
+<<fmi3SetInputApproximation>>
 
 |[blue]#latexmath:[\mathbf{v}_{InitialUnknowns} := \mathbf{f}_{init}(\mathbf{u}_c, \mathbf{u}_d, t_0, \mathbf{v}_{initial=exact})]#
 |`[blue]#fmi3Get{VariableType}#` +
@@ -212,7 +212,7 @@ For an output argument, calling `fmi3Get{VariableType}` on such a variable retur
 
 |Set continuous-time and discrete-time <<input,`inputs`>> latexmath:[\mathbf{u}_{d+c}(tc_i)] and optionally the coefficients for continuous-time <<input,`inputs`>> approximation latexmath:[\mathbf{u}_{c}^{(j)}(tc_i)]
 |`fmi3Set{VariableType}` +
-`fmi3SetInputApproximation`
+<<fmi3SetInputApproximation>>
 
 |[blue]#latexmath:[\begin{matrix} tc_{i+1} := tc_i + hc_i \\ (\mathbf{y}_{c+d}, \mathbf{y}_c^{(j)}, \mathbf{w}_{c+d}) := \mathbf{f}_{doStep}(\mathbf{u}_{c+d}, \mathbf{u}_{c}^{(j)}, tc_i, hc_i, \mathbf{p}_{tune}, \mathbf{p}_{other})_{tc_i} \\ tc_i := tc_{i+1} \end{matrix}]# +
 [blue]#latexmath:[\mathbf{f}_{doStep}] is also a function of the internal variables latexmath:[\mathbf{x}_c], latexmath:[^{\bullet}\mathbf{x}_d]#
@@ -233,7 +233,7 @@ _[Remark - Calling Sequences:_
 _In the table above, for notational convenience in *Initialization Mode* one function call is defined to compute all output arguments from all inputs arguments._
 _In reality, every variable output argument is computed by one_ `fmi3Get{VariableType}` _function call._
 
-_In *Step Mode* the input arguments to_ latexmath:[\mathbf{f}_{doStep}] _are defined by calls to_ `fmi3Set{VariableType}` _and_ `fmi3SetInputApproximation` _functions._
+_In *Step Mode* the input arguments to_ latexmath:[\mathbf{f}_{doStep}] _are defined by calls to_ `fmi3Set{VariableType}` _and_ <<fmi3SetInputApproximation>> _functions._
 _The variables computed by_ latexmath:[\mathbf{f}_{doStep}] _can be inquired by_  `fmi3Get{VariableType}` _function calls.]_
 
 ==== Early Return from Current Communication Step

--- a/docs/4_1_basic_co-simulation_math.adoc
+++ b/docs/4_1_basic_co-simulation_math.adoc
@@ -194,9 +194,9 @@ For an output argument, calling `fmi3Get{VariableType}` on such a variable retur
 |Set variables latexmath:[v_{initial=exact}] and latexmath:[v_{initial=approx}] that have a <<start>> value with <<initial>> = <<exact>> (<<independent>> <<parameter,`parameters`>> latexmath:[\mathbf{p}] and continuous-time <<state,`states`>> with start values latexmath:[\mathbf{x}_{c,initial=exact}] are included here)
 |`fmi3Set{VariableType}`
 
-|Set continuous-time and discrete-time <<input,`inputs`>> latexmath:[\mathbf{u}_{c+d}(tc_0)] and optionally the <<derivative,`derivatives`>> of continuous-time <<input,`inputs`>> latexmath:[\mathbf{u}_{c}^{(j)}(tc_0)]
+|Set continuous-time and discrete-time <<input,`inputs`>> latexmath:[\mathbf{u}_{c+d}(tc_0)] and optionally the coefficients for continuous-time <<input,`inputs`>> approximation latexmath:[\mathbf{u}_{c}^{(j)}(tc_0)]
 |`fmi3Set{VariableType}` +
-`fmi3SetInputDerivatives`
+`fmi3SetInputApproximation`
 
 |[blue]#latexmath:[\mathbf{v}_{InitialUnknowns} := \mathbf{f}_{init}(\mathbf{u}_c, \mathbf{u}_d, t_0, \mathbf{v}_{initial=exact})]#
 |`[blue]#fmi3Get{VariableType}#` +
@@ -210,9 +210,9 @@ For an output argument, calling `fmi3Get{VariableType}` on such a variable retur
 |Set <<independent>> <<tunable>> <<parameter,`parameters`>> latexmath:[\mathbf{p}_{tune}] (and do not set other <<parameter,`parameters`>> latexmath:[\mathbf{p}_{other}])
 |`fmi3Set{VariableType}`
 
-|Set continuous-time and discrete-time <<input,`inputs`>> latexmath:[\mathbf{u}_{d+c}(tc_i)] and optionally the <<derivative,`derivatives`>> of continuous-time <<input,`inputs`>> latexmath:[\mathbf{u}_{c}^{(j)}(tc_i)]
+|Set continuous-time and discrete-time <<input,`inputs`>> latexmath:[\mathbf{u}_{d+c}(tc_i)] and optionally the coefficients for continuous-time <<input,`inputs`>> approximation latexmath:[\mathbf{u}_{c}^{(j)}(tc_i)]
 |`fmi3Set{VariableType}` +
-`fmi3SetInputDerivatives`
+`fmi3SetInputApproximation`
 
 |[blue]#latexmath:[\begin{matrix} tc_{i+1} := tc_i + hc_i \\ (\mathbf{y}_{c+d}, \mathbf{y}_c^{(j)}, \mathbf{w}_{c+d}) := \mathbf{f}_{doStep}(\mathbf{u}_{c+d}, \mathbf{u}_{c}^{(j)}, tc_i, hc_i, \mathbf{p}_{tune}, \mathbf{p}_{other})_{tc_i} \\ tc_i := tc_{i+1} \end{matrix}]# +
 [blue]#latexmath:[\mathbf{f}_{doStep}] is also a function of the internal variables latexmath:[\mathbf{x}_c], latexmath:[^{\bullet}\mathbf{x}_d]#
@@ -233,7 +233,7 @@ _[Remark - Calling Sequences:_
 _In the table above, for notational convenience in *Initialization Mode* one function call is defined to compute all output arguments from all inputs arguments._
 _In reality, every variable output argument is computed by one_ `fmi3Get{VariableType}` _function call._
 
-_In *Step Mode* the input arguments to_ latexmath:[\mathbf{f}_{doStep}] _are defined by calls to_ `fmi3Set{VariableType}` _and_ `fmi3SetInputDerivatives` _functions._
+_In *Step Mode* the input arguments to_ latexmath:[\mathbf{f}_{doStep}] _are defined by calls to_ `fmi3Set{VariableType}` _and_ `fmi3SetInputApproximation` _functions._
 _The variables computed by_ latexmath:[\mathbf{f}_{doStep}] _can be inquired by_  `fmi3Get{VariableType}` _function calls.]_
 
 ==== Early Return from Current Communication Step

--- a/docs/4_2_basic_co-simulation_api.adoc
+++ b/docs/4_2_basic_co-simulation_api.adoc
@@ -12,7 +12,7 @@ This section contains the interface description to access the input/output data 
 ===== Input Approximation [[api-input-approximation]]
 
 In order to enable the slave to approximate the <<continuous>> floating point <<input,`inputs`>> between communication steps, the the coefficients of a polynomial can be provided.
-The order of this approximation is given by the unsigned integer capability flag `MaxInputApproximationOrder`.
+The order of this approximation is given by the unsigned integer capability flag `inputApproximationOrder`.
 
 [[fmi3SetInputApproximation,`fmi3SetInputApproximation`]]
 [source, C]
@@ -34,21 +34,19 @@ include::../headers/fmi3FunctionTypes.h[tags=SetInputApproximation]
 
 <<fmi3SetInputApproximation>>::
 Restrictions on using the function are the same as for the `fmi3Set{VariableType}` function.
-Different input variables may have different interpolation order.
-<<input,`Inputs`>> and their <<derivative,`derivatives`>> are set with respect to the beginning of a communication time step.
 
 The input approximation polynomial on the interval latexmath:[[tc_i, tc_{i+1}]] is defined to be
 
 latexmath:[u(t)= \sum_{j=0}^{k} \frac{1}{j!} u_j (t-tc_i)^j]
 
-where k is the `MaxInputApproximationOrder`.
+where k is the `inputApproximationOrder`.
 
-It is up to the master to define the cofficients latexmath:[u_1] to latexmath:[u_k], while latexmath:[u_0=u_{tc_i}], which is set with the `fmi3SetReal64`.
+It is up to the master to calculate the cofficients latexmath:[u_0] to latexmath:[u_k]. latexmath:[u_1] to latexmath:[u_k] is set using <<fmi3SetInputApproximation>>, while latexmath:[u_0=u_{tc_i}] is set with <<fmi3SetReal64>>.
 
 _[One choice of the master could be to define them to reach a certain value for latexmath:[u_{tc_{i+1}}] with a linear interpolation._ +
 _Another choice of the master could be to use the output derivatives of an connected FMU at time latexmath:[tc_i]:_ +
-_Then the polynomial corresponds to a Taylor polynomial._ +
-_In order to get the output derivatives of an connected FMU, the master can invoke the following function]_
+_Then the polynomial corresponds to a Taylor approximation of the output of the connected FMU at time latexmath:[u_{tc_i}]._ +
+_In order to get the output derivatives of an connected FMU, the master can invoke the following function:]_
 
 [[fmi3GetOutputDerivatives,`fmi3GetOutputDerivatives`]]
 [source, C]

--- a/docs/4_2_basic_co-simulation_api.adoc
+++ b/docs/4_2_basic_co-simulation_api.adoc
@@ -6,14 +6,30 @@ This section contains the interface description to access the input/output data 
 
 <<input,`Input`>> and <<output>> variables and other variables are accessed via the `fmi3Get{VariableType}` and `fmi3Set{VariableType}` functions, defined in <<get-and-set-variable-values>>.
 
-In order to enable the slave to interpolate the <<continuous>> floating point <<input,`inputs`>> between communication steps, the <<derivative,`derivatives`>> of the <<input,`inputs`>> with respect to time can be provided.
-Also, higher <<derivative,`derivatives`>> can be set to allow higher order interpolation.
-Whether the slave is able to handle the <<derivative,`derivatives`>> of <<input,`inputs`>> is given by the unsigned integer capability flag `MaxInputDerivativeOrder`. It delivers the maximum order of the input <<derivative>>.
 
-[[fmi3SetInputDerivatives,`fmi3SetInputDerivatives`]]
+
+
+===== Input Approximation [[api-input-approximation]]
+
+In order to enable the slave to approximate the <<continuous>> floating point <<input,`inputs`>> between communication steps, the the coefficients of a polynomial can be provided.
+The order of this approximation is given by the unsigned integer capability flag `MaxInputApproximationOrder`.
+
+The input approximation polynomial on the interval latexmath:[[tc_i, tc_{i+1}]] is defined to be
+
+latexmath:[u(t)= \sum_{j=0}^{k} \frac{1}{j!} u_j (t-tc_i)^j]
+
+where k is the `MaxInputApproximationOrder`.
+
+It is up to the master to define the cofficients latexmath:[u_1] to latexmath:[u_k], while latexmath:[u_0=u_{tc_i}].
+
+_[One choice of the master could be to use the output derivatives of an connectd FMU at time latexmath:[tc_i]:_
+_Then the polynomial corresponds to a Taylor polynomial._+
+_Another choice would be to define them to reach a certain value for latexmath:[u_0=u_{tc_{i+1}}]  ]_
+
+[[fmi3SetInputApproximation,`fmi3SetInputApproximation`]]
 [source, C]
 ----
-include::../headers/fmi3FunctionTypes.h[tags=SetInputDerivatives]
+include::../headers/fmi3FunctionTypes.h[tags=SetInputApproximation]
 ----
 
 [[fmi3GetOutputDerivatives,`fmi3GetOutputDerivatives`]]
@@ -36,7 +52,7 @@ Both functions have the same arguments:
 * `nValues` is the size of the argument `values`.
 --
 
-<<fmi3SetInputDerivatives>>::
+<<fmi3SetInputApproximation>>::
 Sets the n-th time <<derivative>> of <<input>> variables.
 Restrictions on using the function are the same as for the `fmi3Set{VariableType}` function.
 Different input variables may have different interpolation order.
@@ -152,7 +168,7 @@ In this state the FMU can do one-time initializations and allocate memory.
 The FMU sets all variables to its <<start>> values.
 
 Allowed Function Calls::
-<<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3SetInputDerivatives>>, <<fmi3EnterConfigurationMode>>
+<<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3SetInputApproximation>>, <<fmi3EnterConfigurationMode>>
 
 `fmi3Set{VariableType}`::
 For variables with <<variability>> latexmath:[\neq] <<constant>> and for which <<initial>> = <<exact>> or <<approx>>.
@@ -168,7 +184,7 @@ In between the FMU must evaluate all relevant equations.
 In this way artificial or real algebraic loops over connected FMUs in *Initialization Mode* may be handled by using appropriate numerical algorithms.
 
 Allowed Function Calls::
-<<fmi3ExitInitializationMode>>, <<fmi3SetInputDerivatives>>, <<fmi3GetDirectionalDerivative>>
+<<fmi3ExitInitializationMode>>, <<fmi3SetInputApproximation>>, <<fmi3GetDirectionalDerivative>>
 
 `fmi3Set{VariableType}`::
 For variables with:
@@ -187,7 +203,7 @@ Forbidden Function Calls::
 This state is used by the master to progress simulation time.
 
 Allowed Function Calls::
-<<fmi3SetInputDerivatives>>, <<fmi3GetDirectionalDerivative>>, <<fmi3GetOutputDerivatives>>, `fmi3Get{VariableType}`, <<fmi3Terminate>>
+<<fmi3SetInputApproximation>>, <<fmi3GetDirectionalDerivative>>, <<fmi3GetOutputDerivatives>>, `fmi3Get{VariableType}`, <<fmi3Terminate>>
 
 <<fmi3EnterConfigurationMode>>::
 With this function call the *Reconfiguration Mode* is entered.
@@ -246,7 +262,7 @@ If the function returns `fmi3Fatal` the FMU enters the terminal state.
 Allowed Function Calls::
 <<fmi3DoEarlyReturn>>
 
-`fmi3Set{VariableType}`, <<fmi3SetInputDerivatives>>::
+`fmi3Set{VariableType}`, <<fmi3SetInputApproximation>>::
 If `intermediateVariableSetAllowed = fmi3True`, the value of intermediate variables can be set.
 Intermediate variables are variables that are marked with attribute <<intermediateAccess>> = `true` in the `modelDescription.xml`.
 
@@ -270,7 +286,7 @@ Allowed Function Calls::
 Only for variables with <<causality>> = <<structuralParameter>> and <<variability>> = <<tunable>>.
 
 Forbidden Function Calls::
-<<fmi3EnterConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3GetDoStepDiscardedStatus>>, <<fmi3DoStep>>, <<fmi3EnterStepMode>>, <<fmi3SetInputDerivatives>>, <<fmi3GetDirectionalDerivative>>, <<fmi3GetOutputDerivatives>>, `fmi3Get{VariableType}`
+<<fmi3EnterConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3GetDoStepDiscardedStatus>>, <<fmi3DoStep>>, <<fmi3EnterStepMode>>, <<fmi3SetInputApproximation>>, <<fmi3GetDirectionalDerivative>>, <<fmi3GetOutputDerivatives>>, `fmi3Get{VariableType}`
 
 ===== State: Step Discarded [[state-step-discarded-co-simulation]]
 
@@ -295,7 +311,7 @@ _[In *Step Mode*, the master may change again FMU <<input,`inputs`>> and <<param
 In this case, a new step may be started from `lastSuccessfulTime` which can be retrieved by the <<fmi3GetDoStepDiscardedStatus>> function in state *Step Discarded*.
 
 Forbidden Function Calls::
-<<fmi3EnterConfigurationMode>>, <<fmi3ExitConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3DoStep>>, `fmi3Set{VariableType}`, <<fmi3DoEarlyReturn>>, <<fmi3SetInputDerivatives>>
+<<fmi3EnterConfigurationMode>>, <<fmi3ExitConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3DoStep>>, `fmi3Set{VariableType}`, <<fmi3DoEarlyReturn>>, <<fmi3SetInputApproximation>>
 
 ===== State: Terminated [[state-terminated-co-simulation]]
 
@@ -305,7 +321,7 @@ Allowed Function Calls::
 `fmi3Get{VariableType}`, <<fmi3GetDirectionalDerivative>>, <<fmi3GetOutputDerivatives>>
 
 Forbidden Function Calls::
-<<fmi3EnterConfigurationMode>>, <<fmi3ExitConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3DoStep>>, `fmi3Set{VariableType}`, <<fmi3DoEarlyReturn>>, <<fmi3SetInputDerivatives>>
+<<fmi3EnterConfigurationMode>>, <<fmi3ExitConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3DoStep>>, `fmi3Set{VariableType}`, <<fmi3DoEarlyReturn>>, <<fmi3SetInputApproximation>>
 
 ===== State: Configuration Mode [[state-configuration-mode-co-simulation]]
 
@@ -320,7 +336,7 @@ Allowed Function Calls::
 Only for variables with <<causality>> = <<structuralParameter>> and <<variability>> = <<tunable>>.
 
 Forbidden Function Calls::
- <<fmi3EnterConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3GetDoStepDiscardedStatus>>, <<fmi3DoStep>>, <<fmi3EnterStepMode>>, <<fmi3SetInputDerivatives>>, <<fmi3GetDirectionalDerivative>>, <<fmi3GetOutputDerivatives>>, `fmi3Get{VariableType}`
+ <<fmi3EnterConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3GetDoStepDiscardedStatus>>, <<fmi3DoStep>>, <<fmi3EnterStepMode>>, <<fmi3SetInputApproximation>>, <<fmi3GetDirectionalDerivative>>, <<fmi3GetOutputDerivatives>>, `fmi3Get{VariableType}`
 
 _[The allowed function calls in the respective states are summarized in the following table (functions marked in [yellow-background]#"yellow"# are only available for Co-Simulation, the other functions are available both for Model Exchange and Co-Simulation):_
 
@@ -364,7 +380,7 @@ _[The allowed function calls in the respective states are summarized in the foll
 |<<fmi3SerializeFMUState>>        |  |x |x |x |  |x |x |x |x
 |<<fmi3DeSerializeFMUState>>      |  |x |x |x |  |x |x |x |x
 |<<fmi3GetDirectionalDerivative>> |  |  |x |x |  |8 |7 |x |7
-|<<fmi3SetInputDerivatives>>  {set:cellbgcolor:yellow}     |  {set:cellbgcolor!} |x |x |x |  |  |  |  |
+|<<fmi3SetInputApproximation>>  {set:cellbgcolor:yellow}     |  {set:cellbgcolor!} |x |x |x |  |  |  |  |
 |<<fmi3GetOutputDerivatives>> {set:cellbgcolor:yellow}     |  {set:cellbgcolor!} |  |  |x |  |8 |x |x |7
 |<<fmi3DoStep>>                   {set:cellbgcolor:yellow} |  {set:cellbgcolor!} |  |  |x |  |  |  |  |
 |<<fmi3DoEarlyReturn>>            {set:cellbgcolor:yellow} |  {set:cellbgcolor!} |  |  |  |x |  |  |  |

--- a/docs/4_2_basic_co-simulation_api.adoc
+++ b/docs/4_2_basic_co-simulation_api.adoc
@@ -45,9 +45,9 @@ where k is the `MaxInputApproximationOrder`.
 
 It is up to the master to define the cofficients latexmath:[u_1] to latexmath:[u_k], while latexmath:[u_0=u_{tc_i}].
 
-_[One choice of the master could be to define them to reach a certain value for latexmath:[u_0=u_{tc_{i+1}}]
-_Another choice of the master could be to use the output derivatives of an connected FMU at time latexmath:[tc_i]:_
-_Then the polynomial corresponds to a Taylor polynomial._
+_[One choice of the master could be to define them to reach a certain value for latexmath:[u_0=u_{tc_{i+1}}]_ +
+_Another choice of the master could be to use the output derivatives of an connected FMU at time latexmath:[tc_i]:_ +
+_Then the polynomial corresponds to a Taylor polynomial._ +
 _In order to get the output derivatives of an connected FMU, the master can invoke the following function]_
 
 [[fmi3GetOutputDerivatives,`fmi3GetOutputDerivatives`]]
@@ -62,7 +62,7 @@ include::../headers/fmi3FunctionTypes.h[tags=GetOutputDerivatives]
 
 * `nValueReferences` is the dimension of the arguments `valueReferences` and `orders`.
 
-* `orders` contains the orders of the respective <<derivative>> (`orders` must be larger than zero and smaller than `maxOutputDerivativesOrder`)..
+* `orders` contains the orders of the respective <<derivative>> (`orders` must be larger than zero and smaller than `maxOutputDerivativesOrder`).
 
 * `values` is a vector with the values of the <<derivative,`derivatives`>>.
 

--- a/docs/4_2_basic_co-simulation_api.adoc
+++ b/docs/4_2_basic_co-simulation_api.adoc
@@ -29,10 +29,10 @@ include::../headers/fmi3FunctionTypes.h[tags=SetInputApproximation]
 
 Example:
 
-u1[2*3] u2 u3[2]
-`inputApproximationOrder`=2
+Assuming we have inputs u1[2*3],  u2,  u3[2] and `inputApproximationOrder`=2.
 
-((array serialization of coefficient a_0 for u1), coefficient a_0 for  u2, (array serialization of coefficient a_0 for u3) , (array serialization of coefficient a_1 for u1), coefficient a_1 for  u2, (array serialization of coefficient a_1 for u3) )
+Then the `values` are serialized in the following way:
+((array serialization of coefficient latexmath:[a_1] for u1), coefficient latexmath:[a_1] for  u2, (array serialization of coefficient latexmath:[a_1] for u3) , (array serialization of coefficient latexmath:[a_2] for u1), coefficient latexmath:[a_2] for  u2, (array serialization of coefficient latexmath:[a_2] for u3) )
 
 * `nValues` is the size of the argument `values`. `nValues` only equals `inputApproximationOrder` * `nValueReferences` if all corresponding input variables are scalar variables.
 --

--- a/docs/4_2_basic_co-simulation_api.adoc
+++ b/docs/4_2_basic_co-simulation_api.adoc
@@ -14,6 +14,29 @@ This section contains the interface description to access the input/output data 
 In order to enable the slave to approximate the <<continuous>> floating point <<input,`inputs`>> between communication steps, the the coefficients of a polynomial can be provided.
 The order of this approximation is given by the unsigned integer capability flag `MaxInputApproximationOrder`.
 
+[[fmi3SetInputApproximation,`fmi3SetInputApproximation`]]
+[source, C]
+----
+include::../headers/fmi3FunctionTypes.h[tags=SetInputApproximation]
+----
+
+--
+* `valueReferences` is a vector of value references that define the variables whose input approximation coefficients shall be set.
+
+* `nValueReferences` is the dimension of the arguments `valueReferences` and `orders`.
+
+* `orders` contains the orders of the respective approximatioan (`orders` must be larger than zero and smaller than `maxInputApproxmationOrder`).
+
+* `values` is a vector with the values of the approximation coefficients
+
+* `nValues` is the size of the argument `values`.
+--
+
+<<fmi3SetInputApproximation>>::
+Restrictions on using the function are the same as for the `fmi3Set{VariableType}` function.
+Different input variables may have different interpolation order.
+<<input,`Inputs`>> and their <<derivative,`derivatives`>> are set with respect to the beginning of a communication time step.
+
 The input approximation polynomial on the interval latexmath:[[tc_i, tc_{i+1}]] is defined to be
 
 latexmath:[u(t)= \sum_{j=0}^{k} \frac{1}{j!} u_j (t-tc_i)^j]
@@ -22,15 +45,10 @@ where k is the `MaxInputApproximationOrder`.
 
 It is up to the master to define the cofficients latexmath:[u_1] to latexmath:[u_k], while latexmath:[u_0=u_{tc_i}].
 
-_[One choice of the master could be to use the output derivatives of an connectd FMU at time latexmath:[tc_i]:_
-_Then the polynomial corresponds to a Taylor polynomial._+
-_Another choice would be to define them to reach a certain value for latexmath:[u_0=u_{tc_{i+1}}]  ]_
-
-[[fmi3SetInputApproximation,`fmi3SetInputApproximation`]]
-[source, C]
-----
-include::../headers/fmi3FunctionTypes.h[tags=SetInputApproximation]
-----
+_[One choice of the master could be to define them to reach a certain value for latexmath:[u_0=u_{tc_{i+1}}]
+_Another choice of the master could be to use the output derivatives of an connected FMU at time latexmath:[tc_i]:_
+_Then the polynomial corresponds to a Taylor polynomial._
+_In order to get the output derivatives of an connected FMU, the master can invoke the following function]_
 
 [[fmi3GetOutputDerivatives,`fmi3GetOutputDerivatives`]]
 [source, C]
@@ -38,25 +56,18 @@ include::../headers/fmi3FunctionTypes.h[tags=SetInputApproximation]
 include::../headers/fmi3FunctionTypes.h[tags=GetOutputDerivatives]
 ----
 
-Both functions have the same arguments:
 
 --
-* `valueReferences` is a vector of value references that define the variables whose <<derivative,`derivatives`>> shall be set or get.
+* `valueReferences` is a vector of value references that define the variables whose <<derivative,`derivatives`>> shall be get.
 
 * `nValueReferences` is the dimension of the arguments `valueReferences` and `orders`.
 
-* `orders` contains the orders of the respective <<derivative>> (1 means the first <<derivative>>, 0 is not allowed).
+* `orders` contains the orders of the respective <<derivative>> (`orders` must be larger than zero and smaller than `maxOutputDerivativesOrder`)..
 
 * `values` is a vector with the values of the <<derivative,`derivatives`>>.
 
 * `nValues` is the size of the argument `values`.
 --
-
-<<fmi3SetInputApproximation>>::
-Sets the n-th time <<derivative>> of <<input>> variables.
-Restrictions on using the function are the same as for the `fmi3Set{VariableType}` function.
-Different input variables may have different interpolation order.
-<<input,`Inputs`>> and their <<derivative,`derivatives`>> are set with respect to the beginning of a communication time step.
 
 <<fmi3GetOutputDerivatives>>::
 Retrieves the n-th <<derivative>> of <<output>> values.
@@ -64,7 +75,6 @@ Restrictions on using the function are the same as for the `fmi3Get{VariableType
 The returned <<output,`outputs`>> correspond to the current slave time.
 E.g. after a successful call to <<fmi3DoStep>> the returned values are related to the end of the communication time step.
 
-To allow interpolation/approximation of the floating point output variables between communication steps (if they are used as inputs for other slaves), the <<derivative,`derivatives`>> of the <<output,`outputs`>> with respect to time can be read.
 Whether the slave is able to provide the <<derivative,`derivatives`>> of <<output,`output`>> is given by the unsigned integer capability flag `maxOutputDerivativeOrder`.
 It delivers the maximum order of the <<output>> <<derivative, `derivatives`>>.
 If the actual order is lower (because the order of integration algorithm is low), the retrieved value is 0.

--- a/docs/4_2_basic_co-simulation_api.adoc
+++ b/docs/4_2_basic_co-simulation_api.adoc
@@ -27,12 +27,10 @@ include::../headers/fmi3FunctionTypes.h[tags=SetInputApproximation]
 
 * `values` is a vector with the values of the approximation coefficients. The or of the `values` elements is derived from a threefold serialization: the outer level corresponds to the index of the coefficient, the middle level to the `valueReferences`, the inner level to the serialization of variables. The inner level does not exist for scalar variables.
 
-Example:
-
-Assuming we have inputs u1[2*3],  u2,  u3[2] and `inputApproximationOrder`=2.
-
-Then the `values` are serialized in the following way:
-((array serialization of coefficient latexmath:[a_1] for u1), coefficient latexmath:[a_1] for  u2, (array serialization of coefficient latexmath:[a_1] for u3) , (array serialization of coefficient latexmath:[a_2] for u1), coefficient latexmath:[a_2] for  u2, (array serialization of coefficient latexmath:[a_2] for u3) )
+_[ Example:_ +
+_Assuming we have inputs u1[2*3],  u2,  u3[2] and `inputApproximationOrder`=2._ +
+_Then the `values` are serialized in the following way:_
+_((array serialization of coefficient latexmath:[a_1] for u1), coefficient latexmath:[a_1] for  u2, (array serialization of coefficient latexmath:[a_1] for u3) , (array serialization of coefficient latexmath:[a_2] for u1), coefficient latexmath:[a_2] for  u2, (array serialization of coefficient latexmath:[a_2] for u3) ) ]_
 
 * `nValues` is the size of the argument `values`. `nValues` only equals `inputApproximationOrder` * `nValueReferences` if all corresponding input variables are scalar variables.
 --

--- a/docs/4_2_basic_co-simulation_api.adoc
+++ b/docs/4_2_basic_co-simulation_api.adoc
@@ -23,13 +23,18 @@ include::../headers/fmi3FunctionTypes.h[tags=SetInputApproximation]
 --
 * `valueReferences` is a vector of value references that define the variables whose input approximation coefficients shall be set.
 
-* `nValueReferences` is the dimension of the arguments `valueReferences` and `orders`.
+* `nValueReferences` is the dimension of the argument `valueReferences`
 
-* `orders` contains the orders of the respective approximatioan (`orders` must be larger than zero and smaller than `maxInputApproxmationOrder`).
+* `values` is a vector with the values of the approximation coefficients. The or of the `values` elements is derived from a threefold serialization: the outer level corresponds to the index of the coefficient, the middle level to the `valueReferences`, the inner level to the serialization of variables. The inner level does not exist for scalar variables.
 
-* `values` is a vector with the values of the approximation coefficients
+Example:
 
-* `nValues` is the size of the argument `values`.
+u1[2*3] u2 u3[2]
+`inputApproximationOrder`=2
+
+((array serialization of coefficient a_0 for u1), coefficient a_0 for  u2, (array serialization of coefficient a_0 for u3) , (array serialization of coefficient a_1 for u1), coefficient a_1 for  u2, (array serialization of coefficient a_1 for u3) )
+
+* `nValues` is the size of the argument `values`. `nValues` only equals `inputApproximationOrder` * `nValueReferences` if all corresponding input variables are scalar variables.
 --
 
 <<fmi3SetInputApproximation>>::
@@ -37,11 +42,11 @@ Restrictions on using the function are the same as for the `fmi3Set{VariableType
 
 The input approximation polynomial on the interval latexmath:[[tc_i, tc_{i+1}]] is defined to be
 
-latexmath:[u(t)= \sum_{j=0}^{k} \frac{1}{j!} u_j (t-tc_i)^j]
+latexmath:[u(t)= \sum_{j=0}^{k} \frac{1}{j!} a_j (t-tc_i)^j]
 
 where k is the `inputApproximationOrder`.
 
-It is up to the master to calculate the cofficients latexmath:[u_0] to latexmath:[u_k]. latexmath:[u_1] to latexmath:[u_k] is set using <<fmi3SetInputApproximation>>, while latexmath:[u_0=u_{tc_i}] is set with <<fmi3SetReal64>>.
+It is up to the master to calculate the cofficients latexmath:[a_0] to latexmath:a_k]. latexmath:[a_1] to latexmath:[a_k] is set using <<fmi3SetInputApproximation>>, while latexmath:[a_0=u_{tc_i}] is set with <<fmi3SetReal64>>.
 
 _[One choice of the master could be to define them to reach a certain value for latexmath:[u_{tc_{i+1}}] with a linear interpolation._ +
 _Another choice of the master could be to use the output derivatives of an connected FMU at time latexmath:[tc_i]:_ +
@@ -58,13 +63,14 @@ include::../headers/fmi3FunctionTypes.h[tags=GetOutputDerivatives]
 --
 * `valueReferences` is a vector of value references that define the variables whose <<derivative,`derivatives`>> shall be get.
 
-* `nValueReferences` is the dimension of the arguments `valueReferences` and `orders`.
+* `nValueReferences` is the dimension of the argument `valueReferences`.
 
-* `orders` contains the orders of the respective <<derivative>> (`orders` must be larger than zero and smaller than `maxOutputDerivativesOrder`).
+* `order` defines up which order the respective <<derivative>> are provided (`order` must be larger than zero and must not exceed `maxOutputDerivativesOrder`). +
+_[ This is realized differently than for <<fmi3SetInputApproximation>> because it is expensive to calculate higher orders of derivatives if they are not needed. ]_
 
-* `values` is a vector with the values of the <<derivative,`derivatives`>>.
+* `values` is a vector with the values of the <<derivative,`derivatives`>>. The serialization is analogous as for the `values` in <<fmi3SetInputApproximation>>.
 
-* `nValues` is the size of the argument `values`.
+* `nValues` is the size of the argument `values`. `nValues` only equals `order` * `nValueReferences` if all corresponding input variables are scalar variables.
 --
 
 <<fmi3GetOutputDerivatives>>::

--- a/docs/4_2_basic_co-simulation_api.adoc
+++ b/docs/4_2_basic_co-simulation_api.adoc
@@ -46,7 +46,7 @@ latexmath:[u(t)= \sum_{j=0}^{k} \frac{1}{j!} a_j (t-tc_i)^j]
 
 where k is the `inputApproximationOrder`.
 
-It is up to the master to calculate the cofficients latexmath:[a_0] to latexmath:a_k]. latexmath:[a_1] to latexmath:[a_k] is set using <<fmi3SetInputApproximation>>, while latexmath:[a_0=u_{tc_i}] is set with <<fmi3SetReal64>>.
+It is up to the master to calculate the cofficients latexmath:[a_0] to latexmath:a_k]. latexmath:[a_1] to latexmath:[a_k] is set using <<fmi3SetInputApproximation>>, while latexmath:[a_0=u_{tc_i}] is set with <<fmi3SetFloat64>>.
 
 _[One choice of the master could be to define them to reach a certain value for latexmath:[u_{tc_{i+1}}] with a linear interpolation._ +
 _Another choice of the master could be to use the output derivatives of an connected FMU at time latexmath:[tc_i]:_ +

--- a/docs/4_2_basic_co-simulation_api.adoc
+++ b/docs/4_2_basic_co-simulation_api.adoc
@@ -43,9 +43,9 @@ latexmath:[u(t)= \sum_{j=0}^{k} \frac{1}{j!} u_j (t-tc_i)^j]
 
 where k is the `MaxInputApproximationOrder`.
 
-It is up to the master to define the cofficients latexmath:[u_1] to latexmath:[u_k], while latexmath:[u_0=u_{tc_i}].
+It is up to the master to define the cofficients latexmath:[u_1] to latexmath:[u_k], while latexmath:[u_0=u_{tc_i}], which is set with the `fmi3SetReal64`.
 
-_[One choice of the master could be to define them to reach a certain value for latexmath:[u_0=u_{tc_{i+1}}]_ +
+_[One choice of the master could be to define them to reach a certain value for latexmath:[u_{tc_{i+1}}] with a linear interpolation._ +
 _Another choice of the master could be to use the output derivatives of an connected FMU at time latexmath:[tc_i]:_ +
 _Then the polynomial corresponds to a Taylor polynomial._ +
 _In order to get the output derivatives of an connected FMU, the master can invoke the following function]_

--- a/docs/4_3_basic_co-simulation_schema.adoc
+++ b/docs/4_3_basic_co-simulation_schema.adoc
@@ -50,8 +50,8 @@ If this is the case, then flag `canGetAndSetFMUState` must be `true` as well.
 |`providesDirectionalDerivative`
 |If `true`, the directional derivative of the equations at communication points can be computed with `fmi3GetDirectionalDerivative`.
 
-|`canInterpolateInputs`
-|The slave is able to interpolate <<continuous>> <<input,`inputs`>>.
+|`maxInputInterpolationOrder`
+|The slave is able to approximate <<continuous>> <<input,`inputs`>> with maximum order.
 Calling of `fmi3SetInputDerivatives` has an effect for the slave.
 
 |`maxOutputDerivativeOrder`

--- a/docs/4_3_basic_co-simulation_schema.adoc
+++ b/docs/4_3_basic_co-simulation_schema.adoc
@@ -52,11 +52,11 @@ If this is the case, then flag `canGetAndSetFMUState` must be `true` as well.
 
 |`maxInputInterpolationOrder`
 |The slave is able to approximate <<continuous>> <<input,`inputs`>> with maximum order.
-Calling of `fmi3SetInputApproximation` has an effect for the slave.
+Calling of <<fmi3SetInputApproximation>> has an effect for the slave.
 
 |`maxOutputDerivativeOrder`
 |The slave is able to provide <<derivative,`derivatives`>> of <<output,`outputs`>> with maximum order.
-Calling of `fmi3GetOutputDerivatives` is allowed up to the order defined by `maxOutputDerivativeOrder`.
+Calling of <<fmi3GetOutputDerivatives>> is allowed up to the order defined by `maxOutputDerivativeOrder`.
 
 |`canHandleVariableCommunicationStepSize`
 |The slave can handle variable communication step size.

--- a/docs/4_3_basic_co-simulation_schema.adoc
+++ b/docs/4_3_basic_co-simulation_schema.adoc
@@ -52,7 +52,7 @@ If this is the case, then flag `canGetAndSetFMUState` must be `true` as well.
 
 |`maxInputInterpolationOrder`
 |The slave is able to approximate <<continuous>> <<input,`inputs`>> with maximum order.
-Calling of `fmi3SetInputDerivatives` has an effect for the slave.
+Calling of `fmi3SetInputApproximation` has an effect for the slave.
 
 |`maxOutputDerivativeOrder`
 |The slave is able to provide <<derivative,`derivatives`>> of <<output,`outputs`>> with maximum order.

--- a/docs/5_2_hybrid_co-simulation_api.adoc
+++ b/docs/5_2_hybrid_co-simulation_api.adoc
@@ -289,7 +289,7 @@ _[The allowed function calls in the respective states are summarized in the foll
 |<<fmi3DeSerializeFMUState>>      |  |x |  |x |  |  |  |x |  |  |x |x |x |x
 |<<fmi3GetDirectionalDerivative>> |  |  |  |x |  |  |  |x |  |  |8 |7 |x |7
 |<<fmi3EnterStepMode>>            {set:cellbgcolor:yellow} |  {set:cellbgcolor!} |  |  |  |  |  |  |  |  |  |  |  |  |
-|<<fmi3SetInputDerivatives>>      {set:cellbgcolor:yellow} |  {set:cellbgcolor!} |x |  |x |  |  |  |  |x |  |  |  |  |
+|<<fmi3SetInputApproximation>>      {set:cellbgcolor:yellow} |  {set:cellbgcolor!} |x |  |x |  |  |  |  |x |  |  |  |  |
 |<<fmi3GetOutputDerivatives>>     {set:cellbgcolor:yellow} |  {set:cellbgcolor!} |  |  |  |  |  |  |  |x |  |8 |x |x |7
 |<<fmi3DoStep>>                   {set:cellbgcolor:yellow} |  {set:cellbgcolor!} |  |  |  |  |  |  |  |x |  |  |  |  |
 |<<fmi3ActivateModelPartition>>   {set:cellbgcolor:yellow} |  {set:cellbgcolor!} |  |  |  |  |  |  |  |  |  |  |  |  |

--- a/docs/6_2_scheduled_co-simulation_api.adoc
+++ b/docs/6_2_scheduled_co-simulation_api.adoc
@@ -112,7 +112,7 @@ In case of `fmi3Discard` or `fmi3Error` the master must wait until all other tas
 +
 It is recommended to call `fmi3Set{VariableType}` and `fmi3Get{VariableType}` in the same task as <<fmi3ActivateModelPartition>> for setting and retrieving variable values associated to a <<clock>> activation.
 
-<<get-and-set-variable-values,fmi3Set{VariableType}>>, `fmi3SetInputDerivatives`::
+<<get-and-set-variable-values,fmi3Set{VariableType}>>, `fmi3SetInputApproximation`::
 Is called before the start of the computation of a model partition (i.e. before call of <<fmi3ActivateModelPartition>>) and only for global variables and variables associated to the <<inputClock>> assigned to the model partition.
 +
 The restrictions related to variable <<causality>> and <<variability>> defined for *Step Mode* in Basic Co-Simulation apply.
@@ -214,7 +214,7 @@ Allowed Function Calls::
 - `fmi3Set{VariableType}`: Only for variables with <<causality>> = <<structuralParameter>> and <<variability>> = <<tunable>>.
 
 Forbidden Function Calls::
-Additionally to the generally forbidden functions in Scheduled Co-Simulation listed above the following functions must not be called in this state: <<fmi3EnterConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3GetDoStepDiscardedStatus>>, <<fmi3ActivateModelPartition>>,`fmi3SetInputDerivatives`, <<fmi3GetDirectionalDerivative>>, `fmi3GetOutputDerivatives`, `fmi3Get{VariableType}`, <<fmi3DoEarlyReturn>>
+Additionally to the generally forbidden functions in Scheduled Co-Simulation listed above the following functions must not be called in this state: <<fmi3EnterConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3GetDoStepDiscardedStatus>>, <<fmi3ActivateModelPartition>>,`fmi3SetInputApproximation`, <<fmi3GetDirectionalDerivative>>, `fmi3GetOutputDerivatives`, `fmi3Get{VariableType}`, <<fmi3DoEarlyReturn>>
 
 // TODO: update table
 
@@ -257,7 +257,7 @@ Additionally to the generally forbidden functions in Scheduled Co-Simulation lis
 |<<fmi3SerializeFMUState>>        |  |  |  |  |  |  |  |  |  |
 |<<fmi3DeSerializeFMUState>>      |  |  |  |  |  |  |  |  |  |
 |<<fmi3GetDirectionalDerivative>> |  |  |  |  |  |  |  |  |  |
-|<<fmi3SetInputDerivatives>>      {set:cellbgcolor:yellow}     |  {set:cellbgcolor!} |  |  |  |  |  |  |  |  |
+|<<fmi3SetInputApproximation>>      {set:cellbgcolor:yellow}     |  {set:cellbgcolor!} |  |  |  |  |  |  |  |  |
 |<<fmi3GetOutputDerivatives>>     {set:cellbgcolor:yellow}     |  {set:cellbgcolor!} |  |  |  |  |  |  |  |  |
 |<<fmi3GetDoStepDiscardedStatus>> {set:cellbgcolor:yellow}     |  {set:cellbgcolor!} |  |  |  |  |  |  |  |  |
 |====

--- a/docs/6_2_scheduled_co-simulation_api.adoc
+++ b/docs/6_2_scheduled_co-simulation_api.adoc
@@ -112,7 +112,7 @@ In case of `fmi3Discard` or `fmi3Error` the master must wait until all other tas
 +
 It is recommended to call `fmi3Set{VariableType}` and `fmi3Get{VariableType}` in the same task as <<fmi3ActivateModelPartition>> for setting and retrieving variable values associated to a <<clock>> activation.
 
-<<get-and-set-variable-values,fmi3Set{VariableType}>>, `fmi3SetInputApproximation`::
+<<get-and-set-variable-values,fmi3Set{VariableType}>>, <<fmi3SetInputApproximation>>::
 Is called before the start of the computation of a model partition (i.e. before call of <<fmi3ActivateModelPartition>>) and only for global variables and variables associated to the <<inputClock>> assigned to the model partition.
 +
 The restrictions related to variable <<causality>> and <<variability>> defined for *Step Mode* in Basic Co-Simulation apply.
@@ -121,7 +121,7 @@ If the function returns with `fmi3OK` or `fmi3Warning` the FMU stays in this sta
 In case the function returns `fmi3Fatal` the master can prematurely end all tasks related to the computation of model partitions of this FMU.
 In case the function returns `fmi3Discard` or `fmi3Error` the master must wait until all other tasks related to the computation of the model partitions of this FMU have ended, but new tasks must not be started (e.g. related to <<outputClock>> ticks) and all other function calls for this FMU must also return `fmi3Discard` or `fmi3Error` until the state *Terminated* is reached.
 
-<<get-and-set-variable-values,fmi3Get{VariableType}>>, `fmi3GetOutputDerivatives`, <<fmi3GetDirectionalDerivative>>`::
+<<get-and-set-variable-values,fmi3Get{VariableType}>>, <<fmi3GetOutputDerivatives>>, <<fmi3GetDirectionalDerivative>>`::
 Is called after the end of the computation of a model partition (i.e. after return of <<fmi3ActivateModelPartition>>) and only for global variables and variables associated to the <<inputClock>> assigned to the model partition.
 +
 The restrictions related to variable <<causality>> and <<variability>> defined for *Step Mode* in Basic Co-Simulation apply.
@@ -214,7 +214,7 @@ Allowed Function Calls::
 - `fmi3Set{VariableType}`: Only for variables with <<causality>> = <<structuralParameter>> and <<variability>> = <<tunable>>.
 
 Forbidden Function Calls::
-Additionally to the generally forbidden functions in Scheduled Co-Simulation listed above the following functions must not be called in this state: <<fmi3EnterConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3GetDoStepDiscardedStatus>>, <<fmi3ActivateModelPartition>>,`fmi3SetInputApproximation`, <<fmi3GetDirectionalDerivative>>, `fmi3GetOutputDerivatives`, `fmi3Get{VariableType}`, <<fmi3DoEarlyReturn>>
+Additionally to the generally forbidden functions in Scheduled Co-Simulation listed above the following functions must not be called in this state: <<fmi3EnterConfigurationMode>>, <<fmi3Instantiate>>, <<fmi3SetupExperiment>>, <<fmi3EnterInitializationMode>>, <<fmi3ExitInitializationMode>>, <<fmi3GetDoStepDiscardedStatus>>, <<fmi3ActivateModelPartition>>,<<fmi3SetInputApproximation>>, <<fmi3GetDirectionalDerivative>>, <<fmi3GetOutputDerivatives>>, `fmi3Get{VariableType}`, <<fmi3DoEarlyReturn>>
 
 // TODO: update table
 

--- a/docs/examples/co_simulation.xml
+++ b/docs/examples/co_simulation.xml
@@ -10,7 +10,7 @@
   <BasicCoSimulation
     modelIdentifier="MyLibrary_SpringMassDamper"
     canHandleVariableCommunicationStepSize="true"
-    maxInputApproximationOrder="2"/>
+    InputApproximationOrder="2"/>
   <UnitDefinitions>
     <Unit name="rad">
       <BaseUnit rad="1"/>

--- a/docs/examples/co_simulation.xml
+++ b/docs/examples/co_simulation.xml
@@ -10,7 +10,7 @@
   <BasicCoSimulation
     modelIdentifier="MyLibrary_SpringMassDamper"
     canHandleVariableCommunicationStepSize="true"
-    canInterpolateInputs="true"/>
+    maxInputApproximationOrder="2"/>
   <UnitDefinitions>
     <Unit name="rad">
       <BaseUnit rad="1"/>

--- a/docs/examples/co_simulation.xml
+++ b/docs/examples/co_simulation.xml
@@ -10,7 +10,7 @@
   <BasicCoSimulation
     modelIdentifier="MyLibrary_SpringMassDamper"
     canHandleVariableCommunicationStepSize="true"
-    InputApproximationOrder="2"/>
+    inputApproximationOrder="2"/>
   <UnitDefinitions>
     <Unit name="rad">
       <BaseUnit rad="1"/>

--- a/headers/fmi3FunctionTypes.h
+++ b/headers/fmi3FunctionTypes.h
@@ -596,7 +596,6 @@ typedef fmi3Status fmi3EnterStepModeTYPE(fmi3Instance instance);
 typedef fmi3Status fmi3SetInputApproximationTYPE(fmi3Instance instance,
                                                const fmi3ValueReference valueReferences[],
                                                size_t nValueReferences,
-                                               const fmi3Int32 orders[],
                                                const fmi3Float64 values[],
                                                size_t nValues);
 /* end::SetInputApproximation[] */
@@ -605,7 +604,6 @@ typedef fmi3Status fmi3SetInputApproximationTYPE(fmi3Instance instance,
 typedef fmi3Status fmi3GetOutputDerivativesTYPE(fmi3Instance instance,
                                                 const fmi3ValueReference valueReferences[],
                                                 size_t nValueReferences,
-                                                const fmi3Int32 orders[],
                                                 fmi3Float64 values[],
                                                 size_t nValues);
 /* end::GetOutputDerivatives[] */

--- a/headers/fmi3FunctionTypes.h
+++ b/headers/fmi3FunctionTypes.h
@@ -592,14 +592,14 @@ Types for Functions for Co-Simulation
 typedef fmi3Status fmi3EnterStepModeTYPE(fmi3Instance instance);
 /* end::EnterStepMode[] */
 
-/* tag::SetInputDerivatives[] */
-typedef fmi3Status fmi3SetInputDerivativesTYPE(fmi3Instance instance,
+/* tag::SetInputApproximation[] */
+typedef fmi3Status fmi3SetInputApproximationTYPE(fmi3Instance instance,
                                                const fmi3ValueReference valueReferences[],
                                                size_t nValueReferences,
                                                const fmi3Int32 orders[],
                                                const fmi3Float64 values[],
                                                size_t nValues);
-/* end::SetInputDerivatives[] */
+/* end::SetInputApproximation[] */
 
 /* tag::GetOutputDerivatives[] */
 typedef fmi3Status fmi3GetOutputDerivativesTYPE(fmi3Instance instance,

--- a/headers/fmi3FunctionTypes.h
+++ b/headers/fmi3FunctionTypes.h
@@ -604,6 +604,7 @@ typedef fmi3Status fmi3SetInputApproximationTYPE(fmi3Instance instance,
 typedef fmi3Status fmi3GetOutputDerivativesTYPE(fmi3Instance instance,
                                                 const fmi3ValueReference valueReferences[],
                                                 size_t nValueReferences,
+                                                const fmi3Int32 order,
                                                 fmi3Float64 values[],
                                                 size_t nValues);
 /* end::GetOutputDerivatives[] */

--- a/headers/fmi3Functions.h
+++ b/headers/fmi3Functions.h
@@ -201,7 +201,7 @@ Functions for Co-Simulation
 
 /* Simulating the slave */
 #define fmi3EnterStepMode            fmi3FullName(fmi3EnterStepMode)
-#define fmi3SetInputDerivatives      fmi3FullName(fmi3SetInputDerivatives)
+#define fmi3SetInputApproximation    fmi3FullName(fmi3SetInputApproximation)
 #define fmi3GetOutputDerivatives     fmi3FullName(fmi3GetOutputDerivatives)
 #define fmi3DoStep                   fmi3FullName(fmi3DoStep)
 #define fmi3ActivateModelPartition   fmi3FullName(fmi3ActivateModelPartition)
@@ -313,7 +313,7 @@ Functions for Co-Simulation
 
 /* Simulating the slave */
 FMI3_Export fmi3EnterStepModeTYPE          fmi3EnterStepMode;
-FMI3_Export fmi3SetInputDerivativesTYPE    fmi3SetInputDerivatives;
+FMI3_Export fmi3SetInputApproximationTYPE  fmi3SetInputApproximation;
 FMI3_Export fmi3GetOutputDerivativesTYPE   fmi3GetOutputDerivatives;
 FMI3_Export fmi3ActivateModelPartitionTYPE fmi3ActivateModelPartition;
 FMI3_Export fmi3DoStepTYPE                 fmi3DoStep;

--- a/schema/fmi3InterfaceType.xsd
+++ b/schema/fmi3InterfaceType.xsd
@@ -60,7 +60,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		<xs:complexContent>
 			<xs:extension base="fmi3InterfaceType">
 				<xs:attribute name="canHandleVariableCommunicationStepSize" type="xs:boolean" default="false"/>
-				<xs:attribute name="maxInputApproximationOrder" type="xs:unsignedInt" default="0"/>
+				<xs:attribute name="inputApproximationOrder" type="xs:unsignedInt" default="0"/>
 				<xs:attribute name="maxOutputDerivativeOrder" type="xs:unsignedInt" default="0"/>
 				<xs:attribute name="providesIntermediateVariableAccess" type="xs:boolean" default="false"/>
 				<xs:attribute name="canReturnEarlyAfterIntermediateUpdate" type="xs:boolean" default="false"/>

--- a/schema/fmi3InterfaceType.xsd
+++ b/schema/fmi3InterfaceType.xsd
@@ -60,7 +60,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		<xs:complexContent>
 			<xs:extension base="fmi3InterfaceType">
 				<xs:attribute name="canHandleVariableCommunicationStepSize" type="xs:boolean" default="false"/>
-				<xs:attribute name="canInterpolateInputs" type="xs:boolean" default="false"/>
+				<xs:attribute name="maxInputApproximationOrder" type="xs:unsignedInt" default="0"/>
 				<xs:attribute name="maxOutputDerivativeOrder" type="xs:unsignedInt" default="0"/>
 				<xs:attribute name="providesIntermediateVariableAccess" type="xs:boolean" default="false"/>
 				<xs:attribute name="canReturnEarlyAfterIntermediateUpdate" type="xs:boolean" default="false"/>


### PR DESCRIPTION
addressing #921

-  Input derivatives are coefficients of a specified polynomial that the FMU has to use on the current communication interval. We use the taylor polynomial similar to FMI 1.0 appendix D.
-  Additionally the FMU has an attribute on the maximum order of input deriviatives, replacing the attribute can interpolate inputs.
-  The maximum order of input approximation shall be defined per FMU (and not per input and not generally in the standard.
-  the capability flag CanInterpolateInputs shall be replaced by something like InputApproximationOrder
