### PR TITLE
Replace tc_i with t_o and hc_i with h_i

### DIFF
--- a/docs/4_1_co-simulation_math.adoc
+++ b/docs/4_1_co-simulation_math.adoc
@@ -30,10 +30,10 @@ An FMI Co-Simulation model is described by the following variables:
 |latexmath:[t]
 |Independent variable _[typically: time]_ latexmath:[\in \mathbb{R}].
 (Variable defined with <<causality>> = <<independent>>). +
-The i-th communication point is denoted as latexmath:[t = tc_i] +
-The communication step size is denoted as latexmath:[hc_i = tc_{i+1} - tc_i] +
-Intermediate time points are denoted as latexmath:[t \in (tc_i, tc_{i+1})] where the FMU exchanges information with the master. +
-An early return at time  latexmath:[tc^*_{i+1} \in (tc_i, tc_{i+1})]  corresponds to a redefinition of latexmath:[hc^*_i = tc^*_{i+1} - tc_{i}] and latexmath:[hc_i] to a smaller value during the current timestep.
+The i-th communication point is denoted as latexmath:[t = t_i] +
+The communication step size is denoted as latexmath:[h_i = t_{i+1} - t_i] +
+Intermediate time points are denoted as latexmath:[t \in (t_i, t_{i+1})] where the FMU exchanges information with the master. +
+An early return at time  latexmath:[t^*_{i+1} \in (t_i, t_{i+1})]  corresponds to a redefinition of latexmath:[h^*_i = t^*_{i+1} - t_{i}] and latexmath:[h_i] to a smaller value during the current timestep.
 
 |latexmath:[\mathbf{v}]
 | A vector of all exposed variables (all variables defined in element `<ModelVariables>`, see <<definition-of-model-variables>>).
@@ -47,7 +47,7 @@ These are <<parameter,`parameters`>> and <<start>> values of other variables, su
 The symbol without a subscript references <<parameter,`parameters`>> (variables with <<causality>> = <<parameter>>).
 Dependent <<parameter,`parameters`>> (variables with <<causality>> = <<calculatedParameter>>) are denoted as latexmath:[\mathbf{p}_{\mathit{calculated}}] and <<tunable>> <<parameter,`parameters`>> (variables with <<causality>> = <<parameter>> and <<variability>> = <<tunable>>) are denoted as latexmath:[\mathbf{p}_{\mathit{tune}}].
 
-|latexmath:[\mathbf{u}(tc_i)]
+|latexmath:[\mathbf{u}(t_i)]
 |Input variables.
 The values of these variables are defined outside of the model.
 Variables of this type are defined with attribute <<causality>> = <<input>>.
@@ -56,23 +56,23 @@ Whether the <<input>> is a discrete-time or continuous-time variable is defined 
 |latexmath:[\mathbf{u}_{i, IU}(t)]
 |Intermediate input variables corresponding to the input variables for intermediate update ("IU").
 The values of these variables are defined outside of the model.
