### PR TITLE
Discourage use of memory callbacks in FMI 2.0.2

### DIFF
--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -983,7 +983,7 @@ is extracted from the XML file from element <ModelStructure>._
 . _A so-called graph coloring algorithm is employed to determine the columns
 of the matrix that can be computed by one call of fmi2GetDirectionalDerivative.
 Efficient graph coloring algorithms are freely available,
-such as library ColPack (http://www.cscapes.org/coloringpage/) written in C/C++ (LGPL),
+such as library ColPack (https://cscapes.cs.purdue.edu/coloringpage/) written in C/C++ (LGPL),
 or the routines by Coleman, Garbow, Moré: "Software for estimating sparse Jacobian matrices",
 ACM Transactions on Mathematical Software - TOMS ,
 vol. 10, no. 3, pp. 346-347, 1984. See e.g. http://www.netlib.org/toms/618._

--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -523,6 +523,9 @@ A null pointer can be provided.
 In this case the master must use `fmiGetStatus(..)` to query the status of `fmi2DoStep`.
 If a pointer to a function is provided, it must be called by the FMU after a completed communication step.
 
+_[Note: In FMI 3.0, memory callback functions were removed, because their intended uses failed to materialize and the implementations often had issues.
+It is now discuouraged to use the memory callback functions.]_
+
 [source, C]
 ----
 void fmi2FreeInstance(fmi2Component c);


### PR DESCRIPTION
Fixing #931 , replacing #987, which aimed at FMI 3.0

@andreas-junghanns : In contrast do https://github.com/modelica/fmi-standard/pull/987/commits/a89f05ea0c5e18bae071703409fb85ace4863c16 this shall be non-normative, right?
when you approve this, I will also include it in the FMI 2.0.2 word document.