### PR TITLE
Clarify that in "equations and actions" tables there is no order

### DIFF
--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -1,10 +1,10 @@
 === State Machine and Semantics [[common-state-machine]]
 
-To define allowed calling sequences of FMI functions, state machines are used.
+To define allowed calling sequences of FMI functions, state machines are used. Each state of the state machine corresponds to a certain phase of a simulation.
 All FMI interface types share a number of states in their respective state machines.
 This chapter describes these common states used in at least two of the interface types.
-FMI specific state-machine states will be described in their respective chapters.
-Each state of the state machine corresponds to a certain phase of a simulation.
+State-machine states specific to special FMI interface types will be described in their respective chapters.
+There for each state, the governing equations and actions and the corresponding API functions influencing these equations are listed in a table (not necessarily reflecting the calling order), and allowed functions calls and restrictions on the calling order of these functions are listed.
 
 .Common calling sequence for C functions of common states for all three FMI types.
 [#figure-common-state-machine]
@@ -221,7 +221,7 @@ In the state <<Instantiated>> the FMU can do one-time initializations and alloca
 [#table-math-instantiated]
 [cols="2,1",options="header",]
 |====
-|Equations and Actions
+|Equations and Actions _(not ordered)_
 |Functions Influencing Equations
 
 |Set variables latexmath:[(\mathbf{v}_{\mathit{initial=exact}}] or latexmath:[\mathbf{v}_{\mathit{initial=approx}})] and latexmath:[\mathbf{v}_{\mathit{variability \neq constant}}]
@@ -334,7 +334,7 @@ In <<InitializationMode>>, the FMU computes initial values at the start time lat
 [#table-math-initializationMode]
 [cols="2,1",options="header",]
 |====
-|Equations and Actions
+|Equations and Actions _(not ordered)_
 |Functions Influencing Equations
 
 |Set variables latexmath:[\mathbf{v}_{\mathit{initial=exact}}] +
@@ -424,7 +424,7 @@ The <<ConfigurationMode>> allows setting <<structuralParameter, `structural para
 [#table-math-configurationMode]
 [cols="2,1",options="header",]
 |====
-|Equations and Actions
+|Equations and Actions _(not ordered)_
 |Functions Influencing Equations
 
 |Set latexmath:[\mathbf{v}_{\mathit{causality=structuralParameter}}] +
@@ -456,7 +456,7 @@ In this state, the final values of all variables at the final time of a simulati
 [#table-math-terminated]
 [cols="2,1",options="header",]
 |====
-|Equations and Actions
+|Equations and Actions _(not ordered)_
 |Functions Influencing Equations
 
 |latexmath:[(\mathbf{y}_{c+d}, \mathbf{\dot{x}}_c, \mathbf{x}_{c+d}, \mathbf{z}, \mathbf{w}_{c+d}) := \mathbf{f}_{\mathit{term}}({}^\bullet\mathbf{x}_{c+d}, \mathbf{u}_{c+d}, \mathbf{p}, \mathbf{t})]
@@ -486,7 +486,7 @@ This super state is entered by the FMU when <<fmi3ExitInitializationMode>> is ca
 [#table-math-initialized]
 [cols="2,1",options="header",]
 |====
-|Equations and Actions
+|Equations and Actions _(not ordered)_
 |Functions Influencing Equations
 
 |Activate termination equations latexmath:[\mathbf{f}_{\mathit{term}}].
@@ -523,7 +523,7 @@ There are multiple kinds of events that require a transition to <<EventMode>>:
 [#table-math-event-mode]
 [cols="5,3",options="header",]
 |====
-|Equations and Actions
+|Equations and Actions _(not ordered)_
 |Functions Influencing Equations
 
 |Set <<tunable>> <<parameter,`parameters`>> latexmath:[\mathbf{p}_{\mathit{variability == tunable}}]
@@ -677,7 +677,7 @@ This state must not be entered, if the FMU contains no <<structuralParameter,`st
 [#table-math-reconfigurationMode]
 [cols="2,1",options="header",]
 |====
-|Equations and Actions
+|Equations and Actions _(not ordered)_
 |Functions Influencing Equations
 
 |Set latexmath:[\mathbf{v}_{\mathit{causality=structuralParameter}}] +
@@ -790,7 +790,7 @@ This argument is ignored in Scheduled Execution.
 [#table-math-intermediateUpdateMode]
 [cols="2,1",options="header",]
 |====
-|Equations and Actions
+|Equations and Actions _(not ordered)_
 |Functions Influencing Equations
 
 |Get intermediate variable values latexmath:[\mathbf{v}_u(\mathbf{t}_u)]

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -5,7 +5,9 @@ Each state of the state machine corresponds to a certain phase of a simulation.
 All FMI interface types share a number of states in their respective state machines.
 This chapter describes these common states used in at least two of the interface types.
 State-machine states specific to a single FMI interface type will be described in their respective chapters.
-Each state description lists the governing equations and actions and the corresponding API functions influencing these equations in a table (not reflecting the calling order), and also lists the allowed function calls and usage restrictions.
+
+[[each-state-description]]
+Each state description lists the governing equations and actions and the corresponding API functions influencing these equations in a table (not defining the calling order), and also lists the allowed function calls and usage restrictions.
 
 .Common calling sequence for C functions of common states for all three FMI types.
 [#figure-common-state-machine]
@@ -222,7 +224,7 @@ In the state <<Instantiated>> the FMU can do one-time initializations and alloca
 [#table-math-instantiated]
 [cols="2,1",options="header",]
 |====
-|Equations and Actions _(not ordered)_
+|<<each-state-description,Equations and Actions>>
 |Functions Influencing Equations
 
 |Set variables latexmath:[(\mathbf{v}_{\mathit{initial=exact}}] or latexmath:[\mathbf{v}_{\mathit{initial=approx}})] and latexmath:[\mathbf{v}_{\mathit{variability \neq constant}}]
@@ -335,7 +337,7 @@ In <<InitializationMode>>, the FMU computes initial values at the start time lat
 [#table-math-initializationMode]
 [cols="2,1",options="header",]
 |====
-|Equations and Actions _(not ordered)_
+|<<each-state-description,Equations and Actions>>
 |Functions Influencing Equations
 
 |Set variables latexmath:[\mathbf{v}_{\mathit{initial=exact}}] +
@@ -425,7 +427,7 @@ The <<ConfigurationMode>> allows setting <<structuralParameter, `structural para
 [#table-math-configurationMode]
 [cols="2,1",options="header",]
 |====
-|Equations and Actions _(not ordered)_
+|<<each-state-description,Equations and Actions>>
 |Functions Influencing Equations
 
 |Set latexmath:[\mathbf{v}_{\mathit{causality=structuralParameter}}] +
@@ -457,7 +459,7 @@ In this state, the final values of all variables at the final time of a simulati
 [#table-math-terminated]
 [cols="2,1",options="header",]
 |====
-|Equations and Actions _(not ordered)_
+|<<each-state-description,Equations and Actions>>
 |Functions Influencing Equations
 
 |latexmath:[(\mathbf{y}_{c+d}, \mathbf{\dot{x}}_c, \mathbf{x}_{c+d}, \mathbf{z}, \mathbf{w}_{c+d}) := \mathbf{f}_{\mathit{term}}({}^\bullet\mathbf{x}_{c+d}, \mathbf{u}_{c+d}, \mathbf{p}, \mathbf{t})]
@@ -487,7 +489,7 @@ This super state is entered by the FMU when <<fmi3ExitInitializationMode>> is ca
 [#table-math-initialized]
 [cols="2,1",options="header",]
 |====
-|Equations and Actions _(not ordered)_
+|<<each-state-description,Equations and Actions>>
 |Functions Influencing Equations
 
 |Activate termination equations latexmath:[\mathbf{f}_{\mathit{term}}].
@@ -524,7 +526,7 @@ There are multiple kinds of events that require a transition to <<EventMode>>:
 [#table-math-event-mode]
 [cols="5,3",options="header",]
 |====
-|Equations and Actions _(not ordered)_
+|<<each-state-description,Equations and Actions>>
 |Functions Influencing Equations
 
 |Set <<tunable>> <<parameter,`parameters`>> latexmath:[\mathbf{p}_{\mathit{variability == tunable}}]
@@ -678,7 +680,7 @@ This state must not be entered, if the FMU contains no <<structuralParameter,`st
 [#table-math-reconfigurationMode]
 [cols="2,1",options="header",]
 |====
-|Equations and Actions _(not ordered)_
+|<<each-state-description,Equations and Actions>>
 |Functions Influencing Equations
 
 |Set latexmath:[\mathbf{v}_{\mathit{causality=structuralParameter}}] +
@@ -791,7 +793,7 @@ This argument is ignored in Scheduled Execution.
 [#table-math-intermediateUpdateMode]
 [cols="2,1",options="header",]
 |====
-|Equations and Actions _(not ordered)_
+|<<each-state-description,Equations and Actions>>
 |Functions Influencing Equations
 
 |Get intermediate variable values latexmath:[\mathbf{v}_u(\mathbf{t}_u)]

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -1,10 +1,11 @@
 === State Machine and Semantics [[common-state-machine]]
 
-To define allowed calling sequences of FMI functions, state machines are used. Each state of the state machine corresponds to a certain phase of a simulation.
+To define allowed calling sequences of FMI functions, state machines are used.
+Each state of the state machine corresponds to a certain phase of a simulation.
 All FMI interface types share a number of states in their respective state machines.
 This chapter describes these common states used in at least two of the interface types.
-State-machine states specific to special FMI interface types will be described in their respective chapters.
-There for each state, the governing equations and actions and the corresponding API functions influencing these equations are listed in a table (not necessarily reflecting the calling order), and allowed functions calls and restrictions on the calling order of these functions are listed.
+State-machine states specific to a single FMI interface type will be described in their respective chapters.
+Each state description lists the governing equations and actions and the corresponding API functions influencing these equations in a table (not reflecting the calling order), and also lists the allowed function calls and usage restrictions.
 
 .Common calling sequence for C functions of common states for all three FMI types.
 [#figure-common-state-machine]

--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -74,7 +74,7 @@ extra                         // Additional (meta-)data of the FMU (optional)
 <<figure-zip-structure>> defines the files expected in the `documentation` directory.
 
 ====== Directory Licenses [[license-information]]
-This optional subdirectory can be used to bundle all license texts for the code, binaries or other material (documentation, content of resources folder) contained tin the FMU.
+This optional subdirectory can be used to bundle all license texts for the code, binaries or other material (documentation, content of resources folder) contained in the FMU.
 If it is present, it must contain either a https://spdx.dev[license.spdx], `license.txt` or `license.html` file as entry point.
 
 _[It is strongly recommended to include all license and copyright related information in the licenses folder of an FMU (especially but not only for contained open source software) - the `license.{txt|html}` file can serve as an entry point for describing the contained licenses._

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -18,7 +18,7 @@ In this state, the continuous-time equations are active and integrator steps are
 [#table-math-model-exchange]
 [cols="7,3",options="header"]
 |====
-|Equations and Actions
+|Equations and Actions _(not ordered)_
 |Functions Influencing Equations
 
 |latexmath:[\mathbf{t} := (]<<time>>latexmath:[, 0)]

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -18,7 +18,7 @@ In this state, the continuous-time equations are active and integrator steps are
 [#table-math-model-exchange]
 [cols="7,3",options="header"]
 |====
-|Equations and Actions _(not ordered)_
+|<<each-state-description,Equations and Actions>>
 |Functions Influencing Equations
 
 |latexmath:[\mathbf{t} := (]<<time>>latexmath:[, 0)]

--- a/docs/4_2_co-simulation_api.adoc
+++ b/docs/4_2_co-simulation_api.adoc
@@ -19,7 +19,7 @@ If the FMU is connected in loops with other models, iterations over the FMU equa
 
 [cols="2,1",options="header",]
 |====
-|Equations and Actions _(not ordered)_
+|<<each-state-description,Equations and Actions>>
 |Functions Influencing Equations
 
 |Set <<tunable>> <<parameter,`parameters`>> latexmath:[\mathbf{p}_{\mathit{variability == tunable}}] .

--- a/docs/4_2_co-simulation_api.adoc
+++ b/docs/4_2_co-simulation_api.adoc
@@ -19,7 +19,7 @@ If the FMU is connected in loops with other models, iterations over the FMU equa
 
 [cols="2,1",options="header",]
 |====
-|Equations and Actions
+|Equations and Actions _(not ordered)_
 |Functions Influencing Equations
 
 |Set <<tunable>> <<parameter,`parameters`>> latexmath:[\mathbf{p}_{\mathit{variability == tunable}}] .

--- a/docs/5_2_scheduled_execution_api.adoc
+++ b/docs/5_2_scheduled_execution_api.adoc
@@ -37,7 +37,7 @@ In this state the simulation algorithm can create multiple concurrent tasks rela
 
 [cols="2,1",options="header",]
 |====
-|Equations and Actions _(not ordered)_
+|<<each-state-description,Equations and Actions>>
 |Functions Influencing Equations
 
 |Set <<tunable>> <<parameter,`parameters`>> latexmath:[\mathbf{p}_{\mathit{variability == tunable}}] .

--- a/docs/5_2_scheduled_execution_api.adoc
+++ b/docs/5_2_scheduled_execution_api.adoc
@@ -37,7 +37,7 @@ In this state the simulation algorithm can create multiple concurrent tasks rela
 
 [cols="2,1",options="header",]
 |====
-|Equations and Actions
+|Equations and Actions _(not ordered)_
 |Functions Influencing Equations
 
 |Set <<tunable>> <<parameter,`parameters`>> latexmath:[\mathbf{p}_{\mathit{variability == tunable}}] .


### PR DESCRIPTION
a proposol to fix  the topic of this comment: https://github.com/modelica/fmi-standard/pull/1272#discussion_r573206441 
(I falsely read the "equations and actions" tables to suggest a specfic calling order of the associated API functions.)