### PR TITLE
Reword Early Return and Event handling description

### DIFF
--- a/docs/5_2_hybrid_co-simulation_api.adoc
+++ b/docs/5_2_hybrid_co-simulation_api.adoc
@@ -19,7 +19,7 @@ There may be an event iteration in *Event Mode* at a Newtonian time instant caus
 
 Based on the information provided by <<fmi3CallbackIntermediateUpdate>>, additional information about the discontinuity at that time instant can be obtained by the master from the FMU by calling <<fmi3NewDiscreteStates>> and <<fmi3GetClock>>.
 
-==== Handling a Successful Early-Return by the Co-Simulation Master in Hybrid Co-Simulation
+==== Handling Early Return and Events in Hybrid Co-Simulation
 
 If the FMU is successful in conducting an early return, <<fmi3DoStep>> returns with <<earlyReturn,`earlyReturn == fmi3True`>>.
 If the FMU returns from <<fmi3DoStep>> with <<earlyReturn,`earlyReturn == fmi3True`>>, the Co-Simulation master has to call <<fmi3EnterEventMode>> for that FMU.
@@ -34,15 +34,20 @@ The Co-Simulation master can also call <<fmi3EnterEventMode>> at communication i
 If an FMU provides the early-return capability that includes the handling of events in *Event Mode*,
 the FMU signals this via <<canReturnEarlyAfterIntermediateUpdate>> in the <<modelDescription.xml>>.
 
-The FMU stops computation at the first encountered internal event (if any) and the event time is provided through <<intermediateUpdateTime>>.
-If <<fmi3DoStep>> returns with <<earlyReturn,`earlyReturn == fmi3True`>> and an event has happened, i.e. <<eventOccurred,`eventOccurred == fmi3True`>>, then an event handling has to be done by the Co-Simulation master.
-In order to start event handling the Co-Simulation master has to call <<fmi3EnterEventMode>> for that FMU to push the FMU into *Event Mode*.
+The FMU stops computation at the first encountered internal event (if any) and the event time is provided through the argument <<intermediateUpdateTime>> when calling <<fmi3CallbackIntermediateUpdate>>, along with the reason <<eventOccurred, `eventOccurred == fmi3True`>>.
+The Co-Simulation master can signal back to the FMU if and when to return early with the output arguments <<earlyReturnRequested>> and <<earlyReturnTime>> of <<fmi3CallbackIntermediateUpdate>>.
+If the FMU returns with <<earlyReturn,`earlyReturn == fmi3True`>> from <<fmi3DoStep>>, the Co-Simulation master will start event handling by calling <<fmi3EnterEventMode>> for that FMU to push the FMU into *Event Mode*.
 In this mode the Co-Simulation master is supposed to catch all events through the <<fmi3NewDiscreteStates>> function.
 
 If an early-return request of the Co-Simulation master is ignored by the FMU, then <<fmi3DoStep>> returns with <<earlyReturn,`earlyReturn == fmi3False`>>.
 The master can start a resynchronization of FMUs at an event time, if the <<currentCommunicationPoint>> has passed the event time, the master can roll-back the FMU and repeat the step with a suitable <<communicationStepSize>> (if the FMU supports the roll-back).
 
-In *Event Mode* and only after <<fmi3DoStep>> returned with <<earlyReturn,`earlyReturn == fmi3True`>> the function <<fmi3NewDiscreteStates>> may be called.
+[source, C]
+----
+include::../headers/fmi3FunctionTypes.h[tag=NewDiscreteStates]
+----
+
+In *Event Mode* and only after <<fmi3DoStep>> returned with <<earlyReturn,`earlyReturn == fmi3True`>>, and <<fmi3EnterEventMode>> was called, the function <<fmi3NewDiscreteStates>> may be called.
 Only the following output arguments may be considered:
 
 - When `newDiscreteStatesNeeded = true`, the master should stay in *Event Mode* and another call to <<fmi3NewDiscreteStates>> is required.
@@ -50,8 +55,7 @@ Only the following output arguments may be considered:
 - When <<nextEventTime,`nextEventTimeDefined == fmi3True`>>, an event time is available and the value is given by <<nextEventTime>>.
 This is the case when the model can report in advance the accurate time of the next predictable time event.
 
-[[terminateSimulation_cs,`terminateSimulation`]]
-- When <<terminateSimulation_cs,`terminateSimulation == fmi3True`>>, the model requested to stop integration and the Co-Simulation master should call <<fmi3Terminate>>.
+- When <<terminateSimulation,`terminateSimulation == fmi3True`>>, the model requested to stop integration and the Co-Simulation master should call <<fmi3Terminate>>.
 
 In *Event Mode* it is allowed to call `fmi3Get{VariableType}` after <<fmi3NewDiscreteStates>> has been called and it is allowed to call `fmi3Set{VariableType}` before calling <<fmi3NewDiscreteStates>>.
 The FMU leaves *Event Mode* when the master calls <<fmi3EnterStepMode>>.
