### PR TITLE
Allow String variables without Start elements

### DIFF
--- a/schema/fmi3Variable.xsd
+++ b/schema/fmi3Variable.xsd
@@ -215,8 +215,8 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	<xs:complexType name="fmi3String">
 		<xs:complexContent>
 			<xs:extension base="fmi3VariableBase">
-				<xs:sequence maxOccurs="unbounded">
-					<xs:element name="Start">
+				<xs:sequence>
+					<xs:element name="Start" minOccurs="0" maxOccurs="unbounded">
 						<xs:complexType>
 							<xs:attribute name="value" type="xs:string"/>
 						</xs:complexType>


### PR DESCRIPTION
The `start `attribute for strings became an element (`Start`) in this PR #523. This is fine and was discussed several times.
However, in the current xsd the `Start `element is mandatory.
Currently xsd validation fails for a String variable like this:

```
<String name="StringOut" valueReference="13" causality="output" variability="tunable">
    <Dimension valueReference="0"/>
    <Dimension valueReference="1"/>
</String>
```

This PR fixes the xsd to allow such `String` variables without `Start` elements.