### PR TITLE
Allow setting input start values before fmi2EnterInitializationMode (#369)

### DIFF
--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -346,7 +346,7 @@ If `stopTimeDefined == fmi3False`, then no final value of the <<independent>> va
 
 Function `fmi3Set{VariableType}`::
 
-This function can be called for variables with <<variability>> latexmath:[\neq] <<constant>> and with <<initial>> = <<exact>> or <<approx>>.
+This function can be called for variables with <<variability>> latexmath:[\neq] <<constant>> and with <<initial>> = <<exact>> or <<approx>>, or variables with <<causality>> = <<input>>.
 The intention is to set <<start>> and guess values for these variables.
 
 ===== State: Initialization Mode [[InitializationMode]]


### PR DESCRIPTION
update text to allow seting initial guess vaules for inputs before enter initialization mode.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Checklist

* [x] Used a [personal fork](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo) of the repository to propose changes.
* [x] [Built the specification](https://github.com/modelica/fmi-standard/blob/master/CONTRIBUTING.adoc#building-the-specification-document).