-latexmath:[\mathbf{u}_{i, IU}] are functions defined on the interval latexmath:[ [tc_i, tc_{i+1}] ] with latexmath:[\mathbf{u}_{i, IU}(tc_i)=\mathbf{u}(tc_i)]. +
-With the optional flag <<recommendedIntermediateInputSmoothness>> FMU can signal to the master that best convergence rates can be achieved if the these functions are of the smoothness (latexmath:[C^{k}([ tc_i, tc_{i+1}]), that is k-time continuously differentiable, with latexmath:[C^{0}] meaning continuous.
+latexmath:[\mathbf{u}_{i, IU}] are functions defined on the interval latexmath:[ [t_i, t_{i+1}] ] with latexmath:[\mathbf{u}_{i, IU}(t_i)=\mathbf{u}(t_i)]. +
+With the optional flag <<recommendedIntermediateInputSmoothness>> FMU can signal to the master that best convergence rates can be achieved if the these functions are of the smoothness (latexmath:[C^{k}([ t_i, t_{i+1}]), that is k-time continuously differentiable, with latexmath:[C^{0}] meaning continuous.
 
-|latexmath:[\mathbf{y}(tc_{i+1})], latexmath:[\mathbf{y^{(j)}}(tc_{i+1})],
-|Output variables latexmath:[\mathbf{y}(tc_{i+1})].
+|latexmath:[\mathbf{y}(t_{i+1})], latexmath:[\mathbf{y^{(j)}}(t_{i+1})],
+|Output variables latexmath:[\mathbf{y}(t_{i+1})].
 The values of these variables are computed in the FMU and they are designed to be used in a model connection at communication points.
 So output variables might be used in the environment as input values to other FMUs or other submodels.
 Variables of this type are defined with attribute <<causality>> = <<output>>.
 Via attribute <<variability>> = <<discrete>> or <<continuous>> it is defined whether the <<output>> is a discrete-time or continuous-time variable, see <<definition-of-model-variables>>.
-Also j-th derivatives latexmath:[\mathbf{y}^{(j)}(tc_{i+1})] can be provided if supported by the FMU.
+Also j-th derivatives latexmath:[\mathbf{y}^{(j)}(t_{i+1})] can be provided if supported by the FMU.
 
 
 |latexmath:[\mathbf{y}_{i, IU}(t)]
 |Intermediate output variables corresponding to the output variables latexmath:[\mathbf{y}].
 The values of these variables are computed in the FMU and they are designed to be used by the co-simulation master, for example for extrapolation
 
-|latexmath:[\mathbf{w}(tc_i)]
+|latexmath:[\mathbf{w}(t_i)]
 |Local variables of the FMU that cannot be used for FMU connections.
 Variables of this type are defined with attribute <<causality>> = <<local>> (see <<definition-of-model-variables>>).
 
@@ -100,17 +100,17 @@ When the transient simulation of the coupled system through Co-Simulation is com
 
 \begin{Bmatrix}
 
-\mathbf{x}_{i+1} = \Phi_i \left( \mathbf{x}_i,  \mathbf{u}(tc_i), \mathbf{u}_{i,IU}, \mathbf{p}_{\mathit{tune},i}, hc_i  \right)
+\mathbf{x}_{i+1} = \Phi_i \left( \mathbf{x}_i,  \mathbf{u}(t_i), \mathbf{u}_{i,IU}, \mathbf{p}_{\mathit{tune},i}, h_i  \right)
 
 \\
 
-\left( \left\{ \mathbf{y}^{(j)}_{i+1} \right\}_{j=0,\cdots,m_{odo}}, \mathbf{w}_{i+1}\right) = \Gamma_i \left( \mathbf{x}_i,  \mathbf{u}(tc_i), \mathbf{u}_{i, IU}, \mathbf{p}_{\mathit{tune},i}, hc_i  \right)
+\left( \left\{ \mathbf{y}^{(j)}_{i+1} \right\}_{j=0,\cdots,m_{odo}}, \mathbf{w}_{i+1}\right) = \Gamma_i \left( \mathbf{x}_i,  \mathbf{u}(t_i), \mathbf{u}_{i, IU}, \mathbf{p}_{\mathit{tune},i}, h_i  \right)
 
 \end{Bmatrix}
 ++++
 
-where latexmath:[\mathbf{\Phi}_i] and latexmath:[\mathbf{\Gamma}_i] define the system behavior for the time interval latexmath:[tc_i \leq t < tc_{i+1}],
-with latexmath:[tc_i = tc_0 + \sum_{k=0}^{i-1}hc_k].
+where latexmath:[\mathbf{\Phi}_i] and latexmath:[\mathbf{\Gamma}_i] define the system behavior for the time interval latexmath:[t_i \leq t < t_{i+1}],
+with latexmath:[t_i = t_0 + \sum_{k=0}^{i-1}h_k].
 
 _[For the part of the Co-Simulation slave that is based on an ODE, a differential equation is solved between communication points:_
 
@@ -137,10 +137,10 @@ _For example, for a stiff differential equation one could use a linear implicit 
 
 [latexmath]
 ++++
-\mathbf{\Phi}_i \left( \mathbf{x}_{c,i}, \left\{ \mathbf{u}_{c,i} \right\}_{j = 0,\cdots,m_{ido}},\ \mathbf{p}_{\mathit{tune},i}, tc_i \right)
+\mathbf{\Phi}_i \left( \mathbf{x}_{c,i}, \left\{ \mathbf{u}_{c,i} \right\}_{j = 0,\cdots,m_{ido}},\ \mathbf{p}_{\mathit{tune},i}, t_i \right)
 =
 \mathbf{x}_{c,i} + \left( \mathbf{I} -
-hc_i \frac{\partial \mathbf{\varphi}}{\partial \mathbf{x}_c} \right)^{- 1}  hc_i \mathbf{\phi} \left( \mathbf{x}_{c,i}, \mathbf{u}_{c,i}, \mathbf{p}_{\mathit{tune},i} \right).
+h_i \frac{\partial \mathbf{\varphi}}{\partial \mathbf{x}_c} \right)^{- 1}  h_i \mathbf{\phi} \left( \mathbf{x}_{c,i}, \mathbf{u}_{c,i}, \mathbf{p}_{\mathit{tune},i} \right).
 ++++
 
 _]_
@@ -157,11 +157,11 @@ Definition <<equation-co-simulation-evaluations>> is consistent with the definit
 
 ** The current output variables latexmath:[\mathbf{y}_{i+1}^{(0)}]of the subsystem (same remark as above), along with some of their successive <<derivative,`derivatives`>> latexmath:[\left\{ \mathbf{y}_{i+1}^{(j)} \right\}_{j=1,\cdots,m_{odo}}](in case of continuous-time variables).
 
-** Observation variables and <<calculated>> varying <<parameter,`parameters`>> latexmath:[\mathbf{w}_{i+1}], along with directional derivatives estimated at latexmath:[t = tc_{i+1}] (in case of continuous-time variables).
+** Observation variables and <<calculated>> varying <<parameter,`parameters`>> latexmath:[\mathbf{w}_{i+1}], along with directional derivatives estimated at latexmath:[t = t_{i+1}] (in case of continuous-time variables).
 
-* At intermediate times latexmath:[t\in (tc_i, tc_{i+1})] the master and slave exchange values for latexmath:[\mathbf{u}_{i, IU}(t)] and latexmath:[\mathbf{y}_{i, IU}(t)].
+* At intermediate times latexmath:[t\in (t_i, t_{i+1})] the master and slave exchange values for latexmath:[\mathbf{u}_{i, IU}(t)] and latexmath:[\mathbf{y}_{i, IU}(t)].
 
-* Initialization: The slave being a sampled-data system, its internal states (which can be either continuous-time or discrete-time) need to be initialized at latexmath:[t = tc_0].
+* Initialization: The slave being a sampled-data system, its internal states (which can be either continuous-time or discrete-time) need to be initialized at latexmath:[t = t_0].
 This is performed through an auxiliary function _[this relationship is defined in the XML file under elements `<ModelStructure><InitialUnknown>`]_:
 
 Computing the solution of an FMI Co-Simulation model means to split the solution process in two phases and in every phase different equations and solution methods are utilized.
@@ -203,13 +203,13 @@ For an output argument, calling `fmi3Get{VariableType}` on such a variable retur
 |`fmi3Set{VariableType}`
 
 2+|Equations during *Initialization Mode* in state machine
-|[lime]#Enter *Initialization Mode* at (activate initialization, discrete-time and continuous-time equations). Set and set <<start>> value of <<independent>> variable latexmath:[tc_{i=0}].#
+|[lime]#Enter *Initialization Mode* at (activate initialization, discrete-time and continuous-time equations). Set and set <<start>> value of <<independent>> variable latexmath:[t_{i=0}].#
 |[lime]#fmi3EnterInitializationMode#
 
 |Set variables latexmath:[v_{\mathit{initial=exact}}] and latexmath:[v_{\mathit{initial=approx}}] that have a <<start>> value with <<initial>> = <<exact>> (<<parameter,`parameters`>> latexmath:[\mathbf{p}] and continuous-time <<state,`states`>> with start values latexmath:[\mathbf{x}_{c,\mathit{initial=exact}}] are included here)
 |`fmi3Set{VariableType}`
 
-|Set continuous-time and discrete-time <<input,`inputs`>> latexmath:[\mathbf{u}_{c+d}(tc_0)] of continuous-time <<input,`inputs`>> latexmath:[\mathbf{u}_{c}^{(j)}(tc_0)]
+|Set continuous-time and discrete-time <<input,`inputs`>> latexmath:[\mathbf{u}_{c+d}(t_0)] of continuous-time <<input,`inputs`>> latexmath:[\mathbf{u}_{c}^{(j)}(t_0)]
 |`fmi3Set{VariableType}`
 
 |[blue]#latexmath:[\mathbf{v}_{\mathit{InitialUnknowns}} := \mathbf{f}_{\mathit{init}}(\mathbf{u}_c, \mathbf{u}_d, t_0, \mathbf{v}_{\mathit{initial=exact}})]#
@@ -224,10 +224,10 @@ For an output argument, calling `fmi3Get{VariableType}` on such a variable retur
 |Set <<tunable>> <<parameter,`parameters`>> latexmath:[\mathbf{p}_{\mathit{tune}}] (and do not set other <<parameter,`parameters`>> latexmath:[\mathbf{p}_{\mathit{other}}])
 |`fmi3Set{VariableType}`
 
-|Set continuous-time and discrete-time <<input,`inputs`>> latexmath:[\mathbf{u}_{d+c}(tc_i)]
+|Set continuous-time and discrete-time <<input,`inputs`>> latexmath:[\mathbf{u}_{d+c}(t_i)]
 |`fmi3Set{VariableType}`
 
-|[blue]#latexmath:[\begin{matrix} tc_{i+1} := tc_i + hc_i \\ (\mathbf{y}_{c+d}, \mathbf{y}_c^{(j)}, \mathbf{w}_{c+d}) := \mathbf{f}_{\mathit{doStep}}(\mathbf{u}_{c+d}, \mathbf{u}_{i, IU},  tc_i, hc_i, \mathbf{p}_{\mathit{tune}}, \mathbf{p}_{\mathit{other}})_{tc_i} \\ tc_i := tc_{i+1} \end{matrix}]# +
+|[blue]#latexmath:[\begin{matrix} t_{i+1} := t_i + h_i \\ (\mathbf{y}_{c+d}, \mathbf{y}_c^{(j)}, \mathbf{w}_{c+d}) := \mathbf{f}_{\mathit{doStep}}(\mathbf{u}_{c+d}, \mathbf{u}_{i, IU},  t_i, h_i, \mathbf{p}_{\mathit{tune}}, \mathbf{p}_{\mathit{other}})_{t_i} \\ t_i := t_{i+1} \end{matrix}]# +
 [blue]#latexmath:[\mathbf{f}_{\mathit{doStep}}] is also a function of the internal variables latexmath:[\mathbf{x}_c], latexmath:[^{\bullet}\mathbf{x}_d]#
 |`[blue]#fmi3DoStep#` +
 `[blue]#fmi3Get{VariableType}#` +
@@ -242,12 +242,12 @@ For an output argument, calling `fmi3Get{VariableType}` on such a variable retur
 |`fmi3Set{VariableType}`
 
 
-| [blue]#latexmath:[\mathbf{y}_{i, IU}(t):= \mathbf{f}_{\mathit{Intermediate}}(\mathbf{u}_{i, c+d}, \mathbf{u}_{i, IU} ( t \in [tc_i, t) ),  t, hc_i, \mathbf{p}_{\mathit{tune}}, \mathbf{p}_{\mathit{other}})]#
+| [blue]#latexmath:[\mathbf{y}_{i, IU}(t):= \mathbf{f}_{\mathit{Intermediate}}(\mathbf{u}_{i, c+d}, \mathbf{u}_{i, IU} ( t \in [t_i, t) ),  t, h_i, \mathbf{p}_{\mathit{tune}}, \mathbf{p}_{\mathit{other}})]#
 |`[blue]#fmi3Get{VariableType}#`
 
 2+|*Data types*
 
-2+|latexmath:[t, tc, hc \in \mathbb{R}, \mathbf{p} \in \mathbb{P}^{np}, \mathbf{u}(tc) \in \mathbb{P}^{nu}, \mathbf{y}(tc) \in \mathbb{P}^{ny}, \mathbf{x}_c(t) \in \mathbb{R}^{nxc}, \mathbf{x}_d(t) \in \mathbb{P}^{nxd}, \mathbf{w}(tc) \in \mathbb{P}^{nw}] +
+2+|latexmath:[t, t_i, h_i \in \mathbb{R}, \mathbf{p} \in \mathbb{P}^{np}, \mathbf{u}(t) \in \mathbb{P}^{nu}, \mathbf{y}(t) \in \mathbb{P}^{ny}, \mathbf{x}_c(t) \in \mathbb{R}^{nxc}, \mathbf{x}_d(t) \in \mathbb{P}^{nxd}, \mathbf{w}(t) \in \mathbb{P}^{nw}] +
 latexmath:[\mathbb{R}]: floating point variable, latexmath:[\mathbb{R}]: floating point or Boolean or integer or enumeration or string variable +
 latexmath:[\mathbf{f}_{\mathit{init}}, \mathbf{f}_{\mathit{out}} \in C^0] (=continuous functions with respect to all input parameters inside the respective mode).
 |====

--- a/docs/4_2_co-simulation_api.adoc
+++ b/docs/4_2_co-simulation_api.adoc
@@ -223,7 +223,7 @@ include::../headers/fmi3FunctionTypes.h[tags=DoStep]
 ----
 
 [[currentCommunicationPoint,`currentCommunicationPoint`]]
-* `currentCommunicationPoint` is the current communication point of the master (latexmath:[tc_i]) with the unit of the <<independent>> variable and
+* `currentCommunicationPoint` is the current communication point of the master (latexmath:[t_i]) with the unit of the <<independent>> variable and
 
 [[communicationStepSize,`communicationStepSize`]]
 * `communicationStepSize` is the communication step size (latexmath:[h_i]) with the unit of the <<independent>> variable. `comunicationStepSize` must be latexmath:[> 0.0].
@@ -256,7 +256,7 @@ At the first call to <<fmi3DoStep>> after <<fmi3ExitInitializationMode>> was cal
 
 _[Formally, argument <<currentCommunicationPoint>> is not needed._
 _It is present in order to handle a mismatch between the master and the FMU state of the slave: The <<currentCommunicationPoint>> and the FMU state of the slaves defined by former_ <<fmi3DoStep>> _or_ `fmi3SetFMUState` _calls have to be consistent with respect to each other._
-_For example, if the slave does not use the update formula for the <<independent>> variable as required above,_ latexmath:[t_{i+1} = t_i + h_i] _(using argument_ latexmath:[t_i] = <<currentommunicationPoint>> _of_ <<fmi3DoStep>>) _but uses internally an own update formula, such as_ latexmath:[t_{s,i+1} = t_{s,i} + h_{s,i}] _then the slave could use as time increment_ latexmath:[\text{h}_{s,i} := (t_i - t_{s,i}) + h_i] _(instead of_ latexmath:[\text{h}_{s,i} := h_i] _) to avoid a mismatch between the master time_ latexmath:[t_{i+1}] _and the slave internal time_ latexmath:[t_{s,i+1}] _for large i.]_
+_For example, if the slave does not use the update formula for the <<independent>> variable as required above,_ latexmath:[t_{i+1} = t_i + h_i] _(using argument_ latexmath:[t_i] = <<currentCommunicationPoint>> _of_ <<fmi3DoStep>>) _but uses internally an own update formula, such as_ latexmath:[t_{s,i+1} = t_{s,i} + h_{s,i}] _then the slave could use as time increment_ latexmath:[\text{h}_{s,i} := (t_i - t_{s,i}) + h_i] _(instead of_ latexmath:[\text{h}_{s,i} := h_i] _) to avoid a mismatch between the master time_ latexmath:[t_{i+1}] _and the slave internal time_ latexmath:[t_{s,i+1}] _for large i.]_
 
 It depends on the capabilities of the FMU which argument constellations and calling sequences are allowed (see <<fmi-for-co-simulation>>).
 

--- a/docs/4_2_co-simulation_api.adoc
+++ b/docs/4_2_co-simulation_api.adoc
@@ -226,7 +226,7 @@ include::../headers/fmi3FunctionTypes.h[tags=DoStep]
 * `currentCommunicationPoint` is the current communication point of the master (latexmath:[tc_i]) with the unit of the <<independent>> variable and
 
 [[communicationStepSize,`communicationStepSize`]]
-* `communicationStepSize` is the communication step size (latexmath:[hc_i]) with the unit of the <<independent>> variable. `comunicationStepSize` must be latexmath:[> 0.0].
+* `communicationStepSize` is the communication step size (latexmath:[h_i]) with the unit of the <<independent>> variable. `comunicationStepSize` must be latexmath:[> 0.0].
 
 [[noSetFMUStatePriorToCurrentPoint,`noSetFMUStatePriorToCurrentPoint`]]
 * `noSetFMUStatePriorToCurrentPoint == fmi3True` if `fmi3SetFMUState` will no longer be called for time instants prior to <<currentCommunicationPoint>> in this simulation run. _[The slave can use this flag to flush a result buffer]_
@@ -240,23 +240,23 @@ This is not due to an error, but a natural limit to the simulation time has been
 [[lastSuccessfulTime,`lastSuccessfulTime`]]
 * `lastSuccessfulTime` represents the internal time of the FMU when <<fmi3DoStep>> returns.
 
-The slave is expected to compute until time latexmath:[tc_{i+1} = tc_i + hc_i], or <<lastSuccessfulTime>> `=` <<currentCommunicationPoint>> `+` <<communicationStepSize>>.
+The slave is expected to compute until time latexmath:[t_{i+1} = t_i + h_i], or <<lastSuccessfulTime>> `=` <<currentCommunicationPoint>> `+` <<communicationStepSize>>.
 
 This is especially interesting, if <<fmi3DoStep>> returns with <<earlyReturn,`earlyReturn == fmi3True`>>.
-In this case, the step did not compute until latexmath:[tc_{i+1}], but stopped computation error free until <<lastSuccessfulTime>>.
+In this case, the step did not compute until latexmath:[t_{i+1}], but stopped computation error free until <<lastSuccessfulTime>>.
 However, even when the FMU returns from <<fmi3DoStep>> with <<fmi3OK>>, it is allowed that <<lastSuccessfulTime>> deviates from the expected <<currentCommunicationPoint>> `+` <<communicationStepSize>>.
 _[An example is a fixed-step integrator inside the FMU that cannot possibly stop at exactly the requested time._
 _Advanced Co-Simulation master algorithms might be able to take this information into account._
 _It is even possible that the <<lastSuccessfulTime>> is still equal to <<currentCommunicationPoint>> when <<earlyReturn,`earlyReturn == fmi3True`>> is returned (contrary to the possibly expected <<fmi3Discard>>) to indicate a changed internal state of the FMU, e.g. steps in super-dense time.]_
 
-_[The calling environment defines the communication points and <<fmi3DoStep>> must synchronize to these points by always integrating exactly to latexmath:[tc_i + hc_i]._
+_[The calling environment defines the communication points and <<fmi3DoStep>> must synchronize to these points by always integrating exactly to latexmath:[t_i + h_i]._
 _It is up to <<fmi3DoStep>> how to achieve this.]_
 
 At the first call to <<fmi3DoStep>> after <<fmi3ExitInitializationMode>> was called <<currentCommunicationPoint>> must be equal to `startTime` as set with <<fmi3EnterInitializationMode>>.
 
 _[Formally, argument <<currentCommunicationPoint>> is not needed._
 _It is present in order to handle a mismatch between the master and the FMU state of the slave: The <<currentCommunicationPoint>> and the FMU state of the slaves defined by former_ <<fmi3DoStep>> _or_ `fmi3SetFMUState` _calls have to be consistent with respect to each other._
-_For example, if the slave does not use the update formula for the <<independent>> variable as required above,_ latexmath:[tc_{i+1} = tc_i + hc_i] _(using argument_ latexmath:[tc_i] = <<currentCommunicationPoint>> _of_ <<fmi3DoStep>>) _but uses internally an own update formula, such as_ latexmath:[tc_{s,i+1} = tc_{s,i} + hc_{s,i}] _then the slave could use as time increment_ latexmath:[\text{hc}_{s,i} := (tc_i - tc_{s,i}) + hc_i] _(instead of_ latexmath:[\text{hc}_{s,i} := hc_i] _) to avoid a mismatch between the master time_ latexmath:[tc_{i+1}] _and the slave internal time_ latexmath:[tc_{s,i+1}] _for large i.]_
+_For example, if the slave does not use the update formula for the <<independent>> variable as required above,_ latexmath:[t_{i+1} = t_i + h_i] _(using argument_ latexmath:[t_i] = <<currentommunicationPoint>> _of_ <<fmi3DoStep>>) _but uses internally an own update formula, such as_ latexmath:[t_{s,i+1} = t_{s,i} + h_{s,i}] _then the slave could use as time increment_ latexmath:[\text{h}_{s,i} := (t_i - t_{s,i}) + h_i] _(instead of_ latexmath:[\text{h}_{s,i} := h_i] _) to avoid a mismatch between the master time_ latexmath:[t_{i+1}] _and the slave internal time_ latexmath:[t_{s,i+1}] _for large i.]_
 
 It depends on the capabilities of the FMU which argument constellations and calling sequences are allowed (see <<fmi-for-co-simulation>>).
 

--- a/docs/4___co-simulation.adoc
+++ b/docs/4___co-simulation.adoc
@@ -4,9 +4,9 @@ This chapter defines the Functional Mock-up Interface (FMI) for the coupling of 
 It is designed both for coupling with subsystem models, which have been exported by their simulator together with its solver as runnable code, and for coupling of simulation tools on a single machine or as part of a distributed co-simulation.
 
 Co-simulation exploits the modular structure of coupled problems in all stages of the simulation process beginning with the separate model setup and preprocessing for the individual subsystems in different simulation tools (which can be powerful simulators as well as simple C programs).
-During time integration, the simulation is again performed independently for all subsystems restricting the data exchange between subsystems to discrete communication points latexmath:[tc_i].
+During time integration, the simulation is again performed independently for all subsystems restricting the data exchange between subsystems to discrete communication points latexmath:[t_i].
 For simulator coupling, also the visualization and post-processing of simulation data is done individually for each subsystem in its own native simulation tool.
-In different contexts, the communication points latexmath:[tc_i], the communication steps latexmath:[tc_i \rightarrow tc_{i+1}] and the communication step sizes latexmath:[hc_i := tc_{i+1} - tc_i] are also known as sampling points (synchronization points), macro steps and sampling rates, respectively.
+In different contexts, the communication points latexmath:[t_i], the communication steps latexmath:[t_i \rightarrow t_{i+1}] and the communication step sizes latexmath:[h_i := t_{i+1} - t_i] are also known as sampling points (synchronization points), macro steps and sampling rates, respectively.
 The term "communication point" in FMI for Co-Simulation refers to the communication between subsystems in a co-simulation environment and should not be mixed with the output points for saving simulation results to file.
 
 FMI for Co-Simulation provides an interface standard for the solution of time-dependent coupled systems consisting of subsystems that are continuous in time (model components that are described by non-stationary differential equations) or time-discrete (model components that are described by difference equations such as discrete controllers).
@@ -20,7 +20,7 @@ For co-simulation, two basic groups of functions have to be implemented:
 
 . functions for the data exchange between subsystems
 
-. functions to synchronize the simulation of all subsystems and to proceed in communication steps latexmath:[tc_i \rightarrow tc_{i+1}] from initial time latexmath:[tc_0 := t_{\mathit{start}}] to end time latexmath:[tc_N := t_{\mathit{stop}}]
+. functions to synchronize the simulation of all subsystems and to proceed in communication steps latexmath:[t_i \rightarrow t_{i+1}] from initial time latexmath:[t_0 := t_{\mathit{start}}] to end time latexmath:[t_N := t_{\mathit{stop}}]
 
 // TODO: Add "A Co-sim interface..."
 In FMI for Co-Simulation, both groups of functions are implemented in one software component, the Co-Simulation master.
@@ -31,9 +31,9 @@ In its most general form, the coupled system may be simulated in nested co-simul
 
 // TODO: Add "A Co-sim interface..."
 FMI for Co-Simulation defines interface routines for the communication between the master and all slaves (subsystems) in a co-simulation environment.
-The most common master algorithm stops at each communication point latexmath:[tc_i] the simulation (time integration) of all slaves, collects the outputs latexmath:[y(tc_i)] from all subsystems, determines the subsystem inputs latexmath:[u(tc_i)], distributes these subsystem inputs to the slaves and continues the (co-)simulation with the next communication step latexmath:[tc_i \rightarrow tc_{i+1} = tc_i + hc] with fixed communication step size latexmath:[hc].
-In each slave, an appropriate solver is used to integrate one of the subsystems for a given communication step latexmath:[tc_i \rightarrow tc_{i+1}].
-The most simple co-simulation algorithms approximate the (unknown) subsystem inputs latexmath:[u(t), (t > tc_i))] by frozen data latexmath:[u(tc_i)] for latexmath:[tc_i \leq t < tc_{i+1}].
+The most common master algorithm stops at each communication point latexmath:[t_i] the simulation (time integration) of all slaves, collects the outputs latexmath:[y(t_i)] from all subsystems, determines the subsystem inputs latexmath:[u(t_i)], distributes these subsystem inputs to the slaves and continues the (co-)simulation with the next communication step latexmath:[t_i \rightarrow t_{i+1} = t_i + h] with fixed communication step size latexmath:[h].
+In each slave, an appropriate solver is used to integrate one of the subsystems for a given communication step latexmath:[t_i \rightarrow t_{i+1}].
+The most simple co-simulation algorithms approximate the (unknown) subsystem inputs latexmath:[u(t), (t > t_i))] by frozen data latexmath:[u(t_i)] for latexmath:[t_i \leq t < t_{i+1}].
 FMI for Co-Simulation supports this classical brute force approach as well as more sophisticated master algorithms.
 FMI for Co-Simulation is designed to support a very general class of master algorithms but it does not define the master algorithm itself.
 
