### PR TITLE
Fix C-style == and != signs

### DIFF
--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -163,7 +163,7 @@ An `fmi3ValueReference` references one such value (scalar or array).
 The coding of `fmi3ValueReference` is a "secret" of the environment that generated the FMU.
 The interface to the equations only provides access to variables via this handle.
 Extracting concrete information about a variable can be done by reading the `modelDescription.xml` in which the value handles are defined.
-If a function in the following sections is called with a wrong `fmi3ValueReference` value _[for example, setting a constant with a call to `fmi3SetFloat64`]_, then the function must return with an error ( `fmi3Status = fmi3Error`, see <<status-returned-by-functions>>).
+If a function in the following sections is called with a wrong `fmi3ValueReference` value _[for example, setting a constant with a call to `fmi3SetFloat64`]_, then the function must return with an error ( `fmi3Status == fmi3Error`, see <<status-returned-by-functions>>).
 
 The following data types are the base types used in the interfaces of the C functions.
 
@@ -222,7 +222,7 @@ _The actual calculation is performed by `fmi3Get{VariableType}` functions._
 _Still, `fmi3Set{VariableType}` functions could check whether the input arguments are in their validity range._
 _If not, these functions could return with `fmi3Discard`.]_
 +
-In both model exchange and co-simulation interfaces, function <<logMessage>> was called in the FMU, and it is expected that this function has shown the prepared information message to the user if the FMU was called in debug mode (`loggingOn = fmi3True`). If the FMU was not called in debug mode, <<logMessage>> should not show a message.
+In both model exchange and co-simulation interfaces, function <<logMessage>> was called in the FMU, and it is expected that this function has shown the prepared information message to the user if the FMU was called in debug mode (`loggingOn == fmi3True`). If the FMU was not called in debug mode, <<logMessage>> should not show a message.
 
 `fmi3Error`::
 the FMU encountered an error.
@@ -313,12 +313,12 @@ The following schemes must be understood by the FMU:
 _[Example: An FMU is unzipped in directory `C:\temp\MyFMU`, then `resourceLocation` = `file:///C:/temp/MyFMU/resources` or `file:/C:/temp/MyFMU/resources`._
 _The <<fmi3Instantiate>> functions are then able to read all needed resources from this directory, for example maps or tables used by the FMU.]_
 
-* `visible = fmi3False` defines that the interaction with the user should be reduced to a minimum (no application window, no plotting, no animation, etc.).
+* `visible == fmi3False` defines that the interaction with the user should be reduced to a minimum (no application window, no plotting, no animation, etc.).
 In other words, the FMU is executed in batch mode.
-If `visible = fmi3True`, the FMU is executed in interactive mode, and the FMU might require to explicitly acknowledge start of simulation / instantiation / initialization (acknowledgment is non-blocking).
+If `visible == fmi3True`, the FMU is executed in interactive mode, and the FMU might require to explicitly acknowledge start of simulation / instantiation / initialization (acknowledgment is non-blocking).
 
-* If `loggingOn = fmi3False`, then any logging is disabled and the logger function is not called by the FMU.
-If `loggingOn = fmi3True`, the FMU enables a vendor defined set of `<LogCategories>`.
+* If `loggingOn == fmi3False`, then any logging is disabled and the logger function is not called by the FMU.
+If `loggingOn == fmi3True`, the FMU enables a vendor defined set of `<LogCategories>`.
 This set should typically contain categories for messages that explain execution errors, like `fmi3Discard`, `fmi3Error` and `fmi3Fatal`.
 The function <<fmi3SetDebugLogging>> gives more detailed control about required `<LogCategories>` (see <<definition-of-log-categories>>).
 
