### PR TITLE
fix description of initial==approx

### DIFF
--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1247,7 +1247,7 @@ It is not allowed to provide a value for <<initial>> if <<causality>> = <<input>
 `= exact`: The variable is initialized with the <<start>> value (provided under the variable type element).
 
 [[approx,`approx`]]
-`= approx`: The variable is an iteration variable of an algebraic loop and the iteration at initialization starts with the <<start>> value.
+`= approx`: The <<start>> value provides an approximation that may be modified during initialization, e.g., if the FMU is part of an algebraic loop where the variable might be an iteration variable and <<start>> value is taken as initial value for an iterative solution process.
 
 [[calculated,`calculated`]]
 `= calculated`: The variable is calculated from other variables during initialization.


### PR DESCRIPTION
.... as the FMU cannot know, if a variable is used as an iteration of an algebraic loop, so we cannot claim this in normative text.