@@ -106,7 +110,7 @@ Function calls of this call order can be omitted.
 
 The handling of return values of function calls is identical to Basic Co-Simulation.
 
-If <<terminateSimulation_cs,`terminateSimulation`>> becomes `fmi3True` after calling <<fmi3NewDiscreteStates>> then the co-simulation should be terminated by calling <<fmi3Terminate>>.
+If <<terminateSimulation,`terminateSimulation`>> becomes `fmi3True` after calling <<fmi3NewDiscreteStates>> then the co-simulation should be terminated by calling <<fmi3Terminate>>.
 Once handling of the <<clock>> events finished, the master calls <<fmi3EnterStepMode>> for that FMU to push it into *Step Mode*.
 Note that it is not allowed to call <<fmi3EnterEventMode>> or <<fmi3EnterStepMode>> in Basic and Scheduled Co-Simulation.
 
@@ -157,7 +161,7 @@ In order to handle discrete events and <<clock>> ticks, the FMU is pushed into t
 
 Allowed Function Calls::
 <<fmi3Terminate>>::
-Upon return of <<fmi3NewDiscreteStates>>, if <<terminateSimulation_cs,`terminateSimulation == fmi3True`>>, the master should finish the Co-Simulation by calling `fmi3Terminate` on all FMU instances.
+Upon return of <<fmi3NewDiscreteStates>>, if <<terminateSimulation,`terminateSimulation == fmi3True`>>, the master should finish the Co-Simulation by calling `fmi3Terminate` on all FMU instances.
 
 <<fmi3EnterConfigurationMode>>::
 With this function call the *Reconfiguration Mode* is entered.
@@ -168,7 +172,7 @@ In order to handle discrete events <<fmi3NewDiscreteStates>> is called.
 When the output argument `newDiscreteStatesNeeded == fmi3True`, the FMU should stay in *Event Mode* and another call to <<fmi3NewDiscreteStates>> is required.
 
 <<fmi3EnterStepMode>>::
-Once all events are handled and `newDiscreteStatesNeeded == fmi3False`, the FMU should be pushed to *Step Mode* by calling <<fmi3EnterStepMode>>, unless it requests to terminate the Co-Simulation by setting  <<terminateSimulation_cs,`terminateSimulation`> to `fmi3True`.
+Once all events are handled and `newDiscreteStatesNeeded == fmi3False`, the FMU should be pushed to *Step Mode* by calling <<fmi3EnterStepMode>>, unless it requests to terminate the Co-Simulation by setting  <<terminateSimulation,`terminateSimulation`> to `fmi3True`.
 In this case, a new step can be started from the current communication point time.
 
 <<fmi3GetClock>>::

--- a/docs/5_2_hybrid_co-simulation_api.adoc
+++ b/docs/5_2_hybrid_co-simulation_api.adoc
@@ -48,7 +48,7 @@ include::../headers/fmi3FunctionTypes.h[tag=NewDiscreteStates]
 ----
 
 In *Event Mode* and only after <<fmi3DoStep>> returned with <<earlyReturn,`earlyReturn == fmi3True`>>, and <<fmi3EnterEventMode>> was called, the function <<fmi3NewDiscreteStates>> may be called.
-Only the following output arguments may be considered:
+Only the following output arguments are defined by the FMU:
 
 - When `newDiscreteStatesNeeded = true`, the master should stay in *Event Mode* and another call to <<fmi3NewDiscreteStates>> is required.
 
@@ -56,6 +56,8 @@ Only the following output arguments may be considered:
 This is the case when the model can report in advance the accurate time of the next predictable time event.
 
 - When <<terminateSimulation,`terminateSimulation == fmi3True`>>, the model requested to stop integration and the Co-Simulation master should call <<fmi3Terminate>>.
+
+All other output arguments of <<fmi3NewDiscreteStates>> are undefined and have no meaning in Hybrid Co-Simulation.
 
 In *Event Mode* it is allowed to call `fmi3Get{VariableType}` after <<fmi3NewDiscreteStates>> has been called and it is allowed to call `fmi3Set{VariableType}` before calling <<fmi3NewDiscreteStates>>.
 The FMU leaves *Event Mode* when the master calls <<fmi3EnterStepMode>>.


### PR DESCRIPTION
Resolves  #665 

Initially I thought this chapter had a extraneous part that needed to be moved to its proper place. But I think the idea of the chapter is rather to explain the early-return and event-handling mechanisms. I tried to fix this with this PR