### PR TITLE
Fix XML schema mechanics around variables

### DIFF
--- a/schema/fmi3Variable.xsd
+++ b/schema/fmi3Variable.xsd
@@ -279,21 +279,12 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
-	<xs:complexType name="fmi3EnumerationBase">
-		<xs:complexContent>
-			<xs:restriction base="fmi3VariableBase">
-				<xs:attribute name="declaredType" use="prohibited"/>
-			</xs:restriction>
-		</xs:complexContent>
-	</xs:complexType>
 	<xs:complexType name="fmi3Enumeration">
 		<xs:complexContent>
 			<xs:extension base="fmi3EnumerationBase">
 				<xs:sequence>
 					<xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
 				</xs:sequence>
-				<xs:attribute name="declaredType" type="xs:normalizedString" use="required">
-				</xs:attribute>
 				<xs:attribute name="quantity" type="xs:normalizedString"/>
 				<xs:attribute name="min" type="xs:int"/>
 				<xs:attribute name="max" type="xs:int"/>
@@ -339,7 +330,21 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
+	<xs:complexType name="fmi3EnumerationBase" abstract="true">
+		<xs:complexContent>
+			<xs:extension base="fmi3VariableCore">
+				<xs:attribute name="declaredType" type="xs:normalizedString" use="required"/>				
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
 	<xs:complexType name="fmi3VariableBase" abstract="true">
+		<xs:complexContent>
+			<xs:extension base="fmi3VariableCore">
+				<xs:attribute name="declaredType" type="xs:normalizedString"/>		
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="fmi3VariableCore" abstract="true">
 		<xs:sequence>
 			<xs:element name="Dimension" minOccurs="0" maxOccurs="unbounded">
 				<xs:complexType>
@@ -387,7 +392,6 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			</xs:simpleType>
 		</xs:attribute>
 		<xs:attribute name="canHandleMultipleSetPerTimeInstant" type="xs:boolean"/>
-		<xs:attribute name="declaredType" type="xs:normalizedString"/>
 		<xs:attribute name="clockReference" type="xs:unsignedInt"/>
 		<xs:attribute name="clockElementIndex" type="xs:unsignedLong"/>
 		<xs:attribute name="intermediateAccess" type="xs:boolean"/>

--- a/schema/fmi3Variable.xsd
+++ b/schema/fmi3Variable.xsd
@@ -45,11 +45,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:attributeGroup ref="fmi3Float64Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
-						<xs:list>
-							<xs:simpleType>
-								<xs:restriction base="xs:double"/>
-							</xs:simpleType>
-						</xs:list>
+						<xs:list itemType="xs:double"/>
 					</xs:simpleType>
 				</xs:attribute>
 				<xs:attributeGroup ref="fmi3RealVariableAttributes"/>
@@ -65,11 +61,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:attributeGroup ref="fmi3Float32Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
-						<xs:list>
-							<xs:simpleType>
-								<xs:restriction base="xs:float"/>
-							</xs:simpleType>
-						</xs:list>
+						<xs:list itemType="xs:float"/>
 					</xs:simpleType>
 				</xs:attribute>
 				<xs:attributeGroup ref="fmi3RealVariableAttributes"/>
@@ -85,11 +77,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:attributeGroup ref="fmi3Int8Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
-						<xs:list>
-							<xs:simpleType>
-								<xs:restriction base="xs:byte"/>
-							</xs:simpleType>
-						</xs:list>
+						<xs:list itemType="xs:byte"/>
 					</xs:simpleType>
 				</xs:attribute>
 			</xs:extension>
@@ -104,11 +92,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:attributeGroup ref="fmi3UInt8Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
-						<xs:list>
-							<xs:simpleType>
-								<xs:restriction base="xs:unsignedByte"/>
-							</xs:simpleType>
-						</xs:list>
+						<xs:list itemType="xs:unsignedByte"/>
 					</xs:simpleType>
 				</xs:attribute>
 			</xs:extension>
