### PR TITLE
Fix issue 613

### DIFF
--- a/docs/4_1_co-simulation_math.adoc
+++ b/docs/4_1_co-simulation_math.adoc
@@ -51,8 +51,8 @@ Dependent <<parameter,`parameters`>> (variables with <<causality>> = <<calculate
 The values of these variables are defined outside of the model.
 Variables of this type are defined with attribute <<causality>> = <<input>>.
 Whether the <<input>> is a discrete-time or continuous-time variable is defined via attribute <<variability>> = <<discrete>> or <<continuous>> (see <<definition-of-model-variables>>). +
-If no event happens at the communication point latexmath:[tc_i], <<continuous>> input variables latexmath:[\mathbf{u}(tc_{i+1}] must be consistent with the values of the smooth functions latexmath:[\mathbf{u}_{i, IU}], that is latexmath:[\mathbf{u}_{i, IU}(tc_{i+1})= \mathbf{u}(tc_i)].
-It is also recommended but not mandatory that the function defined by the continuation of latexmath:[\mathbf{u}_{i, IU}] with latexmath:[\mathbf{u}_{i+1, IU}] be of smoothness latexmath:[C^{k}([tc_i, tc_{i+2}\])]  with the optional flag <<recommendedIntermediateInputSmoothness>> of value latexmath:[k]. +
+If no event happens at the communication point latexmath:[t_i], <<continuous>> input variables latexmath:[\mathbf{u}(t_{i+1})] must be consistent with the values of the smooth functions latexmath:[\mathbf{u}_{i, IU}], that is latexmath:[\mathbf{u}_{i, IU}(t_{i+1})= \mathbf{u}(t_i)].
+It is also recommended but not mandatory that the function defined by the continuation of latexmath:[\mathbf{u}_{i, IU}] with latexmath:[\mathbf{u}_{i+1, IU}] be of smoothness latexmath:[C^{k}([t_i, t_{i+2}\])]  with the optional flag <<recommendedIntermediateInputSmoothness>> of value latexmath:[k]. +
 _[This can increase simulation speed for higher order multi-step solvers that in this case do not have to reset even at communication points.]_ +
 If an event happens at the communication point, <<continuous>> input variables may change discontinuously.
 
@@ -131,7 +131,7 @@ _If the simulation algorithm implements an extrapolation method of order_ latexm
 ++++
 \mathbf{u}_{i, IU}(t)
 =
-\sum^{m_{\mathit{extra}}}_{j=0} \mathbf{C_{i, j}} \frac{(t-tc_i)^j}{j!}
+\sum^{m_{\mathit{extra}}}_{j=0} \mathbf{C_{i, j}} \frac{(t-_i)^j}{j!}
 ++++
 _where_ latexmath:[\mathbf{C}_{i, j}] _are coefficients that can be equal to output derivatives of a connected FMU to realize a Taylor polynomial._
 
@@ -246,7 +246,7 @@ For an output argument, calling `fmi3Get{VariableType}` on such a variable retur
 |`fmi3Set{VariableType}`
 
 
-| [blue]#latexmath:[\mathbf{y}_{i, IU}(t):= \mathbf{f}_{\mathit{Intermediate}}(\mathbf{u}_{i, c+d}, \mathbf{u}_{i, IU} ( t \in [t_i, t) ),  t, h_i, \mathbf{p}_{\mathit{tune}}, \mathbf{p}_{\mathit{other}})]#
+| [blue]#latexmath:[\mathbf{y}_{i, IU}(t):= \mathbf{f}_{\mathit{Intermediate}}(\mathbf{u}_{i, c+d}, \mathbf{u}_{i, IU} (t \in [t_i, t_{i+1}) ),  t, h_i, \mathbf{p}_{\mathit{tune}}, \mathbf{p}_{\mathit{other}})]#
 |`[blue]#fmi3Get{VariableType}#`
 
 2+|*Data types*

--- a/docs/4_1_co-simulation_math.adoc
+++ b/docs/4_1_co-simulation_math.adoc
@@ -113,7 +113,7 @@ When the transient simulation of the coupled system through Co-Simulation is com
 \end{Bmatrix}
 ++++
 
-where latexmath:[\mathbf{\Phi}_i] and latexmath:[\mathbf{\Gamma}_i] define the system behavior for the time interval latexmath:[t_i \leq t < t_{i+1}],
+where latexmath:[\mathbf{\Phi}_i] and latexmath:[\mathbf{\Gamma}_i] define the system behavior for the time interval latexmath:[t_i < t \leq t_{i+1}],
 with latexmath:[t_i = t_0 + \sum_{k=0}^{i-1}h_k].
 
 _[For the part of the Co-Simulation FMU that is based on an ODE, a differential equation is solved between communication points:_

--- a/docs/4_1_co-simulation_math.adoc
+++ b/docs/4_1_co-simulation_math.adoc
@@ -131,7 +131,7 @@ _If the simulation algorithm implements an extrapolation method of order_ latexm
 ++++
 \mathbf{u}_{i, IU}(t)
 =
-\sum^{m_{\mathit{extra}}}_{j=0} \mathbf{C_{i, j}} \frac{(t-_i)^j}{j!}
+\sum^{m_{\mathit{extra}}}_{j=0} \mathbf{C_{i, j}} \frac{(t-t_i)^j}{j!}
 ++++
 _where_ latexmath:[\mathbf{C}_{i, j}] _are coefficients that can be equal to output derivatives of a connected FMU to realize a Taylor polynomial._
 

--- a/docs/4___co-simulation.adoc
+++ b/docs/4___co-simulation.adoc
@@ -61,11 +61,9 @@ The algorithm of the FMU may have the property to be able to repeat the simulati
 
 . During the interrupted simulation, the FMU (and its individual solver) can receive values for <<input,`inputs`>> latexmath:[u(t_i)] and send values of outputs latexmath:[y(t_i)].
 
-. Whenever the simulation in a FMU is interrupted, a new time value latexmath:[t_{i+1}, t_i \leq t_{i+1} \leq t_{\mathit{stop}}], can be given to simulate the time subinterval latexmath:[t_i < t \leq t_{i+1}]
+. Whenever the simulation in a FMU is interrupted, a new time value latexmath:[t_{i+1}, t_i < t_{i+1} \leq t_{\mathit{stop}}], can be given to simulate the time subinterval latexmath:[t_i < t \leq t_{i+1}]
 
-. The subinterval length latexmath:[h_i] is the communication step size of the latexmath:[i^{th}] communication step, latexmath:[h_i = t_{i+1} - t_i].
-
-The communication step size initiated by the co-simulation algorithm has to be greater than zero.
+. The subinterval length latexmath:[h_i] is the communication step size of the latexmath:[i^{th}] communication step, latexmath:[h_i = t_{i+1} - t_i]. Note that the communication step size initiated by the co-simulation algorithm has to be greater than zero.
 
 FMI for Co-Simulation allows a co-simulation flow which starts with instantiation and initialization (all FMUs are prepared for computation, the communication links are established), followed by simulation (the FMUs are forced to simulate a communication step), and finishes with shutdown.
 The details of the flow are given in the state machine of the calling sequences from co-simulation algorithm to FMU, for each co-simulation interface (see <<state-machine-co-simulation>>, and <<state-machine-scheduled-execution>>).

--- a/docs/4___co-simulation.adoc
+++ b/docs/4___co-simulation.adoc
@@ -61,9 +61,10 @@ The algorithm of the FMU may have the property to be able to repeat the simulati
 
 . During the interrupted simulation, the FMU (and its individual solver) can receive values for <<input,`inputs`>> latexmath:[u(t_i)] and send values of outputs latexmath:[y(t_i)].
 
-. Whenever the simulation in a FMU is interrupted, a new time value latexmath:[t_{i+1}, t_i < t_{i+1} \leq t_{\mathit{stop}}], can be given to simulate the time subinterval latexmath:[t_i < t \leq t_{i+1}]
+. Whenever the simulation in an FMU is interrupted, a new time value latexmath:[t_{i+1}, t_i < t_{i+1} \leq t_{\mathit{stop}}], can be given to simulate the time subinterval latexmath:[t_i < t \leq t_{i+1}]
 
-. The subinterval length latexmath:[h_i] is the communication step size of the latexmath:[i^{th}] communication step, latexmath:[h_i = t_{i+1} - t_i]. Note that the communication step size initiated by the co-simulation algorithm has to be greater than zero.
+. The subinterval length latexmath:[h_i] is the communication step size of the latexmath:[i^{th}] communication step, latexmath:[h_i = t_{i+1} - t_i].
+Note that the communication step size initiated by the co-simulation algorithm has to be greater than zero.
 
 FMI for Co-Simulation allows a co-simulation flow which starts with instantiation and initialization (all FMUs are prepared for computation, the communication links are established), followed by simulation (the FMUs are forced to simulate a communication step), and finishes with shutdown.
 The details of the flow are given in the state machine of the calling sequences from co-simulation algorithm to FMU, for each co-simulation interface (see <<state-machine-co-simulation>>, and <<state-machine-scheduled-execution>>).


### PR DESCRIPTION
Fixes https://github.com/modelica/fmi-standard/issues/613

This leaves out the part where the intermediate inputs can be set with zero delay. I think we don't yet have the mathematical machinery to describe this.