### PR TITLE
Avoid nested attribute groups (fix #1033)

### DIFF
--- a/schema/fmi3AttributeGroups.xsd
+++ b/schema/fmi3AttributeGroups.xsd
@@ -34,7 +34,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------------
 		</xs:documentation>
 	</xs:annotation>
-	<xs:attributeGroup name="fmi3RealAttributes">
+	<xs:attributeGroup name="fmi3RealBaseAttributes">
 		<xs:attribute name="quantity" type="xs:normalizedString"/>
 		<xs:attribute name="unit" type="xs:normalizedString"/>
 		<xs:attribute name="displayUnit" type="xs:normalizedString"/>
@@ -42,57 +42,47 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		<xs:attribute name="unbounded" type="xs:boolean" default="false"/>
 	</xs:attributeGroup>
 	<xs:attributeGroup name="fmi3Float64Attributes">
-		<xs:attributeGroup ref="fmi3RealAttributes"/>
 		<xs:attribute name="min" type="xs:double"/>
 		<xs:attribute name="max" type="xs:double"/>
 		<xs:attribute name="nominal" type="xs:double"/>
 	</xs:attributeGroup>
 	<xs:attributeGroup name="fmi3Float32Attributes">
-		<xs:attributeGroup ref="fmi3RealAttributes"/>
 		<xs:attribute name="min" type="xs:float"/>
 		<xs:attribute name="max" type="xs:float"/>
 		<xs:attribute name="nominal" type="xs:float"/>
 	</xs:attributeGroup>
-	<xs:attributeGroup name="fmi3IntegerAttributes">
+	<xs:attributeGroup name="fmi3IntegerBaseAttributes">
 		<xs:attribute name="quantity" type="xs:normalizedString"/>
 	</xs:attributeGroup>
 	<xs:attributeGroup name="fmi3Int8Attributes">
-		<xs:attributeGroup ref="fmi3IntegerAttributes"/>
 		<xs:attribute name="min" type="xs:byte"/>
 		<xs:attribute name="max" type="xs:byte"/>
 	</xs:attributeGroup>
 	<xs:attributeGroup name="fmi3UInt8Attributes">
-		<xs:attributeGroup ref="fmi3IntegerAttributes"/>
 		<xs:attribute name="min" type="xs:unsignedByte"/>
 		<xs:attribute name="max" type="xs:unsignedByte"/>
 	</xs:attributeGroup>
 	<xs:attributeGroup name="fmi3Int16Attributes">
-		<xs:attributeGroup ref="fmi3IntegerAttributes"/>
 		<xs:attribute name="min" type="xs:short"/>
 		<xs:attribute name="max" type="xs:short"/>
 	</xs:attributeGroup>
 	<xs:attributeGroup name="fmi3UInt16Attributes">
-		<xs:attributeGroup ref="fmi3IntegerAttributes"/>
 		<xs:attribute name="min" type="xs:unsignedShort"/>
 		<xs:attribute name="max" type="xs:unsignedShort"/>
 	</xs:attributeGroup>
 	<xs:attributeGroup name="fmi3Int32Attributes">
-		<xs:attributeGroup ref="fmi3IntegerAttributes"/>
 		<xs:attribute name="min" type="xs:int"/>
 		<xs:attribute name="max" type="xs:int"/>
 	</xs:attributeGroup>
 	<xs:attributeGroup name="fmi3UInt32Attributes">
-		<xs:attributeGroup ref="fmi3IntegerAttributes"/>
 		<xs:attribute name="min" type="xs:unsignedInt"/>
 		<xs:attribute name="max" type="xs:unsignedInt"/>
 	</xs:attributeGroup>
 	<xs:attributeGroup name="fmi3Int64Attributes">
-		<xs:attributeGroup ref="fmi3IntegerAttributes"/>
 		<xs:attribute name="min" type="xs:long"/>
 		<xs:attribute name="max" type="xs:long"/>
 	</xs:attributeGroup>
 	<xs:attributeGroup name="fmi3UInt64Attributes">
-		<xs:attributeGroup ref="fmi3IntegerAttributes"/>
 		<xs:attribute name="min" type="xs:unsignedLong"/>
 		<xs:attribute name="max" type="xs:unsignedLong"/>
 	</xs:attributeGroup>

--- a/schema/fmi3Type.xsd
+++ b/schema/fmi3Type.xsd
@@ -51,6 +51,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:complexType>
 					<xs:complexContent>
 						<xs:extension base="fmi3TypeDefinitionBase">
+							<xs:attributeGroup ref="fmi3RealBaseAttributes"/>
 							<xs:attributeGroup ref="fmi3Float32Attributes"/>
 						</xs:extension>
 					</xs:complexContent>
@@ -60,6 +61,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:complexType>
 					<xs:complexContent>
 						<xs:extension base="fmi3TypeDefinitionBase">
+							<xs:attributeGroup ref="fmi3RealBaseAttributes"/>
 							<xs:attributeGroup ref="fmi3Float64Attributes"/>
 						</xs:extension>
 					</xs:complexContent>
@@ -69,6 +71,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:complexType>
 					<xs:complexContent>
 						<xs:extension base="fmi3TypeDefinitionBase">
+							<xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
 							<xs:attributeGroup ref="fmi3Int8Attributes"/>
 						</xs:extension>
 					</xs:complexContent>
@@ -78,6 +81,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:complexType>
 					<xs:complexContent>
 						<xs:extension base="fmi3TypeDefinitionBase">
+							<xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
 							<xs:attributeGroup ref="fmi3UInt8Attributes"/>
 						</xs:extension>
 					</xs:complexContent>
@@ -87,6 +91,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:complexType>
 					<xs:complexContent>
 						<xs:extension base="fmi3TypeDefinitionBase">
+							<xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
 							<xs:attributeGroup ref="fmi3Int16Attributes"/>
 						</xs:extension>
 					</xs:complexContent>
@@ -96,6 +101,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:complexType>
 					<xs:complexContent>
 						<xs:extension base="fmi3TypeDefinitionBase">
+							<xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
 							<xs:attributeGroup ref="fmi3UInt16Attributes"/>
 						</xs:extension>
 					</xs:complexContent>
@@ -105,6 +111,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:complexType>
 					<xs:complexContent>
 						<xs:extension base="fmi3TypeDefinitionBase">
+							<xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
 							<xs:attributeGroup ref="fmi3Int32Attributes"/>
 						</xs:extension>
 					</xs:complexContent>
@@ -114,6 +121,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:complexType>
 					<xs:complexContent>
 						<xs:extension base="fmi3TypeDefinitionBase">
+							<xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
 							<xs:attributeGroup ref="fmi3UInt32Attributes"/>
 						</xs:extension>
 					</xs:complexContent>
@@ -123,6 +131,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:complexType>
 					<xs:complexContent>
 						<xs:extension base="fmi3TypeDefinitionBase">
+							<xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
 							<xs:attributeGroup ref="fmi3Int64Attributes"/>
 						</xs:extension>
 					</xs:complexContent>
@@ -132,6 +141,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:complexType>
 					<xs:complexContent>
 						<xs:extension base="fmi3TypeDefinitionBase">
+							<xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
 							<xs:attributeGroup ref="fmi3UInt64Attributes"/>
 						</xs:extension>
 					</xs:complexContent>

--- a/schema/fmi3Variable.xsd
+++ b/schema/fmi3Variable.xsd
@@ -42,6 +42,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:sequence>
 					<xs:element name="Alias" type="fmi3FloatVariableAlias" minOccurs="0" maxOccurs="unbounded"/>
 				</xs:sequence>
+				<xs:attributeGroup ref="fmi3RealBaseAttributes"/>
 				<xs:attributeGroup ref="fmi3Float64Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
@@ -58,6 +59,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:sequence>
 					<xs:element name="Alias" type="fmi3FloatVariableAlias" minOccurs="0" maxOccurs="unbounded"/>
 				</xs:sequence>
+				<xs:attributeGroup ref="fmi3RealBaseAttributes"/>
 				<xs:attributeGroup ref="fmi3Float32Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
@@ -74,6 +76,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:sequence>
 					<xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
 				</xs:sequence>
+				<xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
 				<xs:attributeGroup ref="fmi3Int8Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
@@ -89,6 +92,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:sequence>
 					<xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
 				</xs:sequence>
+				<xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
 				<xs:attributeGroup ref="fmi3UInt8Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
@@ -104,6 +108,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:sequence>
 					<xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
 				</xs:sequence>
+				<xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
 				<xs:attributeGroup ref="fmi3Int16Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
@@ -119,6 +124,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:sequence>
 					<xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
 				</xs:sequence>
+				<xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
 				<xs:attributeGroup ref="fmi3UInt16Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
@@ -134,6 +140,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:sequence>
 					<xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
 				</xs:sequence>
+				<xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
 				<xs:attributeGroup ref="fmi3Int32Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
@@ -149,6 +156,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:sequence>
 					<xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
 				</xs:sequence>
+				<xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
 				<xs:attributeGroup ref="fmi3UInt32Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
@@ -164,6 +172,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:sequence>
 					<xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
 				</xs:sequence>
+				<xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
 				<xs:attributeGroup ref="fmi3Int64Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>
@@ -179,6 +188,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:sequence>
 					<xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
 				</xs:sequence>
+				<xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
 				<xs:attributeGroup ref="fmi3UInt64Attributes"/>
 				<xs:attribute name="start">
 					<xs:simpleType>


### PR DESCRIPTION
Resolves #1033 

This makes the schema more useful to various tools that are not able to deal with nested attributeGroups in sane ways. It is a schema internal change and does not affect XML instances.