@@ -123,11 +107,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:attributeGroup ref="fmi3Int16Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
-						<xs:list>
-							<xs:simpleType>
-								<xs:restriction base="xs:short"/>
-							</xs:simpleType>
-						</xs:list>
+						<xs:list itemType="xs:short"/>
 					</xs:simpleType>
 				</xs:attribute>
 			</xs:extension>
@@ -142,11 +122,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:attributeGroup ref="fmi3UInt16Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
-						<xs:list>
-							<xs:simpleType>
-								<xs:restriction base="xs:unsignedShort"/>
-							</xs:simpleType>
-						</xs:list>
+						<xs:list itemType="xs:unsignedShort"/>
 					</xs:simpleType>
 				</xs:attribute>
 			</xs:extension>
@@ -161,11 +137,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:attributeGroup ref="fmi3Int32Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
-						<xs:list>
-							<xs:simpleType>
-								<xs:restriction base="xs:int"/>
-							</xs:simpleType>
-						</xs:list>
+						<xs:list itemType="xs:int"/>
 					</xs:simpleType>
 				</xs:attribute>
 			</xs:extension>
@@ -180,11 +152,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:attributeGroup ref="fmi3UInt32Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
-						<xs:list>
-							<xs:simpleType>
-								<xs:restriction base="xs:unsignedInt"/>
-							</xs:simpleType>
-						</xs:list>
+						<xs:list itemType="xs:unsignedInt"/>
 					</xs:simpleType>
 				</xs:attribute>
 			</xs:extension>
@@ -199,11 +167,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:attributeGroup ref="fmi3Int64Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
-						<xs:list>
-							<xs:simpleType>
-								<xs:restriction base="xs:long"/>
-							</xs:simpleType>
-						</xs:list>
+						<xs:list itemType="xs:long"/>
 					</xs:simpleType>
 				</xs:attribute>
 			</xs:extension>
@@ -218,11 +182,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:attributeGroup ref="fmi3UInt64Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
-						<xs:list>
-							<xs:simpleType>
-								<xs:restriction base="xs:unsignedLong"/>
-							</xs:simpleType>
-						</xs:list>
+						<xs:list itemType="xs:unsignedLong"/>
 					</xs:simpleType>
 				</xs:attribute>
 			</xs:extension>
@@ -236,11 +196,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				</xs:sequence>
 				<xs:attribute name="start">
 					<xs:simpleType>
-						<xs:list>
-							<xs:simpleType>
-								<xs:restriction base="xs:boolean"/>
-							</xs:simpleType>
-						</xs:list>
+						<xs:list itemType="xs:boolean"/>
 					</xs:simpleType>
 				</xs:attribute>
 			</xs:extension>
@@ -252,8 +208,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:sequence maxOccurs="unbounded">
 					<xs:element name="Start">
 						<xs:complexType>
-							<xs:attribute name="value" type="xs:string">
-							</xs:attribute>
+							<xs:attribute name="value" type="xs:string"/>
 						</xs:complexType>
 					</xs:element>
 					<xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
@@ -290,11 +245,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:attribute name="max" type="xs:int"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
-						<xs:list>
-							<xs:simpleType>
-								<xs:restriction base="xs:int"/>
-							</xs:simpleType>
-						</xs:list>
+						<xs:list itemType="xs:int"/>
 					</xs:simpleType>
 				</xs:attribute>
 			</xs:extension>
@@ -309,11 +260,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:attributeGroup ref="fmi3ClockAttributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
-						<xs:list>
-							<xs:simpleType>
-								<xs:restriction base="xs:boolean"/>
-							</xs:simpleType>
-						</xs:list>
+						<xs:list itemType="xs:boolean"/>
 					</xs:simpleType>
 				</xs:attribute>
 			</xs:extension>


### PR DESCRIPTION
This addresses the breakage in the enumeration variable definitions identified in #1034, as well as changing start value lists to use the itemType instead of a restricted type, as identified in #1033, as well as some other minor cleanups.

Nested attributegroups also mentioned in #1033 are not that easy to do away with without introducing a bit of duplication, so whether to go down this route, or rather suggest a simple xslt transformation for the schema for implementers so constrained, is something to be discussed in the #1033 issue going forward, but this PR contains the easy fixes, as far as I can tell. Fixes #1034.