### PR TITLE
Remove schema default for variability (fix #1243)

### DIFF
--- a/schema/fmi3Variable.xsd
+++ b/schema/fmi3Variable.xsd
@@ -327,7 +327,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				</xs:restriction>
 			</xs:simpleType>
 		</xs:attribute>
-		<xs:attribute name="variability" default="continuous">
+		<xs:attribute name="variability">
 			<xs:simpleType>
 				<xs:restriction base="xs:normalizedString">
 					<xs:enumeration value="constant"/>


### PR DESCRIPTION
Remove schema default value for variability attribute of variables, since the actual default (continuous vs. discrete) depends on the variable type (i.e. float vs. other types), and hence needs to be handled by the application, not the XML parser. Fixes #1243.

The only alternative in XML Schema 1.0 would be to drop the attribute from the base type and introduce it some level below that, which seems suboptimal.