### PR TITLE
Turn up into Up for Functional Mock-Up

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,10 +1,10 @@
 image::docs/images/FMI_logo_horizontal.svg[width=30%,align="center"]
 
-= Functional Mock-up Interface
+= Functional Mock-Up Interface
 
 image:https://circleci.com/gh/modelica/fmi-standard.svg?style=svg["CircleCI", link="https://circleci.com/gh/modelica/fmi-standard"]
 
-The Functional Mock-up Interface (FMI) is a free standard that defines an interface to exchange dynamic models using a combination of XML files, binaries and C code.
+The Functional Mock-Up Interface (FMI) is a free standard that defines an interface to exchange dynamic models using a combination of XML files, binaries and C code.
 It's supported by https://fmi-standard.org/tools/[100+] tools and maintained as a https://modelica.org/projects[Modelica Association Project].
 
 https://fmi-standard.org/downloads/[Releases] and the https://fmi-standard.org/docs/3.0-dev/[latest development version] of the specification are available on the https://fmi-standard.org/[FMI website].

--- a/docs/0___preamble.adoc
+++ b/docs/0___preamble.adoc
@@ -1,4 +1,4 @@
-The https://fmi-standard.org/[Functional Mock-up Interface (FMI)] is a free standard that defines a container and an interface to exchange dynamic models using a combination of XML files, binaries and C code, distributed as a ZIP file.
+The https://fmi-standard.org/[Functional Mock-Up Interface (FMI)] is a free standard that defines a container and an interface to exchange dynamic models using a combination of XML files, binaries and C code, distributed as a ZIP file.
 It is supported by https://fmi-standard.org/tools/[more than 150 tools] and maintained as a https://www.modelica.org/projects[Modelica Association Project].
 https://github.com/modelica/fmi-standard/releases[Releases] and https://github.com/modelica/fmi-standard/issues[issues] can be found on https://github.com/modelica/fmi-standard[github.com/modelica].
 

--- a/docs/1___overview.adoc
+++ b/docs/1___overview.adoc
@@ -51,7 +51,7 @@ The asynchronous mode for FMUs known from FMI 2.0 has been removed since this mo
 
 === Overview
 
-The FMI (Functional Mock-up Interface) defines an interface to be implemented by an executable called an FMU (Functional Mock-up Unit).
+The FMI (Functional Mock-Up Interface) defines an interface to be implemented by an executable called an FMU (Functional Mock-Up Unit).
 The FMI functions are used (called) by a simulation environment to create one or more instances of the FMU and to simulate them, typically together with other models.
 An FMU may either have its own solvers (<<fmi-for-co-simulation,FMI for Co-Simulation>>), or require the simulation environment to perform numerical integration (<<fmi-for-model-exchange,FMI for Model Exchange>>), or require the simulation environment to trigger model partition execution (<<fmi-for-scheduled-execution,FMI for Scheduled Execution>>).
 The goal of this interface is that the calling of an FMU in a simulation environment is reasonably simple.

--- a/docs/2___common_concepts.adoc
+++ b/docs/2___common_concepts.adoc
@@ -4,7 +4,7 @@ The FMI defines the following interface types: FMI for Model Exchange, Co-Simula
 The concepts defined in this chapter are common to at least two of these interface types.
 The definitions that are specific to the particular cases are defined in <<fmi-for-model-exchange>>, <<fmi-for-co-simulation>>, and <<fmi-for-scheduled-execution>>.
 
-The term _FMU_ (Functional Mock-up Unit) denotes an implementation (or any mix) of interface types.
+The term _FMU_ (Functional Mock-Up Unit) denotes an implementation (or any mix) of interface types.
 
 In the following, we assume that the reader is familiar with the basics of the C programming language and the basics of numerical simulation.
 Please refer to <<glossary>> for the most commonly used terms.

--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -72,7 +72,7 @@ See <<state-event,event indicator>>.
 |See _direct feedthrough_.
 
 |_FMI_
-|Functional Mock-up Interface: +
+|Functional Mock-Up Interface: +
 Interface of a functional mock-up in form of a model.
 In analogy to the term digital mock-up (see _mock-up_), functional mock-up describes a computer-based representation of the functional behaviour of a system for all kinds of analyses.
 
@@ -80,15 +80,15 @@ In analogy to the term digital mock-up (see _mock-up_), functional mock-up descr
 |The function of the FMI C-API.
 
 |_FMI for co-simulation_
-|Functional Mock-up Interface for Co-Simulation: +
-One of the MODELISAR _functional mock-up interface types._ It connects the _importer_ with one or more _FMU_.
+|Functional Mock-Up Interface for Co-Simulation: +
+One of the MODELISAR _Functional Mock-Up Interface types._ It connects the _importer_ with one or more _FMU_.
 
 |_FMI for model exchange_
-|Functional Mock-up Interface for Model Exchange: +
-One of the MODELISAR _functional mock-up interface types._ It consists of the _model description_ and the _C API_. +
+|Functional Mock-Up Interface for Model Exchange: +
+One of the MODELISAR _Functional Mock-Up Interface types._ It consists of the _model description_ and the _C API_. +
 
 |_FMU_
-|Functional Mock-up Unit: +
+|Functional Mock-Up Unit: +
 A "model class" following the interface type FMI for Model Exchange, or a model following the interface types FMI for Co-Simulation or FMI for Scheduled Execution).
 An FMU is one ZIP file as defined in <<fmu-distribution>>.
 The zip file comprises essentially an XML file that defines the model variables, and a set of C function implementations (see <<general-mechanisms>>).

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,4 +1,4 @@
-= Functional Mock-up Interface Specification
+= Functional Mock-Up Interface Specification
 :sectnums:
 :sectnumlevels: 5
 :toc: left


### PR DESCRIPTION
Out logo uses "Functional Mock-Up Interface".
The web page almost always uses "Functional Mock-up Interface" in the text.

Do we want to use the logo way in 3.0?
This PR has the required changes.