### PR TITLE
Avoid ambiguous references to code, figures, and tables.

### DIFF
--- a/docs/1___overview.adoc
+++ b/docs/1___overview.adoc
@@ -136,8 +136,10 @@ In many ways, the Scheduled Co-Simulation interface is the equivalent of the Mod
 
 image::images/fmi-types-overview.svg[width=50%, align="center"]
 
-The following table gives an overview of the features of the different interfaces.
+<<table-overview-features>> gives an overview of the features of the different interfaces.
 
+.Overview of features per interface.
+[[table-overview-features]]
 [cols=",^,^,^,^",options="header"]
 |====
 |Feature

--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -1112,7 +1112,7 @@ _After each such call, the elements of the resulting directional derivative vect
 
 _More details and implementational notes are available from <<ABL12>>._
 
-_Example 2_
+_Example:_
 
 _Directional derivatives for higher dimension variables are almost treated in the same way.
 Consider, for example, an FMU which calculates its output latexmath:[{Y}] by multiplying its 2x2 input latexmath:[{U}] with a 3x2 constant gain latexmath:[{K}], with_

--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -1046,7 +1046,8 @@ _Likewise `nSensitivity` is only equal to `nUnknowns` (resp., `nKnowns`) if all 
 
 ===== Directional derivatives
 
