### PR TITLE
Remove XSD attributes with default values

### DIFF
--- a/schema/fmi3BuildDescription.xsd
+++ b/schema/fmi3BuildDescription.xsd
@@ -38,7 +38,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	<xs:element name="fmiBuildDescription">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="BuildConfiguration" minOccurs="1" maxOccurs="unbounded">
+				<xs:element name="BuildConfiguration" maxOccurs="unbounded">
 					<xs:complexType>
 						<xs:sequence>
 							<xs:element name="SourceFileSet" minOccurs="0" maxOccurs="unbounded">

--- a/schema/fmi3ModelDescription.xsd
+++ b/schema/fmi3ModelDescription.xsd
@@ -43,10 +43,10 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	<xs:element name="fmiModelDescription">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="ModelExchange" type="fmi3ModelExchange" minOccurs="0" maxOccurs="1" />
-				<xs:element name="BasicCoSimulation" type="fmi3CoSimulation" minOccurs="0" maxOccurs="1" />
-				<xs:element name="HybridCoSimulation" type="fmi3CoSimulation" minOccurs="0" maxOccurs="1" />
-				<xs:element name="ScheduledCoSimulation" type="fmi3CoSimulation" minOccurs="0" maxOccurs="1" />
+				<xs:element name="ModelExchange" type="fmi3ModelExchange" minOccurs="0"/>
+				<xs:element name="BasicCoSimulation" type="fmi3CoSimulation" minOccurs="0"/>
+				<xs:element name="HybridCoSimulation" type="fmi3CoSimulation" minOccurs="0"/>
+				<xs:element name="ScheduledCoSimulation" type="fmi3CoSimulation" minOccurs="0"/>
 				<xs:element name="UnitDefinitions" minOccurs="0">
 					<xs:complexType>
 						<xs:sequence maxOccurs="unbounded">
@@ -116,7 +116,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<xs:attribute name="license" type="xs:string"/>
 			<xs:attribute name="generationTool" type="xs:normalizedString"/>
 			<xs:attribute name="generationDateAndTime" type="xs:dateTime"/>
-			<xs:attribute name="variableNamingConvention" use="optional" default="flat">
+			<xs:attribute name="variableNamingConvention" default="flat">
 				<xs:simpleType>
 					<xs:restriction base="xs:normalizedString">
 						<xs:enumeration value="flat"/>

--- a/schema/fmi3Terminal.xsd
+++ b/schema/fmi3Terminal.xsd
@@ -40,7 +40,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<xs:element name="TerminalMemberVariable" minOccurs="0" maxOccurs="unbounded">
 				<xs:complexType>
 					<xs:attribute name="variableKind" type="xs:normalizedString" use="required"/>
-					<xs:attribute name="memberName" type="xs:normalizedString" use="optional"/>
+					<xs:attribute name="memberName" type="xs:normalizedString"/>
 					<xs:attribute name="variableName" type="xs:normalizedString" use="required"/>
 				</xs:complexType>
 			</xs:element>
@@ -58,12 +58,12 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 					<xs:sequence>
 						<xs:element ref="VendorAnnotations" minOccurs="0"/>
 					</xs:sequence>
-					<xs:attribute name="defaultConnectionColor" use="optional">
+					<xs:attribute name="defaultConnectionColor">
 						<xs:simpleType>
 							<xs:list itemType="xs:unsignedByte"/>
 						</xs:simpleType>
 					</xs:attribute>
-					<xs:attribute name="defaultConnectionStrokeSize" type="xs:double" use="optional"/>
+					<xs:attribute name="defaultConnectionStrokeSize" type="xs:double"/>
 					<xs:attribute name="x1" type="xs:double" use="required"/>
 					<xs:attribute name="y1" type="xs:double" use="required"/>
 					<xs:attribute name="x2" type="xs:double" use="required"/>
@@ -75,7 +75,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		</xs:sequence>
 		<xs:attribute name="name" type="xs:normalizedString" use="required"/>
 		<xs:attribute name="matchingRule" type="xs:normalizedString" use="required"/>
-		<xs:attribute name="terminalKind" type="xs:normalizedString" use="optional"/>
-		<xs:attribute name="description" type="xs:string" use="optional"/>
+		<xs:attribute name="terminalKind" type="xs:normalizedString"/>
+		<xs:attribute name="description" type="xs:string"/>
 	</xs:complexType>
 </xs:schema>

--- a/schema/fmi3Type.xsd
+++ b/schema/fmi3Type.xsd
@@ -151,8 +151,8 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:complexType>
 					<xs:complexContent>
 						<xs:extension base="fmi3TypeDefinitionBase">
-							<xs:attribute name="mimeType" type="xs:normalizedString" use="optional" default="application/octet-stream"/>
-							<xs:attribute name="maxSize" type="xs:nonNegativeInteger" use="optional"/>
+							<xs:attribute name="mimeType" type="xs:normalizedString" default="application/octet-stream"/>
+							<xs:attribute name="maxSize" type="xs:nonNegativeInteger"/>
 						</xs:extension>
 					</xs:complexContent>
 				</xs:complexType>

--- a/schema/fmi3Variable.xsd
+++ b/schema/fmi3Variable.xsd
@@ -267,9 +267,9 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:sequence>
 					<xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
 				</xs:sequence>
-				<xs:attribute name="mimeType" type="xs:normalizedString" use="optional" default="application/octet-stream">
+				<xs:attribute name="mimeType" type="xs:normalizedString" default="application/octet-stream">
 				</xs:attribute>
-				<xs:attribute name="maxSize" type="xs:nonNegativeInteger" use="optional">
+				<xs:attribute name="maxSize" type="xs:nonNegativeInteger">
 				</xs:attribute>
 				<xs:attribute name="start">
 					<xs:simpleType>
@@ -388,9 +388,9 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		</xs:attribute>
 		<xs:attribute name="canHandleMultipleSetPerTimeInstant" type="xs:boolean"/>
 		<xs:attribute name="declaredType" type="xs:normalizedString"/>
-		<xs:attribute name="clockReference" type="xs:unsignedInt" use="optional"/>
-		<xs:attribute name="clockElementIndex" type="xs:unsignedLong" use="optional"/>
-		<xs:attribute name="intermediateAccess" type="xs:boolean" use="optional"/>
+		<xs:attribute name="clockReference" type="xs:unsignedInt"/>
+		<xs:attribute name="clockElementIndex" type="xs:unsignedLong"/>
+		<xs:attribute name="intermediateAccess" type="xs:boolean"/>
 	</xs:complexType>
 
 	<xs:group name="fmi3Variable">


### PR DESCRIPTION
If we want all attributes to be there, even with default values, we should be consistent and always have them everywhere. I think removing default settings is cleaner.