### PR TITLE
make independent variable mandatory in xml and add references to indepent 

### DIFF
--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -460,12 +460,12 @@ In case the FMU utilizes a numerical integrator with variable step size and erro
 An FMU for Co-Simulation might ignore this argument.
 
 * `startTime` and `stopTime` can be used to check whether the model is valid within the given boundaries, or to allocate the necessary memory for storing results.
-`startTime` is the <<fixed>> <<initial>> value of the <<independent>> variable.
+`startTime` is the <<fixed>> <<initial>> value of the <<independent>> variable end inherits its unit.
 +
 _[It is defined with <<causality>> = <<independent>> in the <<modelDescription.xml>>._
 _If the <<independent>> variable is `time`, `startTime` is the starting time of initialization.]_
 
-* If `stopTimeDefined == fmi3True`, then `stopTime` is the final value of the <<independent>> variable.
+* If `stopTimeDefined == fmi3True`, then `stopTime` is the final value of the <<independent>> variable end inherits its unit.
 If the environment tries to compute past `stopTime`, the FMU has to return <<fmi3Error,`fmi3Status == fmi3Error`>>.
 If `stopTimeDefined == fmi3False`, then no final value of the <<independent>> variable is defined and argument `stopTime` is meaningless.
 +
@@ -995,8 +995,7 @@ Each state derivative variable listed as elements `<ModelStructure><Derivative>`
 
 Details are given in the description of element <<dependencies>> in <<ModelStructure>>.
 _[For example continuous-time <<input,`inputs`>> in *Continuous-Time Mode*._
-_If a variable with <<causality>> = <<independent>> is explicitly defined under `<ModelVariables>`, a directional derivative with respect to this variable can be computed._
-_If such a variable is not defined, the directional derivative with respect to the <<independent>> variable cannot be calculated]._
+_A directional derivative with respect to this variable can be computed.]._
 
 * latexmath:[{\mathbf{v}_{\mathit{rest}}}] is the set of <<input>> variables of function *h* that either changes its value in the actual state but are non-floating point variables, or do not change their values in this state, but change their values in other states _[for example, discrete-time <<input,`inputs`>> in *Continuous-Time Mode*]_.
 

--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -460,12 +460,12 @@ In case the FMU utilizes a numerical integrator with variable step size and erro
 An FMU for Co-Simulation might ignore this argument.
 
 * `startTime` and `stopTime` can be used to check whether the model is valid within the given boundaries, or to allocate the necessary memory for storing results.
-`startTime` is the <<fixed>> <<initial>> value of the <<independent>> variable end inherits its unit.
+`startTime` is the <<fixed>> <<initial>> value of the <<independent>> variable and inherits its unit.
 +
 _[It is defined with <<causality>> = <<independent>> in the <<modelDescription.xml>>._
 _If the <<independent>> variable is `time`, `startTime` is the starting time of initialization.]_
 
-* If `stopTimeDefined == fmi3True`, then `stopTime` is the final value of the <<independent>> variable end inherits its unit.
+* If `stopTimeDefined == fmi3True`, then `stopTime` is the final value of the <<independent>> variable and inherits its unit.
 If the environment tries to compute past `stopTime`, the FMU has to return <<fmi3Error,`fmi3Status == fmi3Error`>>.
 If `stopTimeDefined == fmi3False`, then no final value of the <<independent>> variable is defined and argument `stopTime` is meaningless.
 +

--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -995,7 +995,7 @@ Each state derivative variable listed as elements `<ModelStructure><Derivative>`
 
 Details are given in the description of element <<dependencies>> in <<ModelStructure>>.
 _[For example continuous-time <<input,`inputs`>> in *Continuous-Time Mode*._
-_A directional derivative with respect to this variable can be computed.]._
+_A directional derivative with respect to the independent variable can be computed.]._
 
 * latexmath:[{\mathbf{v}_{\mathit{rest}}}] is the set of <<input>> variables of function *h* that either changes its value in the actual state but are non-floating point variables, or do not change their values in this state, but change their values in other states _[for example, discrete-time <<input,`inputs`>> in *Continuous-Time Mode*]_.
 

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1219,11 +1219,11 @@ The algebraic relationship to the <<input,`inputs`>> is defined via the <<depend
 It is not allowed to use the variable value in another model or slave.
 
 [[independent,`independent`]]
