### PR TITLE
Remove reference to variable index in example for array convention

### DIFF
--- a/docs/1___overview.adoc
+++ b/docs/1___overview.adoc
@@ -310,7 +310,6 @@ Properties that might be additionally needed for trajectory optimization, for ex
 Here the convention of linear algebra, the control community and the most important tools in this area is utilized.
 In other words the first element along one dimension starts at index one.
 In all these cases, the starting index is also explicitly mentioned at the respective definition of the array.
-For example, in the <<modelDescription.xml>> file, the set of exposed variables is defined as ordered sets where the first element is referenced with index one (these indices are, for example, used to define the sparseness structure of partial derivative matrices).
 
 ** In the implementation view, one-dimensional C arrays are used.
 In order to access an array element the C convention is used.


### PR DESCRIPTION
Removes the inconsistent example for usage of 1-based indices mentioned in https://github.com/modelica/fmi-standard/issues/1128#issuecomment-680116448 (variable index is no longer present in FMI 3.0)

If some has a better example, please commit