@@ -41,9 +41,9 @@ FMI for Co-Simulation is designed to support a very general class of master algo
 The ability of slaves to support more sophisticated master algorithms is characterized by a set of capability flags inside the XML description of the slave (see <<fmi-for-co-simulation>>).
 Typical examples are:
 
-- the ability to handle variable communication step sizes latexmath:[hc_i],
+- the ability to handle variable communication step sizes latexmath:[h_i],
 
-- the ability to repeat a rejected communication step latexmath:[tc_i \rightarrow tc_{i+1}] with reduced communication step size,
+- the ability to repeat a rejected communication step latexmath:[t_i \rightarrow t_{i+1}] with reduced communication step size,
 
 - the ability to provide <<derivative,`derivatives`>> of <<output,`outputs`>> w.r.t. time, to allow input approximation (<<transfer-of-input-output-and-parameters>>),
 
@@ -57,15 +57,15 @@ FMI for Co-Simulation is restricted to slaves with the following properties:
 The current time latexmath:[t] is running step by step from latexmath:[t_{\mathit{start}}] to latexmath:[t_{\mathit{stop}}].
 The algorithm of the slave may have the property to be able to repeat the simulation of parts of latexmath:[[t_{\mathit{start}}, t_{\mathit{stop}}]] or the whole time interval latexmath:[[t_{\mathit{start}}, t_{\mathit{stop}}]].
 
