### PR TITLE
Add ABI version for VS 2019

### DIFF
--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -196,7 +196,10 @@ ABI version `<abi_ver>`::
 |Visual Studio 2015 (MSVC++ 14.0)
 
 |141
-|Visual Studio 2017 (MSVC++ 15.0)
+|Visual Studio 2017 (MSVC++ 15.X)
+
+|142
+|Visual Studio 2019 (MSVC++ 16.X)
 |====
 
 Sub-ABI `<abi_sub>`::

--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -196,10 +196,10 @@ ABI version `<abi_ver>`::
 |Visual Studio 2015 (MSVC++ 14.0)
 
 |141
-|Visual Studio 2017 (MSVC++ 15.X)
+|Visual Studio 2017 (MSVC++ 15.x)
 
 |142
-|Visual Studio 2019 (MSVC++ 16.X)
+|Visual Studio 2019 (MSVC++ 16.x)
 |====
 
 Sub-ABI `<abi_sub>`::


### PR DESCRIPTION
This also generalizes the MSVC version for `abi_ver` = 141.