### PR TITLE
Explain local variables

### DIFF
--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1212,7 +1212,7 @@ They can be continuous-time or discrete <<state,`states`>>, their derivatives, c
 Some local variables are listed in the `<fmiModelDescription><ModelStructure>`, if they are a `Derivative`, `EventIndicator` or `ClockedState`.
 During initialization: you can ignore local variables only if they do not have start values and are not listed as `InitialUnknown`.
 After initialization: local variables are ignorable, if you do not want to use the structure of the model for connectivity or linearization of the FMU (or they are not listed in the `<fmiModelDescription><ModelStructure>` at all).
-You can set a local variable only if they are a state.
+You can set a local variable only if they are a state in Model Exchange.
 
 _[TODO: add ClockedState elements to ModelStructure.]_
 _[TODO: rename Derivative to StateDerivative to differentiate between derivatives of states and general derivatives of any other variable.]_

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1205,9 +1205,20 @@ The algebraic relationship to the <<input,`inputs`>> is defined via the <<depend
 An <<outputClock,`output clock`>> can be left unconnected or can be connected to an <<inputClock, `input clock`>>, usually of another FMU (for exceptions see <<triggeredBy>>).
 
 [[local,`local`]]
-`= local`: Local variable that is calculated from other variables or is a continuous-time <<state>> or an event indicator (see <<ModelStructure>>).
+`= local`: Local variables are a subset of all internal variables.
+Local variables are listed in the `modelDescription.xml`.
+Local variables cannot be variables of any other causality (see this table cell).
+They can be continuous-time or discrete <<state,`states`>>, their derivatives, clocked states or event indicators.
+Some local variables are listed in the `<fmiModelDescription><ModelStructure>`, if they are a `Derivative`, `EventIndicator` or `ClockedState`.
+During initialization: you can ignore local variables only if they do not have start values and are not listed as `InitialUnknown`.
+After initialization: local variables are ignorable, if you do not want to use the structure of the model for connectivity or linearization of the FMU (or they are not listed in the `<fmiModelDescription><ModelStructure>` at all).
+You can set a local variable only if they are a state.
+
+_[TODO: add ClockedState elements to ModelStructure.]_
+_[TODO: rename Derivative to StateDerivative to differentiate between derivatives of states and general derivatives of any other variable.]_
+
 Local variable values must not be used in another model or FMU. +
-[[localClock,`local clock`]] If <<variability>> = <<clock>> the variable defines a <<localClock,`local clock`>> computed by the FMU..
+[[localClock,`local clock`]] If <<variability>> = <<clock>> the variable defines a <<localClock,`local clock`>> computed by the FMU.
 
 [[independent,`independent`]]
 `= independent`: The independent variable (usually `time` _[but could also be, for example, `angle`]_).

--- a/docs/2_2_common_schema.adoc
+++ b/docs/2_2_common_schema.adoc
@@ -1205,20 +1205,24 @@ The algebraic relationship to the <<input,`inputs`>> is defined via the <<depend
 An <<outputClock,`output clock`>> can be left unconnected or can be connected to an <<inputClock, `input clock`>>, usually of another FMU (for exceptions see <<triggeredBy>>).
 
 [[local,`local`]]
-`= local`: Local variables are a subset of all internal variables.
-Local variables are listed in the `modelDescription.xml`.
-Local variables cannot be variables of any other causality (see this table cell).
-They can be continuous-time or discrete <<state,`states`>>, their derivatives, clocked states or event indicators.
-Some local variables are listed in the `<fmiModelDescription><ModelStructure>`, if they are a `Derivative`, `EventIndicator` or `ClockedState`.
-During initialization: you can ignore local variables only if they do not have start values and are not listed as `InitialUnknown`.
-After initialization: local variables are ignorable, if you do not want to use the structure of the model for connectivity or linearization of the FMU (or they are not listed in the `<fmiModelDescription><ModelStructure>` at all).
-You can set a local variable only if they are a state in Model Exchange.
+`= local`: Local variables are: +
+
+* continuous-time <<state,`states`>> and their `Derivative`pass:[s], `ClockedState`pass:[s], `EventIndicator`pass:[s] or `InitialUnknown`pass:[s].
+These variables are listed in the `<fmiModelDescription><ModelStructure>`. +
+* [[localClock,`local clock`]] internal, intermediate variables or local clocks which can be read for debugging purposes and are not listed in the `<fmiModelDescription><ModelStructure>`.
+
+Setting of local variables: +
+
+* In *Initialization Mode* and before, local variables need to be set if they do have start values or are listed as `InitialUnknown`.
+
+* In super state *Initialized*, `fmi3Set{VariableType}` must not be called on any of the local variables.
+Only in Model Exchange, continuous <<state,`states`>> can be set with <<fmi3SetContinuousStates>>.
+Local variable values must not be used as input to another model or FMU.
+
+_[Continuous-time <<state,`states`>> and their `Derivative`pass:[s], `ClockedState`pass:[s], `EventIndicator`pass:[s] or `InitialUnknown`pass:[s] are listed as local variables to give them properties like name and unit for debugging purposes and a value reference to be listed in <fmiModelDescription><ModelStructure>.]_
 
 _[TODO: add ClockedState elements to ModelStructure.]_
 _[TODO: rename Derivative to StateDerivative to differentiate between derivatives of states and general derivatives of any other variable.]_
