### PR TITLE
Remove SetClock restriction of IU

### DIFF
--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -897,8 +897,6 @@ When getting or setting the values of array variables, the serialization of arra
 
 * `nValues` provides the number of values in the `values` and `subactive` (if not null) vectors, which is only equal to `nValueReferences` if all <<valueReference,`valueReferences`>> point to scalar clock variables.
 
-It is not allowed to call this function within the callback function <<intermediateUpdate>>.
-
 [[fmi3GetClock,`fmi3GetClock`]]
 [source, C]
 ----


### PR DESCRIPTION
@masoud-najafi : this is one of the fixes from the mixed PR 1106. Can you check if this was an intended removal and please explain what happens if an input clock is set in fmi3IntermediateUpdate?