### PR TITLE
change partial derivative capabilities to plural + list them in schema description

### DIFF
--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -1011,7 +1011,7 @@ with the Jacobian
 where latexmath:[\mathbf{v}_{\mathit{known}}] are the latexmath:[n] knowns, and latexmath:[\mathbf{h}] are the latexmath:[m] functions to calculate the latexmath:[m] unknwon variables latexmath:[\mathbf{v}_{\mathit{unknwon}}]  from the knowns.
 
 Both functions can also be used to construct the partial derivative matrices.
-The functions may only be called if their availability is indicated by the attributes `providesDirectionalDerivative` and `providesAdjointDerivative` respectively.
+The functions may only be called if their availability is indicated by the attributes `providesDirectionalDerivatives` and `providesAdjointDerivatives` respectively.
 
 [[fmi3GetDirectionalDerivative,`fmi3GetDirectionalDerivative`]]
 [source, C]

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1781,7 +1781,7 @@ _This is for example, important for linearization, in order that the interpretat
 The corresponding continuous-time <<state,`states`>> are defined by attribute <<derivative>> of the corresponding variable state derivative element.
 _[Note that higher order derivatives must be mapped to first order derivatives but the mapping definition can be preserved due to attribute <<derivative>>._
 _Example: if_ latexmath:[{\frac{\text{ds}}{\text{dt}} = v,\ \frac{\text{dv}}{\text{dt}} =f(..)}] _,then_ latexmath:[{\left\{ v,\ \frac{\text{dv}}{\text{dt}} \right\}}] _is the vector of state derivatives and attribute <<derivative>> of_ latexmath:[{v}] _references_ latexmath:[{s}] _, and attribute <<derivative>> of_ latexmath:[{\frac{\text{dv}}{\text{dt}}}] _references_ latexmath:[{v}] _.]_ +
-For Co-Simulation, elements `<Derivative>` are ignored if capability flag `providesDirectionalDerivative` has a value of `false`, in other words, it cannot be computed.
+For Co-Simulation, elements `<Derivative>` are ignored if capability flag `providesDirectionalDerivatives` has a value of `false`, in other words, it cannot be computed.
 _[This is the default._
 _If an FMU supports more than Model Exchange , then the `<Derivative>` elements might be present, since it is needed for Model Exchange._
 _If the above flag is set to `false` for the Co-Simulation cases, then the `<Derivative>` elements are ignored for Co-Simulation._
@@ -1885,7 +1885,7 @@ _[<<parameter,`parameters`>> and <<tunable>> <<parameter,`parameters`>> must not
 - <<independent>> variable (usually time; <<causality>> = <<independent>>).
 If an <<independent>> variable is not explicitly defined under variables, it is assumed that the unknown depends explicitly on the <<independent>> variable.
 
-For Co-Simulation, if the capability flag `providesDirectionalDerivative` has a value of `false`, then <<dependencies>> does not list the dependency on continuous-time.
+For Co-Simulation, if the capability flag `providesDirectionalDerivatives` has a value of `false`, then <<dependencies>> does not list the dependency on continuous-time.
 In other words, the respective partial derivatives cannot be computed.
 
 // TODO: should be discussed after Karl's return

--- a/docs/3_3_model_exchange_schema.adoc
+++ b/docs/3_3_model_exchange_schema.adoc
@@ -46,7 +46,7 @@ That is, functions <<fmi3GetFMUState>>, <<fmi3SetFMUState>>, and <<fmi3FreeFMUSt
 If this is the case, then flag `canGetAndSetFMUState` must be `true` as well.
 
 |`providesDirectionalDerivatives`
-|If `true`, the directional derivative of the equations can be computed with `fmi3GetDirectionalDerivative`
+|If `true`, the directional derivative of the equations can be computed with `fmi3GetDirectionalDerivative`.
 |====
 
 The flags have the following default values.

--- a/docs/3_3_model_exchange_schema.adoc
+++ b/docs/3_3_model_exchange_schema.adoc
@@ -45,7 +45,7 @@ That is, functions <<fmi3GetFMUState>>, <<fmi3SetFMUState>>, and <<fmi3FreeFMUSt
 |If `true`, the environment can serialize the internal FMU state, in other words, functions <<fmi3SerializedFMUStateSize>>, <<fmi3SerializeFMUState>>, `fmi3DeSerializeFMUState` are supported by the FMU.
 If this is the case, then flag `canGetAndSetFMUState` must be `true` as well.
 
-|`providesDirectionalDerivative`
+|`providesDirectionalDerivatives`
 |If `true`, the directional derivative of the equations can be computed with `fmi3GetDirectionalDerivative`
 |====
 

--- a/docs/4_3_basic_co-simulation_schema.adoc
+++ b/docs/4_3_basic_co-simulation_schema.adoc
@@ -43,8 +43,11 @@ That is, <<fmi3GetFMUState>>, <<fmi3SetFMUState>>, and <<fmi3FreeFMUState>> are 
 |If `true`, the environment can serialize the internal FMU state, in other words, <<fmi3SerializedFMUStateSize>>, <<fmi3SerializeFMUState>>, <<fmi3DeSerializeFMUState>> are supported by the FMU.
 If this is the case, then flag `canGetAndSetFMUState` must be `true` as well.
 
-|`providesDirectionalDerivative`
+|`providesDirectionalDerivatives`
 |If `true`, the directional derivative of the equations at communication points can be computed with `fmi3GetDirectionalDerivative`.
+
+|`providesAdjointDerivatives`
+|If `true`, the adjoint derivatives of the equations can be computed with `fmi3GetAdjointDerivative`
 
 |`maxOutputDerivativeOrder`
 |The slave is able to provide <<derivative,`derivatives`>> of <<output,`outputs`>> with maximum order.

--- a/docs/5_3_hybrid_co-simulation_schema.adoc
+++ b/docs/5_3_hybrid_co-simulation_schema.adoc
@@ -26,3 +26,5 @@ The XML file may have the following content:
 ----
 //include::examples/co_simulation_clocked_cosimulation.xml[]
 ----
+
+TODO: Add capabilities

--- a/docs/6_3_scheduled_co-simulation_schema.adoc
+++ b/docs/6_3_scheduled_co-simulation_schema.adoc
@@ -15,3 +15,5 @@ The example below is the same one as shown in section [TBD] for a `fmi3ClockedCo
 ----
 //include::examples/co_simulation_scheduled_execution.xml[]
 ----
+
+TODO: describe capabilities

--- a/schema/fmi3InterfaceType.xsd
+++ b/schema/fmi3InterfaceType.xsd
@@ -44,8 +44,8 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		<xs:attribute name="canBeInstantiatedOnlyOncePerProcess" type="xs:boolean" default="false"/>
 		<xs:attribute name="canGetAndSetFMUState" type="xs:boolean" default="false"/>
 		<xs:attribute name="canSerializeFMUState" type="xs:boolean" default="false"/>
-		<xs:attribute name="providesDirectionalDerivative" type="xs:boolean" default="false"/>
-		<xs:attribute name="providesAdjointDerivative" type="xs:boolean" default="false"/>
+		<xs:attribute name="providesDirectionalDerivatives" type="xs:boolean" default="false"/>
+		<xs:attribute name="providesAdjointDerivatives" type="xs:boolean" default="false"/>
 		<xs:attribute name="providesPerElementDependencies" type="xs:boolean" default="false"/>
 	</xs:complexType>
 	<xs:complexType name="fmi3ModelExchange">


### PR DESCRIPTION
resolves #1017 

additionally fixes the missing description of providesAdjointDerivative schema description for ME and BCS listed in #1018, #1019 