-
-Local variable values must not be used in another model or FMU. +
-[[localClock,`local clock`]] If <<variability>> = <<clock>> the variable defines a <<localClock,`local clock`>> computed by the FMU.
 
 [[independent,`independent`]]
 `= independent`: The independent variable (usually `time` _[but could also be, for example, `angle`]_).

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -182,12 +182,12 @@ Compute state derivatives (that is derivatives w.r.t. to the <<independent>> var
 Note that <<fmi3Discard,`fmi3Status == fmi3Discard`>> is possible for both functions.
 
 The <<derivative,`derivatives`>> are returned as a vector with `nContinuousStates` elements.
-The ordering of the elements of the `derivatives` vector must be identical to the ordering of the state vector (for example, `derivatives[2]` is the <<derivative>> of `continuousStates[2]`).
-The order of the states and derivatives must be the same as the ordered list of elements `<ModelStructure><Derivative>`.
+The ordering of the elements of the `derivatives` vector must be identical to the ordering of the `continuousStates` vector (for example, `derivatives[2]` is the <<derivative>> of `continuousStates[2]`).
+The order of the `continuousStates` and `derivatives` vector must be the same as the ordered list of elements `<ModelStructure><Derivative>`.
 _[Array variables are serialized in "row major" order, as usual.]_
 
 The event indicators are returned as a vector with `nEventIndicators` elements.
-The order of event indicators in `eventIndicators` vector must be the same as the ordered list of `<EventIndicator>` elements in `<ModelStructure>`.
+The order of the `eventIndicators` vector must be the same as the ordered list of elements `<ModelStructure><EventIndicator>`.
 _[Array variables are serialized in "row major" order, as usual.]_
 A <<state event>> is triggered when the domain of an event indicator changes from latexmath:[z_j > 0] to latexmath:[z_j \leq 0] or vice versa.
 The FMU must guarantee that at an event restart latexmath:[z_j \neq 0], for example, by shifting latexmath:[z_j] with a small value.

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -182,12 +182,12 @@ Compute state derivatives (that is derivatives w.r.t. to the <<independent>> var
 Note that <<fmi3Discard,`fmi3Status == fmi3Discard`>> is possible for both functions.
 
 The <<derivative,`derivatives`>> are returned as a vector with `nContinuousStates` elements.
-The ordering of the elements of the `derivatives` vector is identical to the ordering of the state vector (for example, `derivatives[2]` is the <<derivative>> of `continuousStates[2]`).
-The order of the states and derivatives is also the same as the ordered list of elements `<ModelStructure><Derivative>`.
+The ordering of the elements of the `derivatives` vector must be identical to the ordering of the state vector (for example, `derivatives[2]` is the <<derivative>> of `continuousStates[2]`).
+The order of the states and derivatives must be the same as the ordered list of elements `<ModelStructure><Derivative>`.
 _[Array variables are serialized in "row major" order, as usual.]_
 
 The event indicators are returned as a vector with `nEventIndicators` elements.
-The order of event indicators in `eventIndicators` vector is the same as the ordered list of `<EventIndicator>` elements in `<ModelStructure>`.
+The order of event indicators in `eventIndicators` vector must be the same as the ordered list of `<EventIndicator>` elements in `<ModelStructure>`.
 _[Array variables are serialized in "row major" order, as usual.]_
 A <<state event>> is triggered when the domain of an event indicator changes from latexmath:[z_j > 0] to latexmath:[z_j \leq 0] or vice versa.
 The FMU must guarantee that at an event restart latexmath:[z_j \neq 0], for example, by shifting latexmath:[z_j] with a small value.


### PR DESCRIPTION
This still misses:
 - addition of ClockedState to ModelStructure (to list dependencies)
 - renaming of Derivative to StateDerivative (to differentiate to normal variable derivatives)

This should be discussed tomorrow at the design meeting.