-. The slave can be given a time value latexmath:[tc_i, t_{\mathit{start}} \leq tc_i \leq t_{\mathit{stop}}].
+. The slave can be given a time value latexmath:[t_i, t_{\mathit{start}} \leq t_i \leq t_{\mathit{stop}}].
 
-. The slave is able to interrupt the simulation when latexmath:[tc_i] is reached.
+. The slave is able to interrupt the simulation when latexmath:[t_i] is reached.
 
-. During the interrupted simulation, the slave (and its individual solver) can receive values for <<input,`inputs`>> latexmath:[u(tc_i)] and send values of outputs latexmath:[y(tc_i)].
+. During the interrupted simulation, the slave (and its individual solver) can receive values for <<input,`inputs`>> latexmath:[u(t_i)] and send values of outputs latexmath:[y(t_i)].
 
-. Whenever the simulation in a slave is interrupted, a new time value latexmath:[tc_{i+1}, tc_i \leq tc_{i+1} \leq t_{\mathit{stop}}], can be given to simulate the time subinterval latexmath:[tc_i < t \leq tc_{i+1}]
+. Whenever the simulation in a slave is interrupted, a new time value latexmath:[t_{i+1}, t_i \leq t_{i+1} \leq t_{\mathit{stop}}], can be given to simulate the time subinterval latexmath:[t_i < t \leq t_{i+1}]
 
-. The subinterval length latexmath:[hc_i] is the communication step size of the latexmath:[i^{th}] communication step, latexmath:[hc_i = tc_{i+1} - tc_i].
+. The subinterval length latexmath:[h_i] is the communication step size of the latexmath:[i^{th}] communication step, latexmath:[h_i = t_{i+1} - t_i].
 
 The communication step size initiated by the master has to be greater than zero.
 


### PR DESCRIPTION
Resolves #1050 

(I have not renamed the clock activiation times to c_i as this seems misleading to "constants"; so t_i is used both for communication timesteps in CS and clock activation times for clocks. As these different meanings are used in different chapters, it is clear from the context what t_i means. If someone disgrees, please improve ....)