-`= independent`: The independent variable (usually `time` _[but could be also for example `angle`]_).
+`= independent`: The independent variable (usually `time` _[but could also be, for example, `angle`]_).
 All variables are a function of this <<independent>> variable.
 <<variability>> must be <<continuous>>.
-Exactly one variable of an FMU *MUST* be defined as <<independent>>.
-If the unit for the independent variable is not defined it is implicitely`unit = s`.
+Exactly one variable of an FMU must be defined as <<independent>>.
+If the unit for the independent variable is not defined, it is implicitely`unit = s`.
 If one variable is defined as <<independent>>, it must be defined with a floating point type without a <<start>> attribute.
 It is not allowed to call function `fmi3Set{VariableType}` on an <<independent>> variable.
 Instead, its value is initialized with <<fmi3EnterInitializationMode>> and after initialization set by <<fmi3SetTime>> for Model Exchange and by arguments <<currentCommunicationPoint>> and <<communicationStepSize>> of <<fmi3DoStep>> for Co-Simulation FMUs.

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1219,11 +1219,11 @@ The algebraic relationship to the <<input,`inputs`>> is defined via the <<depend
 It is not allowed to use the variable value in another model or slave.
 
 [[independent,`independent`]]
-`= independent`: The independent variable (usually `time`).
+`= independent`: The independent variable (usually `time` _[but could be also for example `angle`]_).
 All variables are a function of this <<independent>> variable.
 <<variability>> must be <<continuous>>.
-At most one variable of an FMU can be defined as <<independent>>.
-If no variable is defined as <<independent>>, it is implicitly present with `name = time` and `unit = s`.
+Exactly one variable of an FMU *MUST* be defined as <<independent>>.
+If the unit for the independent variable is not defined it is implicitely`unit = s`.
 If one variable is defined as <<independent>>, it must be defined with a floating point type without a <<start>> attribute.
 It is not allowed to call function `fmi3Set{VariableType}` on an <<independent>> variable.
 Instead, its value is initialized with <<fmi3EnterInitializationMode>> and after initialization set by <<fmi3SetTime>> for Model Exchange and by arguments <<currentCommunicationPoint>> and <<communicationStepSize>> of <<fmi3DoStep>> for Co-Simulation FMUs.
@@ -1942,7 +1942,6 @@ Knowns latexmath:[{\mathbf{v}_{\mathit{known}}}] in *Event Mode* and *Continuous
 - continuous-time states
 
 - <<independent>> variable (usually time; <<causality>> = <<independent>>).
-If an <<independent>> variable is not explicitly defined under variables, it is assumed that the unknown depends explicitly on the <<independent>> variable.
 
 _[<<parameter,`parameters`>> and <<tunable>> <<parameter,`parameters`>> must not be listed as knowns in this mode. This may change in a future FMI version which implies the possibility to calculate derivatives with respect to parameters.]_
 
