### PR TITLE
Add Name to sourcefileset

### DIFF
--- a/docs/2_6_source_code.adoc
+++ b/docs/2_6_source_code.adoc
@@ -40,6 +40,9 @@ An importer of the FMU has to regard every `<SourceFileSet>` of the matching `<B
 |Attribute
 |Description
 
+|`name`
+|Name of the `<SourceFileSet>`
+
 |`language`
 |Language of the source files (e.g. `C99`, `C++11`)
 

--- a/schema/fmi3BuildDescription.xsd
+++ b/schema/fmi3BuildDescription.xsd
@@ -79,6 +79,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 										</xs:element>
 										<xs:element ref="Annotations" minOccurs="0"/>
 									</xs:sequence>
+									<xs:attribute name="name" type="xs:normalizedString"/>
 									<xs:attribute name="language" type="xs:normalizedString"/>
 									<xs:attribute name="compiler" type="xs:normalizedString"/>
 									<xs:attribute name="compilerOptions" type="xs:string"/>


### PR DESCRIPTION
Hello. The motivation to add a name attribute to a soucefileset is the following use case: A consumer wants to compile a source file set and create a library for which he needs to choose a name. If provided by the source file set the name attribute can be used to name the library. I would like to invite everyone to express their opinion on this small extension and hopefully approve the idea. Thank you. 