### PR TITLE
add newline to fix link to states

### DIFF
--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -626,6 +626,7 @@ This argument is only valid in Model Exchange.
 
 [[valuesOfContinuousStatesChanged,`valuesOfContinuousStatesChanged`]]
 * If argument `valuesOfContinuousStatesChanged == fmi3True`, then at least one continuous state has changed its value. +
+
 [[state,`state`]]
 The new values of the <<state,`states`>> can be inquired with <<fmi3GetContinuousStates>> or individually for each state for which <<reinit, `reinit = true`>> by calling `fmi3GetFloat64`. +
 This argument is only valid in Model Exchange.


### PR DESCRIPTION
Fix link to "state" by inserting a newline
(for #1272 generation and upload of generated html is not working)