### PR TITLE
Issue 1005: Clarify the meaning of master clock.

### DIFF
--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1313,9 +1313,9 @@ Examples: (a) automatic tests of FMUs are performed, and the FMU is tested by pr
 (b) For a Model Exchange FMU, the FMU might be part of an algebraic loop.
 If the <<input>> variable is iteration variable of this algebraic loop, then initialization starts with its <<start>> value.]_
 
-If <<causality>> = <<input>> the value for <<initial>> has to be set to <<exact>> and it is required to provide a <<start>> value for describing the expected initial condition of master <<clock,`clocks`>> for that FMU.
-If an <<inputClock>> has `fmi3True` as an <<start>> value the master should activate the <<clock>> the first time it enters *Event Mode*.
-The master can nevertheless choose different <<start>> values if it is not possible to fulfill the conditions in a simulation setup.
+If <<causality>> = <<input>> and <<variability>> = <<clock>>, that is, the variable is an <<inputClock>>, it is required to provide a <<start>> value for describing the expected initial condition of the <<inputClock>> for that FMU.
+If an <<inputClock>> has `fmi3True` as a <<start>> value, the environment should activate the <<clock>> the first time it enters *Event Mode*.
+The environment can nevertheless choose different <<start>> values if it is not possible to fulfill the conditions in a simulation setup.
 
 If <<causality>> = <<output>> the <<initial>> attribute value is set to <<calculated>> and no <<start>> value is provided.
 


### PR DESCRIPTION
Resolves https://github.com/modelica/fmi-standard/issues/1005

- The master here is interpreted as an input clock (we think that's the intention)
- We removed the sentence "If <<causality>> = <<input>> the value for <<initial>> has to be set to <<exact>>" because the same information is specified in the table below.

The fixes are done by me, @IZacharias , and @MBlesken .