### PR TITLE
Add missing parameter name "serializedState" in fmi2SerializeFMUstate()

### DIFF
--- a/headers/fmi2FunctionTypes.h
+++ b/headers/fmi2FunctionTypes.h
@@ -203,7 +203,7 @@ Types for Common Functions
    typedef fmi2Status fmi2SetFMUstateTYPE           (fmi2Component c, fmi2FMUstate  FMUstate);
    typedef fmi2Status fmi2FreeFMUstateTYPE          (fmi2Component c, fmi2FMUstate* FMUstate);
    typedef fmi2Status fmi2SerializedFMUstateSizeTYPE(fmi2Component c, fmi2FMUstate  FMUstate, size_t* size);
-   typedef fmi2Status fmi2SerializeFMUstateTYPE     (fmi2Component c, fmi2FMUstate  FMUstate, fmi2Byte[], size_t size);
+   typedef fmi2Status fmi2SerializeFMUstateTYPE     (fmi2Component c, fmi2FMUstate  FMUstate, fmi2Byte serializedState[], size_t size);
    typedef fmi2Status fmi2DeSerializeFMUstateTYPE   (fmi2Component c, const fmi2Byte serializedState[], size_t size, fmi2FMUstate* FMUstate);
 
 /* Getting partial derivatives */


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Checklist

* [ ] Used a [personal fork](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo) of the repository to propose changes.
* [ ] [Built the specification](https://github.com/modelica/fmi-standard/blob/master/CONTRIBUTING.adoc#building-the-specification-document).
* [ ] [Re-generated schema figures](https://github.com/modelica/fmi-standard/blob/master/CONTRIBUTING.adoc#changing-the-xsd-schemas).
* [ ] [Linted the documents](https://github.com/modelica/fmi-standard/blob/master/CONTRIBUTING.adoc#building-the-specification-document).

Add your [meaningful description](https://github.com/modelica/fmi-standard/blob/master/CONTRIBUTING.adoc#bug-reports) here and reference any related issues with `#<issue>`.