### PR TITLE
update comment on synchronous systems to FMI 3.0

### DIFF
--- a/docs/3_1_model_exchange_math.adoc
+++ b/docs/3_1_model_exchange_math.adoc
@@ -410,7 +410,8 @@ _Examples:_
 
 Synchronous systems::
 _A synchronous system, such as Lucid Synchrone <<PZ06>> or Modelica 3.3 <<MLS12>>, is called periodically, and at every sample instant the discrete-time equations are evaluated exactly once._
-_An FMU of this type should be implemented in FMI 3.0 with <<clock,`clocks`>>! However, just like in FMI2.0, it could in principle also be implemented also by activating the model equations only at the first event iteration and returning always `newDiscreteStatesNeeded == fmi3False` from <<fmi3NewDiscreteStates>>._
+_An FMU of this type should be implemented in FMI 3.0 with <<clock,`clocks`>>._
+_However, just like in FMI 2.0, it could in principle also be implemented by activating the model equations only at the first event iteration and returning always `newDiscreteStatesNeeded == fmi3False` from <<fmi3NewDiscreteStates>>._
 _Furthermore, the discrete-time <<state,`states`>> are not updated by <<fmi3NewDiscreteStates>>, but as first action before the discrete-time equations are evaluated, in order that_ latexmath:[^{\bullet}\mathbf{x}_d] _(= value at the previous clock tick) and_ latexmath:[\mathbf{x}_d] _(value at the latest <<clock>> tick) have reasonable values between clock ticks._
 
 State machines with one memory location for a state::

--- a/docs/3_1_model_exchange_math.adoc
+++ b/docs/3_1_model_exchange_math.adoc
@@ -410,8 +410,8 @@ _Examples:_
 
 Synchronous systems::
 _A synchronous system, such as Lucid Synchrone <<PZ06>> or Modelica 3.3 <<MLS12>>, is called periodically, and at every sample instant the discrete-time equations are evaluated exactly once._
-_An FMU of this type can be implemented by activating the model equations only at the first event iteration and returning always `newDiscreteStatesNeeded == fmi3False` from <<fmi3NewDiscreteStates>>._
-_Furthermore, the discrete-time <<state,`states`>> are not updated by <<fmi3NewDiscreteStates>>, but as first action before the discrete-time equations are evaluated, in order that_ latexmath:[^{\bullet}\mathbf{x}_d] _(= value at the previous <<clock>> tick) and_ latexmath:[\mathbf{x}_d] _(value at the latest <<clock>> tick) have reasonable values between <<clock>> ticks._
+_An FMU of this type should be implemented in FMI 3.0 with <<clock,`clocks`>>! However, just like in FMI2.0, it could in principle also be implemented also by activating the model equations only at the first event iteration and returning always `newDiscreteStatesNeeded == fmi3False` from <<fmi3NewDiscreteStates>>._
+_Furthermore, the discrete-time <<state,`states`>> are not updated by <<fmi3NewDiscreteStates>>, but as first action before the discrete-time equations are evaluated, in order that_ latexmath:[^{\bullet}\mathbf{x}_d] _(= value at the previous clock tick) and_ latexmath:[\mathbf{x}_d] _(value at the latest <<clock>> tick) have reasonable values between clock ticks._
 
 State machines with one memory location for a state::
 _In such a system there is only one memory location for a discrete-time <<state>> and not two, and therefore a discrete-time <<state>> is updated in the statement where it is assigned (and not in <<fmi3NewDiscreteStates>>)._


### PR DESCRIPTION
This addresses a point of #1015 : 
The comment on how to implement synchronous systems with FMI should point to the new clocks feature in the first place and only additionally describe how to implement such a behaviour "manually"