### PR TITLE
Fix compression method name `deflate` -> `deflated`

### DIFF
--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -10,7 +10,7 @@ The behavior of those functions is unspecified, so while calling environments ca
 The extension of the ZIP file must be `.fmu` _[, for example, `HybridVehicle.fmu`]_.
 The compression method for all files stored in the ZIP archive must be either 8 (`deflate`), or 0 (`store`).
 Only files stored using compression method 8 (`deflate`) may be stored with general purpose bit 3 set.
-The version needed to extract field of the archive must not be higher than 2.0, and encryption must not be employed.
+The field `version needed to extract` of the archive must not be higher than 2.0, and encryption must not be employed.
 The archive may not be a split or spanned ZIP archive.
  _[These restrictions ensure broad compatibility of the archive with common ZIP processing tools and libraries.)]_
 

--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -8,7 +8,7 @@ The FMU must implement all common API functions according to <<general-mechanism
 Especially it is required that all functions that are part of the specified FMI interface type are present, even if they are only needed for optional capabilities that the FMU does not support.
 The behavior of those functions is unspecified, so while calling environments can rely on the functions being present, they cannot rely on any particular behavior for functions only needed for capabilities the FMU does not support.
 The extension of the ZIP file must be `.fmu` _[, for example, `HybridVehicle.fmu`]_.
-The compression method used for the ZIP file must be `deflate` _[(most free tools, such as zlib, offer only the common compression method `deflate`)]_.
+The compression method for all files stored in the ZIP file must be `deflated` _[(most free tools, such as zlib, offer only the common compression method `deflated`)]_.
 
 
 _[Note: especially section 4.4.17 of https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT[the ZIP format specification] states that backslashes "\" are forbidden as path separator, only forward slashes "/" are allowed._ +

--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -8,8 +8,11 @@ The FMU must implement all common API functions according to <<general-mechanism
 Especially it is required that all functions that are part of the specified FMI interface type are present, even if they are only needed for optional capabilities that the FMU does not support.
 The behavior of those functions is unspecified, so while calling environments can rely on the functions being present, they cannot rely on any particular behavior for functions only needed for capabilities the FMU does not support.
 The extension of the ZIP file must be `.fmu` _[, for example, `HybridVehicle.fmu`]_.
-The compression method for all files stored in the ZIP file must be `deflate` _[(most free tools, such as zlib, offer only the common compression method `deflate`)]_.
-
+The compression method for all files stored in the ZIP archive must be either 8 (`deflate`), or 0 (`store`).
+Only files stored using compression method 8 (`deflate`) may be stored with general purpose bit 3 set.
+The version needed to extract field of the archive must not be higher than 2.0, and encryption must not be employed.
+The archive may not be a split or spanned ZIP archive.
+ _[These restrictions ensure broad compatibility of the archive with common ZIP processing tools and libraries.)]_
 
 _[Note: especially section 4.4.17 of https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT[the ZIP format specification] states that backslashes "\" are forbidden as path separator, only forward slashes "/" are allowed._ +
 _Non-ASCII directory names are not explicitly forbidden, but might pose a problem on different operating systems and are thus discouraged.]_

--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -8,7 +8,7 @@ The FMU must implement all common API functions according to <<general-mechanism
 Especially it is required that all functions that are part of the specified FMI interface type are present, even if they are only needed for optional capabilities that the FMU does not support.
 The behavior of those functions is unspecified, so while calling environments can rely on the functions being present, they cannot rely on any particular behavior for functions only needed for capabilities the FMU does not support.
 The extension of the ZIP file must be `.fmu` _[, for example, `HybridVehicle.fmu`]_.
-The compression method for all files stored in the ZIP file must be `deflated` _[(most free tools, such as zlib, offer only the common compression method `deflated`)]_.
+The compression method for all files stored in the ZIP file must be `deflate` _[(most free tools, such as zlib, offer only the common compression method `deflate`)]_.
 
 
 _[Note: especially section 4.4.17 of https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT[the ZIP format specification] states that backslashes "\" are forbidden as path separator, only forward slashes "/" are allowed._ +


### PR DESCRIPTION
This PR fixes two tiny issues on the FMU compression:
* The compression property (as for example returned by `unzip -Zsvh HybridVehicle.fmu`) is called `deflated`.
* The compression method is not a per-archive property, but a per-file property.

Additionally, it is not clear which zlib tool is meant, since usually zlib is a library (see https://en.wikipedia.org/wiki/Zlib).