@@ -352,7 +352,7 @@ Pointer to a function that is called in the FMU _[usually if an `fmi3XXX` functi
 * `instanceName` is the instance name of the model that calls this function.
 // TODO fix following sentence
 * `status` contains the severity of the message.
-If <<logMessage>> is called with `status = fmi3OK`, then the message is a pure information message.
+If <<logMessage>> is called with `status == fmi3OK`, then the message is a pure information message.
 
 * `category` is the category of the message.
 The meaning of `category` is defined by the modeling environment that generated the FMU.
@@ -388,22 +388,22 @@ In other cases, a null pointer can be assigned to the <<intermediateUpdate>> cal
 * <<intermediateUpdateTime>> indicates the internal time of the FMU at the time of calling the callback function.
 
 [[eventOccurred,`eventOccurred`]]
-* <<eventOccurred,`eventOccurred = fmi3True`>> means that an internal event has occurred.
+* <<eventOccurred,`eventOccurred == fmi3True`>> means that an internal event has occurred.
 
 [[clocksTicked,`clocksTicked`]]
-* <<clocksTicked,`clocksTicked = fmi3True`>> means that an FMU clock has ticked.
+* <<clocksTicked,`clocksTicked == fmi3True`>> means that an FMU clock has ticked.
 
 [[intermediateVariableSetAllowed,`intermediateVariableSetAllowed`]]
-* <<intermediateVariableSetAllowed,`intermediateVariableSetAllowed = fmi3True`>> means the master algorithm is allowed to set FMU variables using `fmi3Set{VariableType}`.
+* <<intermediateVariableSetAllowed,`intermediateVariableSetAllowed == fmi3True`>> means the master algorithm is allowed to set FMU variables using `fmi3Set{VariableType}`.
 
 [[intermediateVariableGetAllowed,`intermediateVariableGetAllowed`]]
-* <<intermediateVariableGetAllowed,`intermediateVariableGetAllowed = fmi3True`>> means the master algorithm is allowed to get FMU variables using `fmi3Get{VariableType}`.
+* <<intermediateVariableGetAllowed,`intermediateVariableGetAllowed == fmi3True`>> means the master algorithm is allowed to get FMU variables using `fmi3Get{VariableType}`.
 
 [[intermediateStepFinished,`intermediateStepFinished`]]
-* <<intermediateStepFinished, `intermediateStepFinished = fmi3True`>> means that an internal step was finished.
+* <<intermediateStepFinished, `intermediateStepFinished == fmi3True`>> means that an internal step was finished.
 
 [[canReturnEarly,`canReturnEarly`]]
-* <<canReturnEarly,`canReturnEarly = fmi3True`>> means the master is allowed to ask the FMU to return early from a <<fmi3DoStep>>.
+* <<canReturnEarly,`canReturnEarly == fmi3True`>> means the master is allowed to ask the FMU to return early from a <<fmi3DoStep>>.
 
 The various combinations of flags allow a Co-Simulation master algorithm to react appropriately to the needs and capabilities of the FMU.
 
@@ -435,11 +435,11 @@ include::../headers/fmi3FunctionTypes.h[tags=SetDebugLogging]
 ----
 The function controls debug logging that is output via the logger function callback.
 
-* If `loggingOn = fmi3True`, debug logging is enabled, otherwise it is switched off.
+* If `loggingOn == fmi3True`, debug logging is enabled, otherwise it is switched off.
 
 * `nCategories` defines the length of the next argument `categories`
-If `loggingOn = fmi3True` and `nCategories = 0`, then all debug messages shall be output.
-If `loggingOn = fmi3True` and `nCategories > 0`, then only debug messages according to the `categories` argument shall be printed via the <<logMessage>> function.
+If `loggingOn == fmi3True` and `nCategories == 0`, then all debug messages shall be output.
+If `loggingOn == fmi3True` and `nCategories > 0`, then only debug messages according to the `categories` argument shall be printed via the <<logMessage>> function.
 
 * `categories` is a vector with `nCategories` elements.
 The allowed values of `categories` are defined by the modeling environment that generated the FMU.
@@ -478,11 +478,11 @@ Setting other variables is not allowed.
 * `toleranceDefined` and `tolerance` depend on the interface type:
 
 Model Exchange::
-If `toleranceDefined = fmi3True`, then the model is called with a numerical integration scheme where the step size is controlled by using `tolerance` for error estimation (usually as relative tolerance).
+If `toleranceDefined == fmi3True`, then the model is called with a numerical integration scheme where the step size is controlled by using `tolerance` for error estimation (usually as relative tolerance).
 In such a case all numerical algorithms used inside the model (for example, to solve non-linear algebraic equations) should also operate with an error estimation of an appropriate smaller relative tolerance.
 
 Co-Simulation::
-If `toleranceDefined = fmi3True`, then the communication step size of the FMU is controlled by error estimation.
+If `toleranceDefined == fmi3True`, then the communication step size of the FMU is controlled by error estimation.
 In case the FMU utilizes a numerical integrator with variable step size and error estimation, it is suggested to use `tolerance` for the error estimation of the integrator (usually as relative tolerance). +
 An FMU for Co-Simulation might ignore this argument.
 
@@ -492,9 +492,9 @@ An FMU for Co-Simulation might ignore this argument.
 _[It is defined with <<causality>> = <<independent>> in the `modelDescription.xml`._
 _If the <<independent>> variable is `time`, `startTime` is the starting time of initialization.]_
 
-* If `stopTimeDefined = fmi3True`, then `stopTime` is the final value of the <<independent>> variable.
-If the environment tries to compute past `stopTime`, the FMU has to return `fmi3Status = fmi3Error`.
-If `stopTimeDefined = fmi3False`, then no final value of the <<independent>> variable is defined and argument `stopTime` is meaningless.
+* If `stopTimeDefined == fmi3True`, then `stopTime` is the final value of the <<independent>> variable.
+If the environment tries to compute past `stopTime`, the FMU has to return `fmi3Status == fmi3Error`.
+If `stopTimeDefined == fmi3False`, then no final value of the <<independent>> variable is defined and argument `stopTime` is meaningless.
 +
 _[If the <<independent>> variable is `time`, `stopTime` is the stop time of the simulation.]_
 
@@ -581,7 +581,7 @@ Furthermore, the actual value of every variable defined in the `modelDescription
 
 The strings returned by `fmi3GetString`, as well as the binary values returned by `fmi3GetBinary`, must be copied in the target environment because the allocated memory for these strings might be deallocated or overwritten by the next call to any of the FMI functions.
 
-For Model Exchange: `fmi3Status = fmi3Discard` is possible for `fmi3GetFloat32` and `fmi3GetFloat64` only, but not for `fmi3Get*Int*`, `fmi3GetBoolean`, `fmi3GetString`, `fmi3GetBinary`, because these are discrete-time variables and their values can only change at an event instant where `fmi3Discard` does not make sense.
+For Model Exchange: `fmi3Status == fmi3Discard` is possible for `fmi3GetFloat32` and `fmi3GetFloat64` only, but not for `fmi3Get*Int*`, `fmi3GetBoolean`, `fmi3GetString`, `fmi3GetBinary`, because these are discrete-time variables and their values can only change at an event instant where `fmi3Discard` does not make sense.
 
 It is also possible to set the values of certain variables at particular instants in time using the following functions:
 
@@ -602,7 +602,7 @@ Set <<parameter,`parameters`>>, <<input,`inputs`>>, and <<start>> values, and re
 
 All strings passed as arguments to `fmi3SetString`, as well as all binary values passed as arguments to `fmi3SetBinary`, must be copied inside these functions, because there is no guarantee of the lifetime of strings or binary values, when these functions return.
 
-Note, `fmi3Status = fmi3Discard` is possible for the `fmi3Set{VariableType}` functions.
+Note, `fmi3Status == fmi3Discard` is possible for the `fmi3Set{VariableType}` functions.
 
 For Co-Simulation FMUs, additional functions are defined in <<transfer-of-input-output-and-parameters>> to set and inquire <<derivative,`derivatives`>> of variables with respect to time in order to allow interpolation.
 
@@ -846,7 +846,7 @@ Inquires whether a set of <<clock,`clocks`>> is active by providing the value re
 * `valueReferences` is a vector of `nValueReferences` value handles that define the clock variables that shall be inquired.
 
 * `values` will return the activation status at the current time instant of the <<clock,`clocks`>> referenced by `valueReferences[]`.
-If `values[i] = fmi3ClockActive` the <<clock>> is currently active, otherwise the <<clock>> is not active.
+If `values[i] == fmi3ClockActive` the <<clock>> is currently active, otherwise the <<clock>> is not active.
 
 * `nValues` provides the number of values in the `values` vector, which is only equal to `nValueReferences` if all <<valueReference>>pass:[s] point to scalar clock variables.
 

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -544,8 +544,8 @@ _If the FMU is generated so that min/max shall be checked whenever meaningful (f
 
 _If `fmi3Set{VariableType}` is called violating the min/max attribute settings of the corresponding variable, the following actions are performed:_
 
-- _On a <<fixed>> or <<tunable>> <<parameter>> `fmi3Status = fmi3Discard` is returned._
-- _On an <<input>>, the FMU decides what to return (If no computation is possible, it could return `fmi3Status = fmi3Discard`, in other situations it may return `fmi3Warning` or `fmi3Error`, or `fmi3OK`, if it is uncritical)._
+- _On a <<fixed>> or <<tunable>> <<parameter>> `fmi3Status == fmi3Discard` is returned._
+- _On an <<input>>, the FMU decides what to return (If no computation is possible, it could return `fmi3Status == fmi3Discard`, in other situations it may return `fmi3Warning` or `fmi3Error`, or `fmi3OK`, if it is uncritical)._
 
 _If an FMU defines min/max values for integer types and `<Enumeration>` variables (<<local>> and <<output>> variables), then the expected behavior of the FMU is that `fmi3Get{VariableType}` functions return values in the defined range._
 
@@ -1199,7 +1199,7 @@ Co-Simulation: By convention, the variable is from a real sampled data system an
 // TODO how does this work with IVA?
 
 [[continuous,`continuous`]]
-- `continuous`: Only a variable of `type = fmi3GetFloat32` or `type = fmi3GetFloat64` can be <<continuous>>. +
+- `continuous`: Only a variable of `type == fmi3GetFloat32` or `type == fmi3GetFloat64` can be <<continuous>>. +
 Model Exchange: No restrictions on value changes. +
 Co-Simulation: By convention, the variable is part of a differential equation.
 
@@ -1288,7 +1288,7 @@ For scalar clock variables this attribute must not be specified or must be speci
 |
 [[intermediateAccess,`intermediateAccess`]]
 If this boolean attribute is `true`, the variable can be accessed during a communication step.
-Variables with <<causality>> <<parameter>> must not be marked with <<intermediateAccess,`intermediateAccess = fmi3True`>>.
+Variables with <<causality>> <<parameter>> must not be marked with <<intermediateAccess,`intermediateAccess == fmi3True`>>.
 // TODO: link to see math-intermediate-variable-access)
 This attribute is only used for Basic Co-Simulation and Hybrid Co-Simulation. The default value of this attribute is `false`.
 // TODO: default false is not defined in the xsd (yet?)

--- a/docs/2_4_common_co-simulation.adoc
+++ b/docs/2_4_common_co-simulation.adoc
@@ -50,7 +50,7 @@ Typical examples are:
 
 FMI for Co-Simulation is restricted to slaves with the following properties:
 
-. All calculated values are time-dependent functions within an a priori defined time interval latexmath:[t_{start} \leq t \leq t_{stop}] (provided `stopTimeDefined = fmi3True` when calling <<fmi3EnterInitializationMode>>).
+. All calculated values are time-dependent functions within an a priori defined time interval latexmath:[t_{start} \leq t \leq t_{stop}] (provided `stopTimeDefined == fmi3True` when calling <<fmi3EnterInitializationMode>>).
 
 . All simulations are carried out with increasing time in general.
 The current time latexmath:[t] is running step by step from latexmath:[t_{start}] to latexmath:[t_{stop}].
@@ -215,7 +215,7 @@ In this way multiple event types and also <<outputClock>> ticks or interrupts ca
 
 ===== Intermediate Variable Access [[api-intermediate-variable-access]]
 
-If the Co-Simulation master signals the support for intermediate variable access and an FMU has at least one variable with <<intermediateAccess,`intermediateAccess = fmi3True`>>, the FMU can use the callback function <<fmi3CallbackIntermediateUpdate>> to communicate information back to the Co-Simulation master.
+If the Co-Simulation master signals the support for intermediate variable access and an FMU has at least one variable with <<intermediateAccess,`intermediateAccess == fmi3True`>>, the FMU can use the callback function <<fmi3CallbackIntermediateUpdate>> to communicate information back to the Co-Simulation master.
 
 [source, C]
 ----
@@ -226,15 +226,15 @@ The following output arguments in <<fmi3CallbackIntermediateUpdate>> are used fo
 
 * <<intermediateUpdateTime>> is the simulation time at which the <<fmi3CallbackIntermediateUpdate>> callback function is called by the FMU.
 
-* If <<intermediateVariableSetAllowed,`intermediateVariableSetAllowed = fmi3True`>>, the Co-Simulation master may provide intermediate <<input>> variables by calling `fmi3Set{VariableType}` for variables with <<intermediateAccess,`intermediateAccess = fmi3True`>>.
+* If <<intermediateVariableSetAllowed,`intermediateVariableSetAllowed == fmi3True`>>, the Co-Simulation master may provide intermediate <<input>> variables by calling `fmi3Set{VariableType}` for variables with <<intermediateAccess,`intermediateAccess == fmi3True`>>.
 
-* If <<intermediateVariableGetAllowed,`intermediateVariableGetAllowed = fmi3True`>>, the Co-Simulation master may collect intermediate output variables by calling `fmi3Get{VariableType}` for variables with <<intermediateAccess,`intermediateAccess = fmi3True`>>.
+* If <<intermediateVariableGetAllowed,`intermediateVariableGetAllowed == fmi3True`>>, the Co-Simulation master may collect intermediate output variables by calling `fmi3Get{VariableType}` for variables with <<intermediateAccess,`intermediateAccess == fmi3True`>>.
 
-* If <<intermediateStepFinished, `intermediateStepFinished = fmi3False`>>, the Co-Simulation master shall only use intermediate output variables to compute intermediate <<input>> variables at the current state.
+* If <<intermediateStepFinished, `intermediateStepFinished == fmi3False`>>, the Co-Simulation master shall only use intermediate output variables to compute intermediate <<input>> variables at the current state.
 
 Hence, it is important to distinguish intermediate output from successful internal integration steps from intermediate outputs valid only for temporary solver states.
 <<figure-intermediate-variable-access>> shows an overview of the solver states and the intended use of intermediate variable access.
-It is not allowed to call <<intermediateUpdate>> for a simulation time point prior to a previous call with <<intermediateStepFinished,`intermediateStepFinished = fmi3True`>>.
+It is not allowed to call <<intermediateUpdate>> for a simulation time point prior to a previous call with <<intermediateStepFinished,`intermediateStepFinished == fmi3True`>>.
 
 .Overview of solver states and intermediate variable access during a communication step
 [#figure-intermediate-variable-access]

--- a/docs/3_1_model_exchange_math.adoc
+++ b/docs/3_1_model_exchange_math.adoc
@@ -119,7 +119,7 @@ image::images/Event.svg[width=60%, align="center"]
 
 [start=4]
 . At every completed step of an integrator, <<fmi3CompletedIntegratorStep>> must be called (provided the capability flag `completedIntegratorStepNotNeeded` of `<ModelDescription>` is `false`).
-An event occurs at this time instant, if indicated by the return argument `enterEventMode = fmi3True`.
+An event occurs at this time instant, if indicated by the return argument `enterEventMode == fmi3True`.
 Such an event is called step event.
 _[Step events are, for example, used to dynamically change the (continuous) <<state,`states`>> of a model internally in the FMU, because the previous states are no longer suited numerically.]_
 
@@ -406,7 +406,7 @@ _Examples:_
 
 Synchronous systems::
 _A synchronous system, such as Lucid Synchrone <<PZ06>> or Modelica 3.3 <<MLS12>>, is called periodically, and at every sample instant the discrete-time equations are evaluated exactly once._
-_An FMU of this type can be implemented by activating the model equations only at the first event iteration and returning always `newDiscreteStatesNeeded = fmi3False` from <<fmi3NewDiscreteStates>>._
+_An FMU of this type can be implemented by activating the model equations only at the first event iteration and returning always `newDiscreteStatesNeeded == fmi3False` from <<fmi3NewDiscreteStates>>._
 _Furthermore, the discrete-time <<state,`states`>> are not updated by <<fmi3NewDiscreteStates>>, but as first action before the discrete-time equations are evaluated, in order that_ latexmath:[^{\bullet}\mathbf{x}_d] _(= value at the previous <<clock>> tick) and_ latexmath:[\mathbf{x}_d] _(value at the latest <<clock>> tick) have reasonable values between <<clock>> ticks._
 
 State machines with one memory location for a state::

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -74,7 +74,7 @@ _[These arguments are not mutually exclusive and may all be `fmi3False` if the c
 
 * `stepEvent` signals with `fmi3True` that a step event occurred.
 
-* `rootsFound` is an array of length `nEventIndicators`. For `i = 1, ..., nEventIndicators, rootsFound[i-1]` latexmath:[\neq] `0` if the event indicator latexmath:[z_i] has a root, and `rootsFound[i-1] == 0` if not.
+* `rootsFound` is an array of length `nEventIndicators`. For `i = 1, ..., nEventIndicators, rootsFound[i-1] != 0` if the event indicator latexmath:[z_i] has a root, and `rootsFound[i-1] == 0` if not.
 For the components latexmath:[z_i] for which a root was found, the sign of `rootsFound[i-1]` indicates the direction of the zero-crossing.
 A value of `+1` indicates that latexmath:[z_i] is increasing, while a value of `-1` indicates a decreasing latexmath:[z_i].
 If `nEventIndicators == 0` the value of `rootsFound` is not defined.

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -39,7 +39,7 @@ Set a new (continuous) state vector and re-initialize caching of variables that 
 
 and is provided for checking purposes (variables that depend solely on<<constant,`constants`>>, <<parameter,`parameters`>>, time, and <<input,`inputs`>> do not need to be newly computed in the sequel, but the previously computed values can be reused).
 Note that the continuous <<state,`states`>> might also be changed in *Event Mode*.
-Note that `fmi3Status = fmi3Discard` is possible.
+Note that `fmi3Status == fmi3Discard` is possible.
 
 [source, C]
 ----
@@ -92,25 +92,25 @@ include::../headers/fmi3FunctionTypes.h[tags=NewDiscreteStates]
 The FMU is in *Event Mode* and the super-dense time is incremented by this call. +
 If the super-dense time before a call to <<fmi3NewDiscreteStates>> was latexmath:[(t_R,t_I)], then the time instant after the call is latexmath:[(t_R,t_I)]. +
 
-* If output argument `newDiscreteStatesNeeded = fmi3True`, the FMU should stay in *Event Mode*, and the FMU requires to set new inputs to the FMU (`fmi3Set{VariableType}` on <<input,`inputs`>>) to compute and get the <<output,`outputs`>> (`fmi3Get{VariableType}` on <<output,`outputs`>>) and to call <<fmi3NewDiscreteStates>> again.
+* If output argument `newDiscreteStatesNeeded == fmi3True`, the FMU should stay in *Event Mode*, and the FMU requires to set new inputs to the FMU (`fmi3Set{VariableType}` on <<input,`inputs`>>) to compute and get the <<output,`outputs`>> (`fmi3Get{VariableType}` on <<output,`outputs`>>) and to call <<fmi3NewDiscreteStates>> again.
 Depending on the connection with other FMUs, the environment shall
-** call <<fmi3Terminate>>, if `terminateSimulation = fmi3True` is returned by at least one FMU,
-** call <<fmi3EnterContinuousTimeMode>> if all FMUs return `newDiscreteStatesNeeded = fmi3False`, and
+** call <<fmi3Terminate>>, if `terminateSimulation == fmi3True` is returned by at least one FMU,
+** call <<fmi3EnterContinuousTimeMode>> if all FMUs return `newDiscreteStatesNeeded == fmi3False`, and
 ** stay in *Event Mode* otherwise.
 When the FMU is terminated, it is assumed that an appropriate message is printed by the logMessage function (see <<creation-destruction-and-logging>>) to explain the reason for the termination.
 
-* If output argument `terminateSimulation = fmi3True`, the FMU can signal it needs to terminate the simulation by calling <<fmi3Terminate>>.
+* If output argument `terminateSimulation == fmi3True`, the FMU can signal it needs to terminate the simulation by calling <<fmi3Terminate>>.
 
-* If argument `nominalsOfContinuousStatesChanged = fmi3True`, then the nominal values of the <<state,`states`>> have changed due to the function call and can be inquired with <<fmi3GetNominalsOfContinuousStates>>.
+* If argument `nominalsOfContinuousStatesChanged == fmi3True`, then the nominal values of the <<state,`states`>> have changed due to the function call and can be inquired with <<fmi3GetNominalsOfContinuousStates>>.
 
-* If argument `valuesOfContinuousStatesChanged = fmi3True`, then at least one element of the continuous state vector has changed its value due to the function call.
+* If argument `valuesOfContinuousStatesChanged == fmi3True`, then at least one element of the continuous state vector has changed its value due to the function call.
 
 [[state,`state`]]
 The new values of the <<state,`states`>> can be inquired with <<fmi3GetContinuousStates>> or individually for each state for which `reinit = true` by calling `fmi3GetFloat*`.
 If no element of the continuous state vector has changed its value, `valuesOfContinuousStatesChanged` must return `fmi3False`.
 _[If `fmi3True` would be returned in this case, an infinite event loop may occur.]_
 
-* If argument `nextEventTimeDefined = fmi3True`, then the simulation shall integrate at most until `time` reaches value of
+* If argument `nextEventTimeDefined == fmi3True`, then the simulation shall integrate at most until `time` reaches value of
 
 * argument `nextEventTime`, and shall call <<fmi3EnterEventMode>> at this time instant.
 If integration is stopped before `nextEventTime`, for example, due to a state event, the definition of `nextEventTime` becomes obsolete.
@@ -137,9 +137,9 @@ include::../headers/fmi3FunctionTypes.h[tags=CompletedIntegratorStep]
 ----
 
 This function must be called by the environment after every completed step of the integrator provided the capability flag `completedIntegratorStepNotNeeded = false`.
-Argument `noSetFMUStatePriorToCurrentPoint = fmi3True` if `fmi3SetFMUState` will no longer be called for time instants prior to current time in this simulation run [the FMU can use this flag to flush a result buffer]. +
+Argument `noSetFMUStatePriorToCurrentPoint == fmi3True` if `fmi3SetFMUState` will no longer be called for time instants prior to current time in this simulation run [the FMU can use this flag to flush a result buffer]. +
 The function returns `enterEventMode` to signal to the environment if the FMU shall call <<fmi3EnterEventMode>>, and it returns `terminateSimulation` to signal if the simulation shall be terminated.
-If `enterEventMode = fmi3False` and `terminateSimulation = fmi3False` the FMU stays in *Continuous-Time Mode* without calling <<fmi3EnterContinuousTimeMode>> again.
+If `enterEventMode == fmi3False` and `terminateSimulation == fmi3False` the FMU stays in *Continuous-Time Mode* without calling <<fmi3EnterContinuousTimeMode>> again.
 When the integrator step is completed and the <<state,`states`>> are modified by the integrator afterwards (for example, correction by a BDF method),
 then <<fmi3SetContinuousStates>> has to be called with the updated states before <<fmi3CompletedIntegratorStep>> is called. +
 When the integrator step is completed and one or more event indicators change sign (with respect to the previously completed integrator step), then the integrator or the environment has to determine the time instant of the sign change that is closest to the previous completed step up to a certain precision (usually a small multiple of the machine epsilon).
@@ -152,11 +152,11 @@ However, it is not allowed to go back in time over the previous <<fmi3CompletedI
 _[This function might be used, for example, for the following purposes:_
 
 _Delays:_ +
-_All variables that are used in a "delay(..)" operator are stored in an appropriate buffer and the function returns with `enterEventMode = fmi3False`, and `terminateSimulation = fmi3False`._
+_All variables that are used in a "delay(..)" operator are stored in an appropriate buffer and the function returns with `enterEventMode == fmi3False`, and `terminateSimulation == fmi3False`._
 
 . _Dynamic state selection:_ +
 _It is checked whether the dynamically selected states are still numerically appropriate._
-_If yes, the function returns with `enterEventMode = fmi3False`  otherwise with `enterEventMode = fmi3True`._
+_If yes, the function returns with `enterEventMode == fmi3False`  otherwise with `enterEventMode == fmi3True`._
 _In the latter case, <<fmi3EnterEventMode>> has to be called and the states are dynamically changed by a subsequent <<fmi3NewDiscreteStates>>._
 
 _Note that this function is not used to detect time or state events, for example, by comparing event indicators of the previous with the current call of <<fmi3CompletedIntegratorStep>>._
@@ -175,7 +175,7 @@ include::../headers/fmi3FunctionTypes.h[tags=GetEventIndicators]
 ----
 
 Compute state derivatives and event indicators at the current time instant and for the current <<state,`states`>>.
-Note that `fmi3Status = fmi3Discard` is possible for both functions.
+Note that `fmi3Status == fmi3Discard` is possible for both functions.
 
 The <<derivative,`derivatives`>> are returned as a vector with `nx` elements.
 The ordering of the elements of the `derivatives` vector is identical to the ordering of the state vector (for example, `derivatives[2]` is the <<derivative>> of `x[2]`).
@@ -204,8 +204,8 @@ include::../headers/fmi3FunctionTypes.h[tags=GetNominalsOfContinuousStates]
 ----
 
 Return the nominal values of the continuous <<state,`states`>>.
-This function should always be called after calling function <<fmi3NewDiscreteStates>>, if `nominalsOfContinuousStatesChanged = fmi3True`, since then the nominal values of the continuous <<state,`states`>> have changed _[for example, because the association of the continuous <<state,`states`>> to variables has changed due to internal dynamic state selection]_.
-If the FMU does not have information about the nominal value of a continuous <<state>> i, a nominal value `x_nominal[i] = 1.0` should be returned.
+This function should always be called after calling function <<fmi3NewDiscreteStates>>, if `nominalsOfContinuousStatesChanged == fmi3True`, since then the nominal values of the continuous <<state,`states`>> have changed _[for example, because the association of the continuous <<state,`states`>> to variables has changed due to internal dynamic state selection]_.
+If the FMU does not have information about the nominal value of a continuous <<state>> i, a nominal value `x_nominal[i] == 1.0` should be returned.
 Note that it is required that `x_nominal[i] > 0.0`.
 _[Typically, the nominal values of the continuous <<state,`states`>> are used to compute the absolute tolerance required by the integrator._
 _Example:_ +

--- a/docs/4_2_basic_co-simulation_api.adoc
+++ b/docs/4_2_basic_co-simulation_api.adoc
@@ -71,9 +71,9 @@ The computation of a time step is started.
 
 * `communicationStepSize` is the communication step size (latexmath:[hc_i]). `comunicationStepSize` must be latexmath:[> 0.0].
 
-* `noSetFMUStatePriorToCurrentPoint = fmi3True` if `fmi3SetFMUState` will no longer be called for time instants prior to `currentCommunicationPoint` in this simulation run. _[The slave can use this flag to flush a result buffer]_
+* `noSetFMUStatePriorToCurrentPoint == fmi3True` if `fmi3SetFMUState` will no longer be called for time instants prior to `currentCommunicationPoint` in this simulation run. _[The slave can use this flag to flush a result buffer]_
 
-* `earlyReturn` signals to the Co-Simulation master if the FMU returns early from the `doStep` call (`earlyReturn = fmi3True`) or if the `doStep` was completed successfully (`earlyReturn = fmi3False`).
+* `earlyReturn` signals to the Co-Simulation master if the FMU returns early from the `doStep` call (`earlyReturn == fmi3True`) or if the `doStep` was completed successfully (`earlyReturn == fmi3False`).
 
 The slave must integrate until time instant latexmath:[tc_{i+1} = tc_i + hc_i].
 
@@ -116,7 +116,7 @@ Status information is retrieved from the slave by the following function:
 include::../headers/fmi3FunctionTypes.h[tags=GetDoStepDiscardedStatus]
 ----
 
-* If argument `terminate = true`, the slave wants to terminate the simulation.
+* If argument `terminate == fmi3True`, the slave wants to terminate the simulation.
 
 [[lastSuccessfulTime,`lastSuccessfulTime`]]
 * <<lastSuccessfulTime>> is the time instant at which the slave stopped the <<fmi3DoStep>> call.
@@ -175,7 +175,7 @@ Allowed Function Calls::
 For variables with:
 * <<variability>> latexmath:[\neq] <<constant>> that have <<initial>> = <<exact>>, or
 * <<causality>> = <<input>>, or
-* <<causality>> = to <<parameter>> and <<variability>> = to <<tunable>>.
+* <<causality>> = <<parameter>> and <<variability>> = <<tunable>>.
 
 `fmi3Get{VariableType}`::
 For variables with <<causality>> = <<output>> or continuous-time <<state,`states`>> or state derivatives.
@@ -248,12 +248,12 @@ Allowed Function Calls::
 <<fmi3DoEarlyReturn>>
 
 `fmi3Set{VariableType}`, <<fmi3SetInputDerivatives>>::
-If <<intermediateVariableSetAllowed,`intermediateVariableSetAllowed = fmi3True`>>, the value of intermediate variables can be set.
-Intermediate variables are variables that are marked with attribute <<intermediateAccess,`intermediateAccess = fmi3True`>> in the `modelDescription.xml`.
+If <<intermediateVariableSetAllowed,`intermediateVariableSetAllowed == fmi3True`>>, the value of intermediate variables can be set.
+Intermediate variables are variables that are marked with attribute <<intermediateAccess,`intermediateAccess == fmi3True`>> in the `modelDescription.xml`.
 
 `fmi3Get{VariableType}`, <<fmi3GetOutputDerivatives>>::
-If <<intermediateVariableGetAllowed,`intermediateVariableGetAllowed = fmi3True`>>, the value of intermediate variables can be retrieved.
-Intermediate variables are variables that are marked with attribute <<intermediateAccess,`intermediateAccess = fmi3True`>> in the `modelDescription.xml`.
+If <<intermediateVariableGetAllowed,`intermediateVariableGetAllowed == fmi3True`>>, the value of intermediate variables can be retrieved.
+Intermediate variables are variables that are marked with attribute <<intermediateAccess,`intermediateAccess == fmi3True`>> in the `modelDescription.xml`.
 
 Forbidden Function Calls::
 The same functions which are not allowed to be called in *Step Mode* must not be called in this state.
@@ -412,7 +412,7 @@ include::Reference-FMUs/examples/co_simulation.c[tags=CoSimulation]
 [[canReturnEarlyAfterIntermediateUpdate,`canReturnEarlyAfterIntermediateUpdate`]]
 The Boolean capability flag <<canReturnEarlyAfterIntermediateUpdate>> in the modelDescription XML file indicates whether the FMU supports the early-return feature.
 The default value of this capability flag is `false`.
-Each time an internal discontinuity or an event happens inside an FMU with capability flag <<canReturnEarlyAfterIntermediateUpdate,`canReturnEarlyAfterIntermediateUpdate = fmi3True`>>, the callback function <<fmi3CallbackIntermediateUpdate>> is invoked by the FMU.
+Each time an internal discontinuity or an event happens inside an FMU with capability flag <<canReturnEarlyAfterIntermediateUpdate,`canReturnEarlyAfterIntermediateUpdate == fmi3True`>>, the callback function <<fmi3CallbackIntermediateUpdate>> is invoked by the FMU.
 The master can only use this early return functionality if it provides the <<fmi3CallbackIntermediateUpdate>> callback function pointer in the instantiate function.
 
 [[fmi3CallbackIntermediateUpdate,`fmi3CallbackIntermediateUpdate`]]
@@ -422,7 +422,7 @@ include::../headers/fmi3FunctionTypes.h[tag=CallbackIntermediateUpdate]
 ----
 
 The Co-Simulation master can request the FMU to end the <<fmi3DoStep>> at a Newtonian time instant and to do an early return by calling the <<fmi3DoEarlyReturn>> function inside the callback function <<fmi3CallbackIntermediateUpdate>>.
-The Co-Simulation master is only allowed to call this function, if <<canReturnEarly,`canReturnEarly = fmi3True`>>.
+The Co-Simulation master is only allowed to call this function, if <<canReturnEarly,`canReturnEarly == fmi3True`>>.
 If the master does not call <<fmi3DoEarlyReturn>> the FMU continues the <<fmi3DoStep>> computation until the next predefined communication instant (i.e., `currentCommunicationPoint + communicationStepSize`) or until the next call of <<fmi3CallbackIntermediateUpdate>>.
 
 [[fmi3DoEarlyReturn,`fmi3DoEarlyReturn`]]

--- a/docs/4_3_basic_co-simulation_schema.adoc
+++ b/docs/4_3_basic_co-simulation_schema.adoc
@@ -60,10 +60,10 @@ The communication step size (argument communicationStepSize of <<fmi3DoStep>>) h
 
 |`providesIntermediateVariableAccess`
 |The slave is able to provide access to selected variables during callback function call <<intermediateUpdate>>.
-The accessible variables are marked with attribute <<intermediateAccess,`intermediateAccess = fmi3True`>>.
+The accessible variables are marked with attribute <<intermediateAccess,`intermediateAccess == fmi3True`>>.
 
 |<<canReturnEarlyAfterIntermediateUpdate>>
-|If `true`, the slave is able to return early from <<fmi3DoStep>> if the master calls <<fmi3DoEarlyReturn>> in callback <<intermediateUpdate>> and <<canReturnEarly,`canReturnEarly = fmi3True`>>.
+|If `true`, the slave is able to return early from <<fmi3DoStep>> if the master calls <<fmi3DoEarlyReturn>> in callback <<intermediateUpdate>> and <<canReturnEarly,`canReturnEarly == fmi3True`>>.
 _[If set to `true`, a Co-Simulation FMU supports ending <<fmi3DoStep>> before the planned next communication point._
 _This can be used by the simulation master to avoid unnecessary computations and roll backs of the FMU due to external events known by the simulation master.]_
 

--- a/docs/5_2_hybrid_co-simulation_api.adoc
+++ b/docs/5_2_hybrid_co-simulation_api.adoc
@@ -16,41 +16,41 @@ include::../headers/fmi3FunctionTypes.h[tag=CallbackIntermediateUpdate]
 
 * Argument <<intermediateUpdateTime>> is the internal simulation time of the FMU at which the callback has been called.
 If an event happens or a <<outputClock>> ticks, <<intermediateUpdateTime>> is the time of event or <<outputClock>> tick.
-If the FMU signals an `earlyReturn = fmi3True` and `fmi3OK` after returning from <<fmi3DoStep>> then <<intermediateUpdateTime>> is the internal simulation time of the FMU of the last <<fmi3CallbackIntermediateUpdate>> call that signaled <<canReturnEarly,`canReturnEarly = fmi3True`>>.
+If the FMU signals an `earlyReturn == fmi3True` and `fmi3OK` after returning from <<fmi3DoStep>> then <<intermediateUpdateTime>> is the internal simulation time of the FMU of the last <<fmi3CallbackIntermediateUpdate>> call that signaled <<canReturnEarly,`canReturnEarly == fmi3True`>>.
 <<intermediateUpdateTime>> is also the time of intermediate steps of the internal FMU solver.
 
 The following `fmi3Boolean` variables define the reasons for the <<fmi3CallbackIntermediateUpdate>> call.
 Several variables can be set by the FMU.
 Default value of variables is `fmi3False`.
 
-* When <<eventOccurred,`eventOccurred = fmi3True`>>, the master must call <<fmi3DoEarlyReturn>> to do an early return and handle the event via entering *Event Mode*.
+* When <<eventOccurred,`eventOccurred == fmi3True`>>, the master must call <<fmi3DoEarlyReturn>> to do an early return and handle the event via entering *Event Mode*.
 In this case, <<earlyReturnTime>> argument of <<fmi3DoEarlyReturn>> is ignored.
 In *Event Mode* the master shall call the <<fmi3NewDiscreteStates>> function for gathering related information about the event that occurred at <<intermediateUpdateTime>>.
 
-* When <<clocksTicked,`clocksTicked = fmi3True`>>, it means that <<fmi3GetClock>> function should be called for gathering all <<clock>> related information about ticking <<outputClock,`output clocks`>> at <<intermediateUpdateTime>>.
+* When <<clocksTicked,`clocksTicked == fmi3True`>>, it means that <<fmi3GetClock>> function should be called for gathering all <<clock>> related information about ticking <<outputClock,`output clocks`>> at <<intermediateUpdateTime>>.
 If this flag is `fmi3True` the master must call <<fmi3DoEarlyReturn>> to do an early return and handle the <<clock>> event in *Event Mode*.
 In this case, <<earlyReturnTime>> argument of <<fmi3DoEarlyReturn>> is ignored.
 
-* When <<intermediateVariableSetAllowed,`intermediateVariableSetAllowed = fmi3True`>>, the FMU signals that intermediate output values can be collected by the Co-Simulation master.
+* When <<intermediateVariableSetAllowed,`intermediateVariableSetAllowed == fmi3True`>>, the FMU signals that intermediate output values can be collected by the Co-Simulation master.
 
-* When <<intermediateVariableGetAllowed,`intermediateVariableGetAllowed = fmi3True`>>, the FMU signals that intermediate input values can be set by the Co-Simulation master.
+* When <<intermediateVariableGetAllowed,`intermediateVariableGetAllowed == fmi3True`>>, the FMU signals that intermediate input values can be set by the Co-Simulation master.
 
-* When <<intermediateStepFinished, `intermediateStepFinished = fmi3True`>>, the FMU signals that the internal solver step for this time instant is complete.
+* When <<intermediateStepFinished, `intermediateStepFinished == fmi3True`>>, the FMU signals that the internal solver step for this time instant is complete.
 
-* When <<canReturnEarly,`canReturnEarly = fmi3True`>> the master can request the FMU to return early at the current <<intermediateUpdateTime>> time instant via calling <<fmi3DoEarlyReturn>> within the callback function <<fmi3CallbackIntermediateUpdate>>.
-If <<canReturnEarly,`canReturnEarly = fmi3False`>> the FMU will not do the early return, regardless of the master request.
+* When <<canReturnEarly,`canReturnEarly == fmi3True`>> the master can request the FMU to return early at the current <<intermediateUpdateTime>> time instant via calling <<fmi3DoEarlyReturn>> within the callback function <<fmi3CallbackIntermediateUpdate>>.
+If <<canReturnEarly,`canReturnEarly == fmi3False`>> the FMU will not do the early return, regardless of the master request.
 
 Note that only the first discontinuity event at a Newtonian time instant shall be signaled that way.
 But in *Event Mode*, there may be an event iteration at a Newtonian time instant and have super-dense time instants.
 
 Based on the information provided by <<fmi3CallbackIntermediateUpdate>>, additional information about the discontinuity at that time instant can be obtained by calling <<fmi3NewDiscreteStates>> and <<fmi3GetClock>>.
 
-The FMU must not call the callback function <<fmi3CallbackIntermediateUpdate>> with an <<intermediateUpdateTime>> that is smaller than the <<intermediateUpdateTime>> given in a previous call of <<fmi3CallbackIntermediateUpdate>> with `intermediateStepFinished = fmi3True`.
+The FMU must not call the callback function <<fmi3CallbackIntermediateUpdate>> with an <<intermediateUpdateTime>> that is smaller than the <<intermediateUpdateTime>> given in a previous call of <<fmi3CallbackIntermediateUpdate>> with `intermediateStepFinished == fmi3True`.
 
 ==== Handling a Successful Early-Return by the Co-Simulation Master in Hybrid Co-Simulation
 
 If the FMU is successful in conducting an early return, the return value of the `earlyReturn` argument in <<fmi3DoStep>> is `fmi3True`, otherwise `fmi3False`.
-If the FMU returns from <<fmi3DoStep>> with the `earlyReturn = fmi3True` the Co-Simulation master has to call <<fmi3EnterEventMode>> for that FMU.
+If the FMU returns from <<fmi3DoStep>> with the `earlyReturn == fmi3True` the Co-Simulation master has to call <<fmi3EnterEventMode>> for that FMU.
 
 [source, C]
 ----
@@ -63,22 +63,22 @@ If an FMU provides the early-return capability that includes the handling of eve
 the FMU signals this via <<canReturnEarlyAfterIntermediateUpdate>> in the `modelDescription.xml`.
 
 The FMU stops computation at the first encountered internal event (if any) and the event time is provided through <<intermediateUpdateTime>>.
-If <<fmi3DoStep>> returns with `earlyReturn = fmi3True` and an event has happened, i.e. <<eventOccurred,`eventOccurred = fmi3True`>>, then an event handling has to be done by the Co-Simulation master.
+If <<fmi3DoStep>> returns with `earlyReturn == fmi3True` and an event has happened, i.e. <<eventOccurred,`eventOccurred == fmi3True`>>, then an event handling has to be done by the Co-Simulation master.
 In order to start event handling the Co-Simulation master has to call <<fmi3EnterEventMode>> for that FMU to push the FMU into *Event Mode*.
 In this mode the Co-Simulation master is supposed to catch all events through the <<fmi3NewDiscreteStates>> function.
 
-If the early-return request of the Co-Simulation master is ignored by the FMU, then <<fmi3DoStep>> returns with `earlyReturn = fmi3False`.
+If the early-return request of the Co-Simulation master is ignored by the FMU, then <<fmi3DoStep>> returns with `earlyReturn == fmi3False`.
 The master can start a resynchronization of FMUs at an event time, if the `currentCommunicationPoint` has passed the event time, the master can roll-back the FMU and repeat the step with a suitable `communicationStepSize` (if the FMU supports the roll-back).
 
-In *Event Mode* and only after <<fmi3DoStep>> returned with `earlyReturn = fmi3True` the function <<fmi3NewDiscreteStates>> may be called.
+In *Event Mode* and only after <<fmi3DoStep>> returned with `earlyReturn == fmi3True` the function <<fmi3NewDiscreteStates>> may be called.
 Only the following output arguments may be considered:
 
 - When `newDiscreteStatesNeeded = true`, the master should stay in *Event Mode* and another call to <<fmi3NewDiscreteStates>> is required.
 
-- When `nextEventTimeDefined = fmi3True`, an event time is available and the value is given by `nextEventTime`.
+- When `nextEventTimeDefined == fmi3True`, an event time is available and the value is given by `nextEventTime`.
 This is the case when the model can report in advance the accurate time of the next predictable time event.
 
-- When `terminateSimulation = fmi3True`, the model requested to stop integration and the Co-Simulation master should call <<fmi3Terminate>>.
+- When `terminateSimulation == fmi3True`, the model requested to stop integration and the Co-Simulation master should call <<fmi3Terminate>>.
 
 In *Event Mode* it is allowed to call `fmi3Get{VariableType}` after <<fmi3NewDiscreteStates>> has been called and it is allowed to call `fmi3Set{VariableType}` before calling <<fmi3NewDiscreteStates>>.
 The FMU leaves *Event Mode* when the master calls <<fmi3EnterStepMode>>.
@@ -108,7 +108,7 @@ include::../headers/fmi3FunctionTypes.h[tag=EnterStepMode]
 ===== Transfer of Input / Output Values and Parameters in Hybrid Co-Simulation [[transfer-of-input-output-and-parameters-clocked-co-simulation]]
 
 If the Co-Simulation master supports <<clock,`clocks`>>, all <<inputClock,`input clocks`>> of the model should be handled and <<inputClock>> events should be scheduled by the master.
-If an <<outputClock>> ticks, the FMU calls <<fmi3CallbackIntermediateUpdate>> with <<clocksTicked,`clocksTicked = fmi3True`>>.
+If an <<outputClock>> ticks, the FMU calls <<fmi3CallbackIntermediateUpdate>> with <<clocksTicked,`clocksTicked == fmi3True`>>.
 Then the master must call <<fmi3DoEarlyReturn>> to do an early return from <<fmi3DoStep>> and push the FMU into *Event Mode* by calling <<fmi3EnterEventMode>>.
 Once the FMU is in *Event Mode*, the activation status of <<outputClock,`output clocks`>> are retrieved by <<fmi3GetClock>> function.
 Then <<fmi3SetClock>> (and <<fmi3SetIntervalDecimal>> or <<fmi3SetIntervalFraction>> if necessary) should be invoked to enable the ticked <<inputClock,`input clocks`>>.
@@ -124,10 +124,10 @@ The simulation master sets and gets <<clock>> variable values similar to the FMI
 ===== Computation in Hybrid Co-Simulation [[computation-clocked-co-simulation]]
 
 Similar to FMI for Model Exchange, in order to activate <<inputClock,`input clocks`>> of an FMU, it is required to push the FMU into *Event Mode* by calling <<fmi3EnterEventMode>>.
-If <<fmi3DoStep>> returns with `earlyReturn = fmi3True` and <<eventOccurred,`eventOccurred = fmi3True`>> or <<clocksTicked,`clocksTicked = fmi3True`>>, the FMU must be pushed into the *Event Mode* by calling <<fmi3EnterEventMode>>.
+If <<fmi3DoStep>> returns with `earlyReturn == fmi3True` and <<eventOccurred,`eventOccurred == fmi3True`>> or <<clocksTicked,`clocksTicked == fmi3True`>>, the FMU must be pushed into the *Event Mode* by calling <<fmi3EnterEventMode>>.
 
 In order to retrieve the status of <<outputClock,`output clocks`>>, <<fmi3GetClock>> and <<fmi3GetIntervalDecimal>> or <<fmi3GetIntervalFraction>> need to be called in the *Event Mode*.
-If the <<fmi3DoStep>> return value is `fmi3OK` and `earlyReturn = fmi3False`, the calling of <<fmi3GetClock>>, <<fmi3GetIntervalDecimal>>, <<fmi3GetIntervalFraction>>, <<fmi3NewDiscreteStates>> is only meaningful after <<fmi3SetClock>> in the case of super-dense time iterations are desired.
+If the <<fmi3DoStep>> return value is `fmi3OK` and `earlyReturn == fmi3False`, the calling of <<fmi3GetClock>>, <<fmi3GetIntervalDecimal>>, <<fmi3GetIntervalFraction>>, <<fmi3NewDiscreteStates>> is only meaningful after <<fmi3SetClock>> in the case of super-dense time iterations are desired.
 
 Similar to the Model Exchange case, the allowed call order is <<fmi3GetClock>>, <<fmi3GetIntervalDecimal>>, <<fmi3GetIntervalFraction>>, `fmi3Get{VariableType}`, `fmi3Set{VariableType}`.
 Function calls of this call order can be omitted.
@@ -185,7 +185,7 @@ In order to handle discrete events and <<clock>> ticks, the FMU is pushed into t
 
 Allowed Function Calls::
 <<fmi3Terminate>>::
-Upon return of <<fmi3NewDiscreteStates>>, if `terminateSimulation = fmi3True`, the master should finish the Co-Simulation by calling `fmi3Terminate` on all FMU instances.
+Upon return of <<fmi3NewDiscreteStates>>, if `terminateSimulation == fmi3True`, the master should finish the Co-Simulation by calling `fmi3Terminate` on all FMU instances.
 
 <<fmi3EnterConfigurationMode>>::
 With this function call the *Reconfiguration Mode* is entered.
@@ -193,10 +193,10 @@ This function must not be called if the FMU contains no <<tunable>> <<structural
 
 <<fmi3NewDiscreteStates>>::
 In order to handle discrete events <<fmi3NewDiscreteStates>> is called.
-When the output argument `newDiscreteStatesNeeded = fmi3True`, the FMU should stay in *Event Mode* and another call to <<fmi3NewDiscreteStates>> is required.
+When the output argument `newDiscreteStatesNeeded == fmi3True`, the FMU should stay in *Event Mode* and another call to <<fmi3NewDiscreteStates>> is required.
 
 <<fmi3EnterStepMode>>::
-Once all events are handled and `newDiscreteStatesNeeded = fmi3False`, the FMU should be pushed to *Step Mode* by calling <<fmi3EnterStepMode>>, unless it requests to terminate the Co-Simulation by setting  `terminateSimulation` to `fmi3True`.
+Once all events are handled and `newDiscreteStatesNeeded == fmi3False`, the FMU should be pushed to *Step Mode* by calling <<fmi3EnterStepMode>>, unless it requests to terminate the Co-Simulation by setting  `terminateSimulation` to `fmi3True`.
 In this case, a new step can be started from the current communication point time.
 
 <<fmi3GetClock>>::
@@ -224,7 +224,7 @@ This state in Hybrid Co-Simulation differ from Basic Co-Simulation described in 
 Allowed Function Calls::
 
 <<fmi3DoEarlyReturn>>::
-If <<canReturnEarly,`canReturnEarly = fmi3True`>>, the Co-Simulation master can request the FMU to end the <<fmi3DoStep>> and to do an early return by calling this function.
+If <<canReturnEarly,`canReturnEarly == fmi3True`>>, the Co-Simulation master can request the FMU to end the <<fmi3DoStep>> and to do an early return by calling this function.
 
 Forbidden Function Calls::
 All API functions not listed in the allowed function list, including <<fmi3GetClock>> and  <<fmi3SetClock>> are forbidden in this mode.


### PR DESCRIPTION
This addresses #933.
I am not sure this really helps to improve readability.
You are still left wondering in a few places where the XML attribute is not clearly understandable as such.

Also: I have seen strange math not-equals mixed in.
I will also fix those in a next change set.