-_[Example 1_ +
+[[example-directional-derivatives]]
+_[Example:_ +
 _Assume an FMU has the output equations_
 
 [latexmath]
@@ -1074,11 +1075,11 @@ _Depending on the environment where the FMUs are connected, these <<derivative,`
 
 _Note that a direct implementation of this function with analytic derivatives:_
 
-(a) _Provides the directional derivative for all <<input>> variables; so in the above example: latexmath:[{\Delta y_1 = \frac{\partial g_1}{\partial x} \cdot \Delta x + \frac{\partial g_1}{\partial u_1} \cdot \Delta u_1 + \frac{\partial g_1}{\partial u_3} \cdot \Delta u_3 + \frac{\partial g_1}{\partial u_4} \cdot \Delta u_4}]_
+(a) _Provides the directional derivative for all <<input>> variables; so in the <<example-directional-derivatives,above example>>: latexmath:[{\Delta y_1 = \frac{\partial g_1}{\partial x} \cdot \Delta x + \frac{\partial g_1}{\partial u_1} \cdot \Delta u_1 + \frac{\partial g_1}{\partial u_3} \cdot \Delta u_3 + \frac{\partial g_1}{\partial u_4} \cdot \Delta u_4}]_
 
-(b) _Initializes all seed-values to zero; so in the above example: latexmath:[{\Delta x = \Delta u_1 = \Delta u_3 = \Delta u_4 = 0}]_
+(b) _Initializes all seed-values to zero; so in the <<example-directional-derivatives,above example>>: latexmath:[{\Delta x = \Delta u_1 = \Delta u_3 = \Delta u_4 = 0}]_
 
-(c) _Computes the directional derivative with the seed-values provided in the function arguments; so in the above example: latexmath:[{v_{\mathit{sensitivity}} = \Delta y_1 (\Delta x = 0, \Delta u_1 = 1, \Delta u_3 = 0, \Delta u_4 = 0)}]] and latexmath:[{v_{\mathit{sensitivity}} = \Delta y_1 (\Delta x = 0, \Delta u_1 = 0, \Delta u_3 = 1, \Delta u_4 = 0)}]]_
+(c) _Computes the directional derivative with the seed-values provided in the function arguments; so in the <<example-directional-derivatives,above example>>: latexmath:[{v_{\mathit{sensitivity}} = \Delta y_1 (\Delta x = 0, \Delta u_1 = 1, \Delta u_3 = 0, \Delta u_4 = 0)}]] and latexmath:[{v_{\mathit{sensitivity}} = \Delta y_1 (\Delta x = 0, \Delta u_1 = 0, \Delta u_3 = 1, \Delta u_4 = 0)}]]_
 
 _[Note, function <<fmi3GetDirectionalDerivative>> can be utilized for the following purposes:_
 

--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -163,8 +163,10 @@ The interface to the equations only provides access to variable values via `fmi3
 Extracting concrete information about a variable can be done by reading the <<modelDescription.xml>> in which the `fmi3ValueReferences` are defined.
 If a function in the following sections is called with a wrong `fmi3ValueReference` value _[for example, setting a constant with a call to `fmi3SetFloat64`]_, then the function must return with an error ( <<fmi3Error,`fmi3Status == fmi3Error`>>, see <<status-returned-by-functions>>).
 
-The following data types are the base types used in the interfaces of the C functions.
+Listing <<code-base-types>> shows the base types used in the interfaces of the C functions.
 
+.Base types
+[[code-base-types]]
 [source, C]
 ----
 include::../headers/fmi3PlatformTypes.h[tags=VariableTypes]

--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -326,7 +326,7 @@ The function <<fmi3SetDebugLogging>> gives more detailed control about required 
 [[intermediateVariableSetRequired,`intermediateVariableSetRequired`]]
 * `intermediateVariableSetRequired` TODO explanation required
 
-The arguments below are function pointers provided by the simulation environment to be used by the FMU.
+The arguments <<logMessage>>, <<intermediateUpdate>>, <<lockUnlockPreemption,`lockPreemption`>>, and <<lockUnlockPreemption,`unlockPreemption`>>, are function pointers provided by the simulation environment to be used by the FMU.
 It is not allowed to change these functions between <<fmi3Instantiate>> and <<fmi3Terminate>> calls.
 Additionally, a pointer to the environment is provided (`instanceEnvironment`) that needs to be passed to all of the callback functions, in order that those functions can utilize data from the environment, such as mapping a <<valueReference>> to a string, or assigning memory to a certain FMU instance.
 

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -86,7 +86,7 @@ In order to not loose precision, either an appropriate minimal printer algorithm
 |`char*`
 
 |`dateTime`
-|Date, time and time zone (for details see the link above).
+|Date, time and time zone (for details see https://www.w3.org/TR/xmlschema-2/[XML Schema Part 2: Datatypes Second Edition]).
 Example: `2002-10-23T12:00:00Z` (noon on October 23, 2002, Greenwich Mean Time)
 |tool specific
 |====
@@ -733,10 +733,11 @@ Furthermore, for Co-Simulation FMUs the `stepSize` defines the preferred <<commu
 
 This is the root element of the XML file `icons/terminalsAndIcons.xml`, and is defined as:
 
+.Overview of fmiTerminalsAndIcons.
 [[terminals_and_icons_overview]]
 image::images/schema/fmiTerminalsAndIcons.png[width=60%, align="center"]
 
-On the top level, the schema consists of the following elements (see xref:terminals_and_icons_overview[figure above]).
+On the top level, the schema consists of the following elements (see <<terminals_and_icons_overview>>).
 
 [cols="1,3",options="header"]
 |====
@@ -1073,9 +1074,11 @@ _[If the graphical representation is used for an <<input>> or <<output>> (e.g. a
 The element of `<fmiModelDescription><ModelVariables>` is the central part of the model description.
 It provides the static information of all exposed variables and is defined as follows.
 
+.ModelVariables element.
+[[figure-schema-ModelVariables]]
 image::images/schema/ModelVariables.png[width=60%, align="center"]
 
-The `<ModelVariables>` element consists of an ordered set of variable elements (see figure above).
+The `<ModelVariables>` element consists of an ordered set of variable elements (see <<figure-schema-ModelVariables>>).
 Variable elements can uniformly represent variables of primitive (atomic) types, like single floating point or integer variables, or as well as arrays of an arbitrary (but fixed) number of dimensions. The schema definition is present in a separate file `fmi3Variable.xsd`.
 
 Variable elements representing array variables must contain at least one `<Dimension>` element.

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -17,7 +17,7 @@ These schema files utilize several helper schema files.
 
 In this section these schema files are discussed.
 The normative definition are the above mentioned schema files.
-Below, optional elements are marked with a dashed box.
+In the graphical representation of the schema, optional elements are marked with a dashed box (e.g., see <<figure-schema-Annotations>>).
 The required data types (like: `xs:normalizedString`) are defined in https://www.w3.org/TR/xmlschema-2/[XML Schema Part 2: Datatypes Second Edition].
 The types used in the FMI schema files are:
 
@@ -113,6 +113,8 @@ _For example, the information stored in `<ModelVariables><Derivative>` is only c
 All XML-based file formats defined in this standard allow optional `Annotation` elements to be inserted in all XML elements that represent entities of the underlying data model.
 This is achieved through the `Annotations` element:
 
+.Annotations Element.
+[#figure-schema-Annotations]
 image::images/schema/Annotations.png[width=80%]
 
 Each `Annotation` element contains a required `type` attribute, which contains the namespace for that annotation.
@@ -131,13 +133,14 @@ All annotations can safely be ignored by implementations that just implement the
 
 ==== Definition of an FMU (fmiModelDescription) [[fmiModelDescription]]
 
-This is the root-level schema file and contains the following definition (the figure below contains all elements in the schema file.
-Data is defined by attributes to these elements):
+This is the root-level schema file and is illustrated in <<system_overview>>. The figure contains all elements in the schema file.
+Data is defined by attributes to these elements.
 
+.fmiModelDescription Element.
 [[system_overview]]
 image::images/schema/fmiModelDescription.png[width=70%]
 
-On the top level, the schema consists of the following elements (see xref:system_overview[figure above]).
+On the top level, the schema consists of the following elements.
 _[If an optional element is present and defines a list (such as `<UnitDefinitions>`), the list must have at least one element (such as `<Unit>`).]_
 
 [cols="1,3",options="header"]
@@ -827,7 +830,7 @@ Definition `<Terminal>`: A terminal is...
 * intended to be used for signal flow between models, parameter propagation, and compatibility checks of the model configuration
 * a sequence of references to variables with connection meta data
 
-Predefined rules for variable matching in a connection are given below.
+Predefined rules for variable matching in a connection are given in <<table-predefined-matching-rules>>.
 Predefined variable kinds are used to describe how the member variables have to be handled.
 Domain specific connection rules, terminals and their member variables can be provided by other standards.
 
@@ -853,7 +856,7 @@ The normalized string attribute `name` of the `<Terminal>` element is the instan
 //_[The terminal name may contain dots, to enable structured terminals.]_
 
 The normalized string attribute `matchingRule` describes the rules for variable matching in a connection.
-There are three predefined matching rules: plug, bus, and sequence.
+As detailed in <<table-predefined-matching-rules>>, there are three predefined matching rules: plug, bus, and sequence.
 Other standards may define new matching rules.
 _[It is recommended that vendor specific rules start with `_vendorName` or `_toolName` to avoid namespace clashes.]_
 
@@ -861,6 +864,8 @@ There is a sequence of terminal member variables, terminal stream member variabl
 The member variables are the exchanged variables.
 The type of the nested terminals is `fmi3Terminal`, and they can be used to implement structured terminals.
 
+.Predefined matching rules.
+[#table-predefined-matching-rules]
 [cols="1,3",options="header"]
 |====
 |`matchingRule`
@@ -1250,7 +1255,7 @@ It is not allowed to provide a value for <<initial>> if <<causality>> = <<input>
 `= calculated`: The variable is calculated from other variables during initialization.
 It is not allowed to provide a <<start>> value.
 
-If <<initial>> is not present, it is defined by the table below based on <<causality>> and <<variability>>.
+If <<initial>> is not present, it is defined by <<table-definition-initial>> based on <<causality>> and <<variability>>.
 If <<initial>> = <<exact>> or <<approx>>, or <<causality>> = <<input>>, a <<start>> value must be provided.
 If <<initial>> = <<calculated>>, or <<causality>> = <<independent>>, it is not allowed to provide a <<start>> value.
 
@@ -1314,6 +1319,8 @@ This attribute is only used for Basic Co-Simulation and Hybrid Co-Simulation. Th
 
 If <<initial>> is not present, its value is defined by the following tables based on the values of <<causality>> and <<variability>>:
 
+.Definition of <<initial>>.
+[#table-definition-initial]
 [cols="1,1,1,1,1,1,1,1,1,1"]
 |====
 3.2+|
@@ -1745,12 +1752,16 @@ _[A simulation environment can utilize this information to improve the efficienc
 
 `<ModelStructure>` has the following definition:
 
+.ModelStructure element.
+[#figure-schema-ModelStructure]
 image::images/schema/ModelStructure.png[width=90%]
 
-Note that attribute <<dependenciesKind>> for element <<InitialUnknown>> has less enumeration values as <<dependenciesKind>> in the other lists, see below.
+Note that attribute <<dependenciesKind>> for element <<InitialUnknown>> has less enumeration values as <<dependenciesKind>> in the other lists, as detailed in <<table-model-structure-elements>>.
 
-`<ModelStructure>` consists of the following elements (see also figures above; the symbols of the mathematical equations describing the dependency are defined in <<math-model-exchange>>):
+`<ModelStructure>` consists of the following elements (see also <<figure-schema-ModelStructure>>; the symbols of the mathematical equations describing the dependency are defined in <<math-model-exchange>>):
 
+.ModelStructure elements.
+[#table-model-structure-elements]
 [cols="1,5",options="header"]
 |====
 |Element

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -682,8 +682,10 @@ image::images/schema/LogCategories.png[width=80%, align="center"]
 A tool is free to use any `normalizedString` for a category value.
 The `name` attribute of `<Category>` must be unique with respect to all other elements of the `<LogCategories>` list.
 
-<<table-standard-categories>> shows the standardized names for `<Category>`. These names should be used if a tool supports the corresponding log category.
-If a tool supports one of these log categories and wants to expose it, then an element `<Category>` with this name should be added to `<LogCategories>` _[To be clear, only the `<Category>` names listed under `<LogCategories>` in the XML file are known to the importer of the FMU.]_
+<<table-standard-categories>> shows the standardized names for `<Category>`.
+These names should be used if a tool supports the corresponding log category.
+If a tool supports one of these log categories and wants to expose it, then an element `<Category>` with this name should be added to `<LogCategories>`.
+_[To be clear, only the `<Category>` names listed under `<LogCategories>` in the XML file are known to the importer of the FMU.]_
 
 .Standard names for `<Category>`.
 [[table-standard-categories]]

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -136,13 +136,15 @@ All annotations can safely be ignored by implementations that just implement the
 This is the root-level schema file and is illustrated in <<system_overview>>. The figure contains all elements in the schema file.
 Data is defined by attributes to these elements.
 
-.fmiModelDescription Element.
+.fmiModelDescription element.
 [[system_overview]]
 image::images/schema/fmiModelDescription.png[width=70%]
 
-On the top level, the schema consists of the following elements.
+On the top level, the schema consists of the elements detailed in <<table-schema-fmiModelDescription>>.
 _[If an optional element is present and defines a list (such as `<UnitDefinitions>`), the list must have at least one element (such as `<Unit>`).]_
 
+.fmiModelDescription element details.
+[[table-schema-fmiModelDescription]]
 [cols="1,3",options="header"]
 |====
 |Element
@@ -475,16 +477,26 @@ Furthermore, `name` of a `<TypeDefinition>` must be different to all `name` attr
 
 Additionally, one variable type element must be present.
 Each variable type has its own attributes which can be consulted in the schema.
-The following are representative examples:
+<<figure-schema-Float64>>, <<figure-schema-Int32>>, <<figure-schema-Boolean>>, <<figure-schema-Binary>>, and <<figure-schema-Enumeration>>, are representative examples.
 
+.Float64 element.
+[[figure-schema-Float64]]
 image::images/schema/Float64.png[width=60%, align="center"]
 
+.Int32 element.
+[[figure-schema-Int32]]
 image::images/schema/Int32.png[width=50%, align="center"]
 
+.Boolean element.
+[[figure-schema-Boolean]]
 image::images/schema/Boolean.png[width=50%, align="center"]
 
+.Binary element.
+[[figure-schema-Binary]]
 image::images/schema/Binary.png[width=70%, align="center"]
 
+.Enumeration element.
+[[figure-schema-Enumeration]]
 image::images/schema/Enumeration.png[width=75%, align="center"]
 
 
@@ -670,9 +682,11 @@ image::images/schema/LogCategories.png[width=80%, align="center"]
 A tool is free to use any `normalizedString` for a category value.
 The `name` attribute of `<Category>` must be unique with respect to all other elements of the `<LogCategories>` list.
 
-There are the following standardized names for `<Category>` and these names should be used if a tool supports the corresponding log category.
+<<table-standard-categories>> shows the standardized names for `<Category>`. These names should be used if a tool supports the corresponding log category.
 If a tool supports one of these log categories and wants to expose it, then an element `<Category>` with this name should be added to `<LogCategories>` _[To be clear, only the `<Category>` names listed under `<LogCategories>` in the XML file are known to the importer of the FMU.]_
 
+.Standard names for `<Category>`.
+[[table-standard-categories]]
 [cols="1,3",options="header"]
 |====
 |Category
@@ -843,8 +857,9 @@ _Algebraic loops in systems of connected Model Exchange FMUs are not addressed o
 _It is not required that the <<causality>> of the terminal member variables in connected terminals match._
 
 _The SSP standard refers to a `connectorKind`._
-_This `connectorKind` is not related to the `terminalKind` or `variableKind` described in the following sections.]_
+_This `connectorKind` is not related to the `terminalKind` or `variableKind` described in <<section-terminals>> and <<section-terminalvars>>.]_
 
+[[section-terminals]]
 ====== Terminals
 
 Element `<fmiTerminalsAndIcons><Terminals>` is defined as:
@@ -901,6 +916,7 @@ _The structured naming convention of the `<ModelVariables>` is independent from 
 
 _A tool may choose to connect terminals with a different or unknown `terminalKind`, if the `matchingRule` matches.]_
 
+[[section-terminalvars]]
 ====== Terminal Member Variable
 
 The `<TerminalMemberVariable>` is defined as:
@@ -959,7 +975,8 @@ Restricted to <<input>> and <<output>>, <<parameter>> and <<calculatedParameter>
 _[Example: Electric current]_
 |====
 
-====== General remark on signal [[GeneralRemarkOnSignal]]
+[[section-terminals-remarksignal]]
+====== General remark on signal
 
 _[The signal `variableKind` can be applied for different use cases._
 _The first use case is a signal flow from an <<output>> of one FMU to an <<input>> of another FMU. The <<output>> value has to be forwarded to the <<input>>._
@@ -1149,7 +1166,7 @@ Enumeration that defines the causality of the variable.
 Allowed values of this enumeration:
 
 [[parameter,`parameter`]]
-`= parameter`: A data value that is constant during the simulation (except for <<tunable>> parameters, see there) and is provided by the environment and cannot be used in connections, except for parameter propagation in terminals as described in <<GeneralRemarkOnSignal>>.
+`= parameter`: A data value that is constant during the simulation (except for <<tunable>> parameters, see there) and is provided by the environment and cannot be used in connections, except for parameter propagation in terminals as described in <<section-terminals-remarksignal>>.
 <<variability>> must be <<fixed>> or <<tunable>>.
 These parameters can be changed independently, unlike <<calculatedParameter,calculated parameters>>.
 <<initial>> must be <<exact>> or not present (meaning <<exact>>).
@@ -1320,7 +1337,7 @@ Variables with <<causality>> <<parameter>> must not be marked with <<intermediat
 This attribute is only used for Basic Co-Simulation and Hybrid Co-Simulation. The default value of this attribute is `false`.
 |====
 
-If <<initial>> is not present, its value is defined by the following tables based on the values of <<causality>> and <<variability>>:
+If <<initial>> is not present, its value is defined by <<table-definition-initial>> based on the values of <<causality>> and <<variability>>:
 
 .Definition of <<initial>>.
 [#table-definition-initial]
@@ -1441,8 +1458,10 @@ _[Note: (1) If <<causality>> = <<independent>>, it is neither allowed to define 
 _(2) If <<causality>> = <<input>>, it is not allowed to define a value for <<initial>> and a value for <<start>> must be defined._
 _(3) If \(C) and <<initial>> = <<exact>>, then the variable is explicitly defined by its <<start>> value in *Initialization Mode* (so directly after calling <<fmi3ExitInitializationMode>>, the value of the variable is either the <<start>> value stored in a variable element `<XXX start=YYY/>` or the value provided by `fmi3Set{VariableType}`, if this function was called on this variable).]_
 
-The following combinations of <<variability>>/<<causality>> settings are allowed:
+<<table-allowed-variability-causality-combinations>> shows the combinations of <<variability>>/<<causality>> settings that are allowed.
 
+.Allowed combinations of <<variability>>/<<causality>>.
+[[table-allowed-variability-causality-combinations]]
 [cols="1,1,1,1,1,1,1,1,1,1"]
 |====
 3.2+|
@@ -1654,16 +1673,26 @@ _Changing of <<tunable>> <<parameter,`parameters`>> is allowed before an <<fmi3D
 _The FMU internally carries out event handling if necessary.]_
 
 Type specific properties are defined in the required choice element, where exactly one of the numeric types or an `<Enumeration>` must be present in the XML file:
-The following are representative examples:
+<<figure-schema-Variable_Float64>>, <<figure-schema-Variable_Int32>>, <<figure-schema-Variable_Boolean>>, <<figure-schema-Variable_Binary>>, and <<figure-schema-Variable_Enumeration>>, are representative examples.
 
+.Float64 element.
+[[figure-schema-Variable_Float64]]
 image::images/schema/Variable_Float64.png[width=70%, align="center"]
 
+.Int32 element.
+[[figure-schema-Variable_Int32]]
 image::images/schema/Variable_Int32.png[width=70%, align="center"]
 
+.Boolean element.
+[[figure-schema-Variable_Boolean]]
 image::images/schema/Variable_Boolean.png[width=70%, align="center"]
 
+.Binary element.
+[[figure-schema-Variable_Binary]]
 image::images/schema/Variable_Binary.png[width=70%, align="center"]
 
+.Enumeration element.
+[[figure-schema-Variable_Enumeration]]
 image::images/schema/Variable_Enumeration.png[width=70%, align="center"]
 
 The attributes are defined in <<definition-of-types>> (`<TypeDefinitions>`), except:
@@ -1753,7 +1782,7 @@ The optional part defines in which way <<derivative,`derivatives`>>, <<output,`o
 _[The listed <<dependencies>> declare the dependencies between whole (multi-dimensional-)variables and not individual elements of the variables.]_
 _[A simulation environment can utilize this information to improve the efficiency, for example, when connecting FMUs together, or when computing the partial derivative of the <<derivative,`derivatives`>> with respect to the <<state,`states`>> in the simulation engine.]_
 
-`<ModelStructure>` has the following definition:
+<<figure-schema-ModelStructure>> shows the definition of `<ModelStructure>`.
 
 .ModelStructure element.
 [#figure-schema-ModelStructure]
@@ -1761,7 +1790,7 @@ image::images/schema/ModelStructure.png[width=90%]
 
 Note that attribute <<dependenciesKind>> for element <<InitialUnknown>> has less enumeration values as <<dependenciesKind>> in the other lists, as detailed in <<table-model-structure-elements>>.
 
-`<ModelStructure>` consists of the following elements (see also <<figure-schema-ModelStructure>>; the symbols of the mathematical equations describing the dependency are defined in <<math-model-exchange>>):
+`<ModelStructure>` consists of the elements detailed in <<table-model-structure-elements>> (see also <<figure-schema-ModelStructure>>; the symbols of the mathematical equations describing the dependency are defined in <<math-model-exchange>>):
 
 .ModelStructure elements.
 [#table-model-structure-elements]

--- a/docs/2_4_common_co-simulation.adoc
+++ b/docs/2_4_common_co-simulation.adoc
@@ -179,7 +179,7 @@ Multiple event types and also <<outputClock>> ticks or interrupts can be support
 
 ==== Intermediate Variable Access [[intermediate-variable-access]]
 
-Intermediate variable access has three main uses:
+Intermediate variable access has three main use cases:
 
 - An FMU is able to produce valid output variables at intermediate points between two consecutive communication points.
 This is typically the result of an internal solver taking multiple integration steps between two consecutive communication points of a <<fmi3DoStep>>.
@@ -195,7 +195,7 @@ This can be either at temporary solver states or after successful integration st
 The computation requires intermediate output variables from the FMU.
 Whenever the internal solver in the FMU needs updated intermediate <<input>> variables, it provides the intermediate output variables for and requests the intermediate <<input>> variables from the master.
 
-Combinations of the above methods are also allowed.
+Combinations of the above use cases are also allowed.
 
 Access to intermediate variables enables several features such as:
 

--- a/docs/2_4_common_co-simulation.adoc
+++ b/docs/2_4_common_co-simulation.adoc
@@ -268,7 +268,7 @@ It is not allowed to call <<intermediateUpdate>> for a simulation time point pri
 [#figure-intermediate-variable-access]
 image::images/intermediatevariableaccess.svg[width=65%, align="center"]
 
-The following code example shows an implementation of <<fmi3CallbackIntermediateUpdate>> that uses intermediate variable access to record a set of variables at every internal solver step.
+The following code example shows an implementation of <<fmi3CallbackIntermediateUpdate>> that uses intermediate variable access to record a set of variables at every internal solver step:
 
 [source, c]
 ----

--- a/docs/3_1_model_exchange_math.adoc
+++ b/docs/3_1_model_exchange_math.adoc
@@ -12,9 +12,11 @@ The real part latexmath:[t_R] of this tuple is the <<independent>> variable of t
 In this phase latexmath:[t_I = 0].
 The integer part latexmath:[t_I] of this tuple is a counter to enumerate (and therefore distinguish) the events at the same continuous-time instant latexmath:[t_R].
 This time definition is also called "super-dense time" in literature, see, for example, <<LZ07>>.
-An ordering is defined on latexmath:[\mathbb{\text{T}}] that leads to the notation below.
+An ordering is defined on latexmath:[\mathbb{\text{T}}] that leads to the notation in <<table-model-exchange-math-notation>>.
 _[The notation latexmath:[^{\bullet}t] is from <<BCP10,BCP10>>, adapted from non-standard analysis to super-dense time, in order to precisely define the value from the previous event iteration.]_
 
+.Conventions and notation used.
+[#table-model-exchange-math-notation]
 [cols="1,7,4"]
 |====
 |Operation
@@ -107,7 +109,7 @@ All the following events are internal events:
 . At a predefined time instant latexmath:[t_i=(T_{\mathit{next}}(t_{i-1}, 0)] that was defined at the previous event instant latexmath:[t_{i-1}] by the FMU.
 Such an event is called time event.
 
-. At a time instant, where an event indicator latexmath:[z_j(t)] changes its domain from latexmath:[z_j > 0] to latexmath:[z_j \leq 0] or from latexmath:[z_j \leq 0] to latexmath:[z_j > 0] (see <<figure-events>> below).
+. At a time instant, where an event indicator latexmath:[z_j(t)] changes its domain from latexmath:[z_j > 0] to latexmath:[z_j \leq 0] or from latexmath:[z_j \leq 0] to latexmath:[z_j > 0] (see <<figure-events>>).
 More precisely: An event latexmath:[t = t_i] occurs at the smallest time instant "min t" with latexmath:[t>t_{i-1}] where "latexmath:[(z_j(t)>0) \neq (z_j(t_{i-1}) >0)]".
 Such an event is called state event.
 _[This definition is slightly different from the standard definition of state events: "_ latexmath:[z_j(t) \cdot z_j(t_{i-1}) \leq 0] _"._
@@ -164,13 +166,13 @@ Whether the <<output>> is a discrete-time or continuous-time variable is defined
 Variables of this type are defined with attribute <<causality>> = <<local>>, see <<definition-of-model-variables>>.
 
 |latexmath:[\mathbf{z}(t)]
-|A vector of floating point continuous-time variables representing the event indicators utilized to define state events, see below.
-For notational convenience, an event indicator is conceptually treated as a different type of variable as an <<output>> or a <<local>> variable for the mathematical description below.
+|A vector of floating point continuous-time variables representing the event indicators used to define state events (recall <<figure-events>>).
+For notational convenience, an event indicator is conceptually treated as a different type of variable as an <<output>> or a <<local>> variable for the mathematical description in <<table-math-model-exchange>>.
 In reality, event indicator is however part of the <<output,`outputs`>> latexmath:[\mathbf{y}] or the <<local>> variables latexmath:[\mathbf{w}] of an FMU.
 
 |latexmath:[\mathbf{x}_c(t)]
 |A vector of floating point continuous-time variables representing the continuous-time <<state,`states`>>.
-For notational convenience, a continuous-time <<state>> is conceptually treated as a different type of variable as an <<output>> or a <<local>> variable for the mathematical description below.
+For notational convenience, a continuous-time <<state>> is conceptually treated as a different type of variable as an <<output>> or a <<local>> variable for the mathematical description in <<table-math-model-exchange>>.
 In reality, a continuous-time <<state>> is however part of the <<output,`outputs`>> latexmath:[\mathbf{y}] or the <<local>> variables latexmath:[\mathbf{w}] of an FMU.
 
 |latexmath:[\mathbf{x}_d(t)] +

--- a/docs/3_1_model_exchange_math.adoc
+++ b/docs/3_1_model_exchange_math.adoc
@@ -352,7 +352,7 @@ latexmath:[\mathbf{f}_{\mathit{init}}, \mathbf{f}_{\mathit{sim}} \in C^0] (=cont
 
 _[Remark 1 - Calling Sequences:_
 
-_In the table above, for notational convenience in every mode one function call is defined to compute all output arguments from all inputs arguments._
+_In <<table-math-model-exchange>>, for notational convenience in every mode one function call is defined to compute all output arguments from all inputs arguments._
 _In reality, every scalar output argument can be computed by one `fmi3Get{VariableType}` function call._
 _Additionally, the output argument need not be a function of all input arguments, but of only a subset from it, as defined in the XML file under `<ModelStructure>`._
 _This is essential when FMUs are connected in a loop, as shown in <<figure-connected-fmus>>. For example, since_ latexmath:[y_{\mathit{2a}}] _depends only on_ latexmath:[u_{\mathit{1a}}] _, but not on_ latexmath:[u_{\mathit{1b}}]_, it is possible to call_ `fmi3Set{VariableType}` _to set_ latexmath:[u_{\mathit{1a}}] _, and then inquire_ latexmath:[y_{\mathit{2a}}] _with_ `fmi3Get{VariableType}` _without setting_ latexmath:[u_{\mathit{1b}}] _beforehand._
@@ -423,9 +423,9 @@ _This restriction is communicated to the environment of the FMU by the `ScalarVa
 
 _Remark 3 - Event Indicators / Freezing Relations:_
 
-_In the above table, vector_ latexmath:[\mathbf{r}] _is used to collect all relations together that are utilized in the event indicators_ latexmath:[\mathbf{z}] _._
+_In <<table-math-model-exchange>>, vector_ latexmath:[\mathbf{r}] _is used to collect all relations together that are utilized in the event indicators_ latexmath:[\mathbf{z}] _._
 _In *Continuous-Time Mode* all these relations are `frozen` and do not change during the evaluations in the respective mode._
-_This is indicated in the table above by computing_ latexmath:[\mathbf{r}] _when entering the *Continuous-Time Mode* and providing_ latexmath:[\mathbf{r}] _as (internal) input argument to the evaluation functions._
+_This is indicated in <<table-math-model-exchange>> by computing_ latexmath:[\mathbf{r}] _when entering the *Continuous-Time Mode* and providing_ latexmath:[\mathbf{r}] _as (internal) input argument to the evaluation functions._
 _Example:_
 
 _An equation of the form_
@@ -474,7 +474,7 @@ _Furthermore, a hysteresis should be added for the event indicators.]_
 
 An FMU is initialized in *Initialization Mode* with latexmath:[\mathbf{f}_{\mathit{init}}(\ldots)].
 The input arguments to this function consist of the <<input>> variables (= variables with <<causality>> = <<input>>), of the <<independent>> variable (= variable with <<causality>> = <<independent>>; usually the default value `time`), and of all variables that have a <<start>> value with (explicitly or implicitly) <<initial>> = <<exact>> in order to compute the continuous-time <<state,`states`>> and the output variables at the initial time latexmath:[t_0].
-In the above table, the variables with <<initial>> = <<exact>> are collected together in variable latexmath:[\mathbf{v}_{\mathit{initial=exact}}].
+In <<table-math-model-exchange>>, the variables with <<initial>> = <<exact>> are collected together in variable latexmath:[\mathbf{v}_{\mathit{initial=exact}}].
 For example, initialization might be defined by providing initial <<start>> values for the <<state,`states`>>, latexmath:[\mathbf{x}_{\mathit{c0}}], or by stating that the state derivatives are zero (latexmath:[\dot{\mathbf{x}}_{c} = \mathbf{0}]).
 Initialization is a difficult topic by itself, and it is required that an FMU solves a well-defined initialization problem inside the FMU in *Initialization Mode*. +
 After calling <<fmi3ExitInitializationMode>>, the FMU is implicitly in *Event Mode*, and all discrete-time and continuous-time variables at the initial time instant latexmath:[(t_R, 0)] can be calculated.
@@ -493,12 +493,12 @@ In this mode, systems of equations over connected FMUs might be solved (similari
 Once convergence is reached, <<fmi3NewDiscreteStates>> must be called to increment super-dense time (and conceptually update the discrete-time <<state,`states`>> defined internally in the FMU by latexmath:[^{\bullet}\mathbf{x}_d := \mathbf{x}_d]).
 Depending on the discrete-time model, a new event iteration might be needed (for example, because the FMU describes internally a state machine
 and transitions are still able to fire, but new <<input,`inputs`>> shall be taken into account). +
-The function calls in the table above describe precisely which input arguments are needed to compute the desired output argument(s).
+The function calls in <<table-math-model-exchange>> describe precisely which input arguments are needed to compute the desired output argument(s).
 There is no 1:1 mapping of these mathematical functions to C functions.
-Instead, all input arguments are set with `fmi3Set{VariableType}` C function calls, and then the result argument(s) can be determined with the C functions defined in the right column of the above table.
+Instead, all input arguments are set with `fmi3Set{VariableType}` C function calls, and then the result argument(s) can be determined with the C functions defined in the right column of <<table-math-model-exchange>>.
 This technique is discussed in detail in <<providing-independent-variables-and-re-initialization>>.
-_[In short: For efficiency reasons, all equations from the table above will usually be available in one (internal) C function._
+_[In short: For efficiency reasons, all equations from <<table-math-model-exchange>> will usually be available in one (internal) C function._
 _With the C functions described in the next sections, input arguments are copied into the internal model data structure only when their value has changed in the environment._
-_With the C functions in the right column of the table above, the internal function is called in such a way that only the minimum needed equations are evaluated._
+_With the C functions in the right column of <<table-math-model-exchange>>, the internal function is called in such a way that only the minimum needed equations are evaluated._
 _Hereby, variable values calculated from previous calls can be reused._
 _This technique is called "caching" and can significantly enhance the simulation efficiency of real-world models.]_

--- a/docs/3_1_model_exchange_math.adoc
+++ b/docs/3_1_model_exchange_math.adoc
@@ -68,7 +68,7 @@ Between events, variables are either <<continuous>> or do not change their value
 A variable is called discrete-time, if it changes its value only at an event instant.
 Otherwise the variable is called continuous-time.
 Only floating point variables can be continuous-time.
-The following variable indices are used to describe the timing behavior of the corresponding variable (for example, latexmath:[v_d] is a discrete-time variable).
+The following variable indices are used to describe the timing behavior of the corresponding variable (for example, latexmath:[v_d] is a discrete-time variable):
 
 [cols="1,10"]
 |====
@@ -244,7 +244,7 @@ For an output argument, calling `fmi3Get{VariableType}` on such a variable retur
 * [lime]#*green*#: Functions marked in [lime]#green# are special functions to enter or leave a mode.
 * [blue]#*blue*#: Equations and functions marked in [blue]#blue# define the actual computations to be performed in the respective mode.
 
-_[In the following table the setting of the super-dense time, (latexmath:[t_R], latexmath:[t_I]), is precisely described._
+_[In <<table-math-model-exchange>>, the setting of the super-dense time, (latexmath:[t_R], latexmath:[t_I]), is precisely described._
 _Tools will usually not have such a representation of time._
 _However, super-dense time defines precisely when a new "model evaluation" starts and therefore which variable values belong to the same "model evaluation" at the same (super-dense) time instant and should be stored together.]_
 

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -216,7 +216,7 @@ _Example:_ +
 
 ==== State Machine for Model Exchange [[state-machine-model-exchange]]
 
-Every implementation of the FMI must support calling sequences of the functions according to the following state chart:
+Every implementation of the FMI must support calling sequences of the functions according to the state chart in <<figure-model-exchange-state-machine>>.
 
 .Calling sequence of Model Exchange C functions in form of an UML 2.0 state machine.
 [#figure-model-exchange-state-machine]

--- a/docs/4_1_basic_co-simulation_math.adoc
+++ b/docs/4_1_basic_co-simulation_math.adoc
@@ -240,11 +240,10 @@ _The variables computed by_ latexmath:[\mathbf{f}_{\mathit{doStep}}] _can be inq
 In the particular context of multi-FMU architectures, significant co-simulation speed-up may be obtained if the master can avoid waiting until the end of the slowest FMU step integration.
 If an FMU prematurely stops its current step integration computation due to an unpredictable internal event before the normal end of the step calculation, all other concurrently running FMUs may be stopped as soon as possible in order to minimize the time needed for the Co-Simulation master to resynchronize all the FMUs at the same event time.
 
-In this context based on parallel multi-FMU calculations, the following figure illustrates different possibilities to synchronize FMUs at the same event time.
+In this context based on parallel multi-FMU calculations, <<figure-early-return>> illustrates different possibilities to synchronize FMUs at the same event time.
 
 .Different possibilities to synchronize parallel FMUs at the same event time.
-
-[caption="Figure 12: "]
+[[figure-early-return]]
 image::images/earlyReturnFigure.png[width=100%, align="center"]
 
 Each FMU starts integration from communication point latexmath:[t_{i}] to reach the next communication point latexmath:[t_{i+1}].

--- a/docs/4_1_basic_co-simulation_math.adoc
+++ b/docs/4_1_basic_co-simulation_math.adoc
@@ -225,7 +225,7 @@ latexmath:[\mathbf{f}_{\mathit{init}}, \mathbf{f}_{\mathit{out}} \in C^0] (=cont
 
 _[Remark - Calling Sequences:_
 
-_In the table above, for notational convenience in *Initialization Mode* one function call is defined to compute all output arguments from all inputs arguments._
+_In <<table-math-basic-co-simulation>>, for notational convenience in *Initialization Mode* one function call is defined to compute all output arguments from all inputs arguments._
 _In reality, every variable output argument is computed by one_ `fmi3Get{VariableType}` _function call._
 
 _In *Step Mode* the input arguments to_ latexmath:[\mathbf{f}_{\mathit{doStep}}] _are defined by calls to_ `fmi3Set{VariableType}` _functions._

--- a/docs/4_2_basic_co-simulation_api.adoc
+++ b/docs/4_2_basic_co-simulation_api.adoc
@@ -101,7 +101,7 @@ It depends on the capabilities of the FMU which argument constellations and call
 
 ==== State Machine for Basic Co-Simulation [[state-machine-basic-co-simulation]]
 
-The following state machine defines the supported calling sequences.
+The state machine in <<figure-co-simulation-state-machine>> defines the supported calling sequences.
 
 .Calling sequence of Co-Simulation C functions in form of an UML 2.0 state machine.
 [#figure-co-simulation-state-machine]

--- a/docs/4_3_basic_co-simulation_schema.adoc
+++ b/docs/4_3_basic_co-simulation_schema.adoc
@@ -81,10 +81,12 @@ If `needsExecutionTool = false`, the slave is completely contained inside the FM
 
 ==== Example XML Description File [[xml-example-co-simulation]]
 
-The example below is the same as shown in <<xml-example-model-exchange>> for a Model Exchange FMU.
+The <<xml-example-fmimodeldescription-cosimulation>> below is the same as shown in <<xml-example-model-exchange>> for a Model Exchange FMU.
 The only difference is the replacement of the element `<ModelExchange>` with the element `<BasicCoSimulation>` (with additional attributes) and the removal of <<local>> variables, which are associated with continuous <<state,`states`>> and their <<derivative,`derivatives`>>.
 The XML file may have the following content:
 
+.Example fmiModelDescription
+[#xml-example-fmimodeldescription-cosimulation]
 [source, xml]
 ----
 include::examples/co_simulation.xml[]

--- a/docs/5_2_hybrid_co-simulation_api.adoc
+++ b/docs/5_2_hybrid_co-simulation_api.adoc
@@ -115,11 +115,11 @@ _This might not be possible if an <<periodic,aperiodic>> <<inputClock>> of an FM
 
 ==== State Machine for Hybrid Co-Simulation [[state-machine-calling-sequence-clocked-co-simulation]]
 
-The following state machine defines the supported calling sequences.
+The state machine in <<figure-hybrid-co-simulation-state-machine>> defines the supported calling sequences.
 
 .Calling sequence of Hybrid Co-Simulation interface.
-image::images/state-machine-hybrid-co-simulation.svg[width=80%, align="center"]
 [#figure-hybrid-co-simulation-state-machine]
+image::images/state-machine-hybrid-co-simulation.svg[width=80%, align="center"]
 
 In this Co-Simulation interface the following functions must not be called: <<fmi3ActivateModelPartition>> including all functions that are specific to Model Exchange.
 
@@ -191,7 +191,7 @@ This state in Hybrid Co-Simulation does not differ from Basic Co-Simulation desc
 
 ===== State: Intermediate Update Mode
 
-This state in Hybrid Co-Simulation differ from Basic Co-Simulation described in <<state-step-mode-co-simulation>> as following:
+This state in Hybrid Co-Simulation differ from Basic Co-Simulation described in <<state-step-mode-co-simulation>> as follows:
 
 Allowed Function Calls::
 None.


### PR DESCRIPTION
This is work in progress to close https://github.com/modelica/fmi-standard/issues/795

So far, I've tried to make less ambiguous references like:
- "below"
- "above"
- "following"

I've also numbered a few figures and tables, and found other figure that had an absolute number on them (Fig 12 in the master branch).

The reason these "loose" references are so bad is that even if they start rigorous (for instance, when the word "below" actually shows up in the line right before the object referred to), as new content gets added, they become drift away from the object, until it becomes really hard to figure out what "below" refers to...

Still do to:
- [ ] Avoid absolute numbering (e.g., "Example 1", "Remark 1"). There are still remarks and examples in the text that have numbers after them. As far as a quick google search goes, there seems to be no easy way of having custom numbered environments (a la latex theorems) in adoc. So the best solution is to use anchors and good names for the labels (instead of numbers).
