### PR TITLE
Move "Supporting Multiple Interface Types in one FMU" out of "extra directory"

### DIFF
--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -272,7 +272,7 @@ The use of subdirectories beginning with `org.modelica` and `org.fmi-standard` i
 It is explicitly allowed for tools and users other than the original creator of an FMU to modify, add or delete entries in the `extra/` directory without affecting the validity of the FMU in all other aspects.
 Specifically all validation or digital signature schemes used to protect the content of the FMU should take the variability of extra file content into account _[(for example by having separate checksums or signatures for FMU core content and extra content, or not having signatures at all for extra content)]_.
 
-===== Supporting Multiple Interface Types in one FMU
+==== Supporting Multiple Interface Types in one FMU
 
 Exporters are encouraged to support multiple FMI interface types in one FMU, so it can be used in differently capable simulation algorithms and for different use cases.
 To indicate support for a specific interface type, the `<fmiModelDescription>` must have the respective element present. +


### PR DESCRIPTION
Resolves #1226 

by moving  "Supporting Multiple Interface Types in one FMU" one level up (and out of the extra directory section)