@@ -1953,7 +1952,6 @@ _[<<parameter,`parameters`>> and <<tunable>> <<parameter,`parameters`>> must not
 - variables with <<initial>> = <<exact>> _[for example, <<parameter,`parameters`>> or initial <<state,`states`>>]_
 
 - <<independent>> variable (usually time; <<causality>> = <<independent>>).
-If an <<independent>> variable is not explicitly defined under variables, it is assumed that the unknown depends explicitly on the <<independent>> variable.
 
 For Co-Simulation, if the capability flag `providesDirectionalDerivatives` has a value of `false`, then <<dependencies>> does not list the dependency on continuous-time.
 In other words, the respective partial derivatives cannot be computed.

--- a/docs/2_4_common_co-simulation.adoc
+++ b/docs/2_4_common_co-simulation.adoc
@@ -245,10 +245,10 @@ include::../headers/fmi3FunctionTypes.h[tag=CallbackIntermediateUpdate]
 ----
 
 [[intermediateUpdateTime,`intermediateUpdateTime`]]
-* <<intermediateUpdateTime>> is the internal simulation time of the FMU at which the callback has been called.
+* <<intermediateUpdateTime>> is the internal value of the <<independent>> variable _[typically simulation time]_ of the FMU at which the callback has been called.
 If an event happens or an <<outputClock>> ticks, <<intermediateUpdateTime>> is the time of event or <<outputClock>> tick.
 If the FMU returns with <<earlyReturn,`earlyReturn == fmi3True`>> from <<fmi3DoStep>> then <<intermediateUpdateTime>> is the internal simulation time of the FMU of the last <<fmi3CallbackIntermediateUpdate>> call that signaled <<canReturnEarly,`canReturnEarly == fmi3True`>>.
-<<intermediateUpdateTime>> is also the time of intermediate steps of the internal FMU solver.
+<<intermediateUpdateTime>> is also the value of the <<independent variable>> of intermediate steps of the internal FMU solver.
 The FMU must not call the callback function <<fmi3CallbackIntermediateUpdate>> with an <<intermediateUpdateTime>> that is smaller than the <<intermediateUpdateTime>> given in a previous call of <<fmi3CallbackIntermediateUpdate>> with `intermediateStepFinished == fmi3True`.
 
 In case of Hybrid Co-Simulation, the following two `fmi3Boolean` function arguments give reasons for the <<fmi3CallbackIntermediateUpdate>> call.

--- a/docs/3_1_model_exchange_math.adoc
+++ b/docs/3_1_model_exchange_math.adoc
@@ -7,7 +7,7 @@ In this version of the interface, ordinary differential equations in state-space
 Algebraic equation systems might be contained inside the FMU.
 Also, the FMU might consist of discrete-time equations only, for example, describing a sampled-data controller.
 
-The <<independent>> variable time latexmath:[t \in \mathbb{T}] is a tuple latexmath:[t = (t_R,t_I)], where latexmath:[t_R \in \mathbb{R},\ t_{I} \in \mathbb{N} = \{0, 1, 2, \ldots\}].
+The <<independent>> variable latexmath:[t \in \mathbb{T}] _[typically: time]_ is a tuple latexmath:[t = (t_R,t_I)], where latexmath:[t_R \in \mathbb{R},\ t_{I} \in \mathbb{N} = \{0, 1, 2, \ldots\}].
 The real part latexmath:[t_R] of this tuple is the <<independent>> variable of the FMU for describing the continuous-time behavior of the model between events.
 In this phase latexmath:[t_I = 0].
 The integer part latexmath:[t_I] of this tuple is a counter to enumerate (and therefore distinguish) the events at the same continuous-time instant latexmath:[t_R].
@@ -134,7 +134,7 @@ An FMI Model-Exchange model is described by the following variables:
 |Description
 
 |latexmath:[t]
-|<<independent>> variable time latexmath:[\in \mathbb{T}].
+|<<independent>> variable _[typically: time]_ latexmath:[\in \mathbb{T}].
 (Variable defined with <<causality>> = <<independent>>).
 
 |latexmath:[\mathbf{v}]
@@ -312,7 +312,7 @@ latexmath:[\qquad \qquad T_{\mathit{next}}=T_{\mathit{next}}(\mathbf{x}_c,{}^\bu
 [blue]#latexmath:[\qquad {}^\bullet\mathbf{x}_d:=\mathbf{x}_d]#
 |`[lime]#fmi3NewDiscreteStates#`
 
-|Set <<independent>> variable time latexmath:[t_i := (T_{\mathit{next}},0)]
+|Set <<independent>> variable _[typically: time]_ latexmath:[t_i := (T_{\mathit{next}},0)]
 |<<fmi3SetTime>> + (if no continuous-time equations)
 
 2+|Equations during *Continuous-Time Mode*
@@ -324,7 +324,7 @@ latexmath:[\qquad \qquad T_{\mathit{next}}=T_{\mathit{next}}(\mathbf{x}_c,{}^\bu
 [lime]#latexmath:[\qquad \textbf{x}_d, \textbf{w}_d \qquad \textrm{//all discrete-time variables}]# +
 |`[lime]#fmi3EnterContinuousTimeMode#`
 
-|Set <<independent>> variable time latexmath:[t(>t_{\mathit{enter  mode}}): t:=(t_R, 0)]
+|Set <<independent>> variable _[typically: time]_ latexmath:[t(>t_{\mathit{enter  mode}}): t:=(t_R, 0)]
 |<<fmi3SetTime>>
 
 |Set continuous-time <<input,`inputs`>> latexmath:[\mathbf{u}_{c}(t)]
@@ -474,7 +474,7 @@ _Furthermore, a hysteresis should be added for the event indicators.]_
 
 An FMU is initialized in *Initialization Mode* with latexmath:[\mathbf{f}_{\mathit{init}}(\ldots)].
 
-The input arguments to this function consist of the <<input>> variables (= variables with <<causality>> = <<input>>), of the <<independent>> variable (= variable with <<causality>> = <<independent>>; usually the default value `time`), and of all variables that have a <<start>> value with <<initial>> = <<exact>> in order to compute the continuous-time <<state,`states`>> and the output variables at the initial time latexmath:[t_0].
+The input arguments to this function consist of the <<input>> variables (= variables with <<causality>> = <<input>>), of the <<independent>> variable (= variable with <<causality>> = <<independent>> _[typically: time]_), and of all variables that have a <<start>> value with <<initial>> = <<exact>> in order to compute the continuous-time <<state,`states`>> and the output variables at the initial time latexmath:[t_0].
 In <<table-math-model-exchange>>, the variables with <<initial>> = <<exact>> are collected together in variable latexmath:[\mathbf{v}_{\mathit{initial=exact}}].
 
 For example, initialization might be defined by providing initial <<start>> values for the <<state,`states`>>, latexmath:[\mathbf{x}_{\mathit{c0}}], or by stating that the state derivatives are zero (latexmath:[\dot{\mathbf{x}}_{c} = \mathbf{0}]).

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -23,7 +23,7 @@ This is unproblematic for time and states, but is more involved for <<parameter,
 include::../headers/fmi3FunctionTypes.h[tags=SetTime]
 ----
 
-Set a new time instant and re-initialize caching of variables that depend on time, provided the newly provided time value is different to the previously set time value (variables that depend solely on <<constant,`constants`>> or <<parameter,`parameters`>> need not to be newly computed in the sequel, but the previously computed values can be reused).
+Set a new value for the independent variabl (typically a time instant) and re-initialize caching of variables that depend on time, provided the newly provided time value is different to the previously set time value (variables that depend solely on <<constant,`constants`>> or <<parameter,`parameters`>> need not to be newly computed in the sequel, but the previously computed values can be reused).
 
 [[fmi3SetContinuousStates,`fmi3SetContinuousStates`]]
 [source, C]
@@ -177,7 +177,7 @@ include::../headers/fmi3FunctionTypes.h[tags=GetDerivatives]
 include::../headers/fmi3FunctionTypes.h[tags=GetEventIndicators]
 ----
 
-Compute state derivatives and event indicators at the current time instant and for the current <<state,`states`>>.
+Compute state derivatives (that is derivatives w.r.t. to the <<independent variable>> also taking into account its unit) and event indicators at the current instant of the <<independent>> variable _[typically: time]_ and for the current <<state,`states`>>.
 Note that <<fmi3Discard,`fmi3Status == fmi3Discard`>> is possible for both functions.
 
 The <<derivative,`derivatives`>> are returned as a vector with `nContinuousStates` elements.

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -23,7 +23,7 @@ This is unproblematic for time and states, but is more involved for <<parameter,
 include::../headers/fmi3FunctionTypes.h[tags=SetTime]
 ----
 
-Set a new value for the independent variabl (typically a time instant) and re-initialize caching of variables that depend on time, provided the newly provided time value is different to the previously set time value (variables that depend solely on <<constant,`constants`>> or <<parameter,`parameters`>> need not to be newly computed in the sequel, but the previously computed values can be reused).
+Set a new value for the independent variable (typically a time instant) and re-initialize caching of variables that depend on time, provided the newly provided time value is different to the previously set time value (variables that depend solely on <<constant,`constants`>> or <<parameter,`parameters`>> need not to be newly computed in the sequel, but the previously computed values can be reused).
 
 [[fmi3SetContinuousStates,`fmi3SetContinuousStates`]]
 [source, C]

--- a/docs/4_1_basic_co-simulation_math.adoc
+++ b/docs/4_1_basic_co-simulation_math.adoc
@@ -28,7 +28,7 @@ An FMI Co-Simulation model is described by the following variables:
 |Description
 
 |latexmath:[t]
-|Independent variable time latexmath:[\in \mathbb{R}].
+|Independent variable _[typically: time]_ latexmath:[\in \mathbb{R}].
 (Variable defined with <<causality>> = <<independent>>). +
 The i-th communication point is denoted as latexmath:[t = tc_i] +
 The communication step size is denoted as latexmath:[hc_i = tc_{i+1} - tc_i] +

--- a/docs/4_2_basic_co-simulation_api.adoc
+++ b/docs/4_2_basic_co-simulation_api.adoc
@@ -62,10 +62,10 @@ include::../headers/fmi3FunctionTypes.h[tags=DoStep]
 ----
 
 [[currentCommunicationPoint,`currentCommunicationPoint`]]
-* `currentCommunicationPoint` is the current communication point of the master (latexmath:[tc_i]) and
+* `currentCommunicationPoint` is the current communication point of the master (latexmath:[tc_i]) with the unit of the <<independent>> variable and
 
 [[communicationStepSize,`communicationStepSize`]]
-* `communicationStepSize` is the communication step size (latexmath:[hc_i]). `comunicationStepSize` must be latexmath:[> 0.0].
+* `communicationStepSize` is the communication step size (latexmath:[hc_i]) with the unit of the <<independent>> variable. `comunicationStepSize` must be latexmath:[> 0.0].
 
 [[noSetFMUStatePriorToCurrentPoint,`noSetFMUStatePriorToCurrentPoint`]]
 * `noSetFMUStatePriorToCurrentPoint == fmi3True` if `fmi3SetFMUState` will no longer be called for time instants prior to <<currentCommunicationPoint>> in this simulation run. _[The slave can use this flag to flush a result buffer]_

--- a/docs/6_2_scheduled_co-simulation_api.adoc
+++ b/docs/6_2_scheduled_co-simulation_api.adoc
@@ -51,7 +51,7 @@ For a scalar <<clock>> variable this must be 0; for array <<clock>> variables th
 Using the element index 0 means all elements of the <<clock>> variable.
 (Note: If an array has more than one dimension the indices are serialized in the same order as defined for values).
 
-- `fmi3Float64 activationTime`: simulation (i.e. virtual) time of the <<clock>> tick
+- `fmi3Float64 activationTime`: value of the <<independent>> variable of the <<clock>> tick _[typically:  simulation (i.e. virtual) time]_
 
 Scheduling of <<fmi3ActivateModelPartition>> calls for each FMU is done by the simulation master.
 Calls are based on ticks of <<periodic>> or <<periodic,aperiodic>> <<inputClock,`input clocks`>>.

--- a/docs/8___appendix.adoc
+++ b/docs/8___appendix.adoc
@@ -149,7 +149,7 @@ TODO: FMU also goes by "slave". When "slave" is used, the intent is to focus on 
 |TODO
 
 |_independent variable_
-|The numerical algorithm to solve differential equations.
+|All variables are a function of this <<independent>> variable, typically time.
 
 |_inline integration_
 |TODO


### PR DESCRIPTION
Resolves #808 

Taking into account notes from the Berlin FMI Design meeting https://github.com/modelica/fmi-design/blob/master/Meetings/2020-02-25-FMI-Design-Berlin/minutes.adoc#detailed-discussions-and-polls 

Please review, comment and improve (maintainers are welcome to directly commit)

Do we need a change in an xsd making sure to have exactly one independent variable?
