### PR TITLE
Use C99 int/bool types for all types

### DIFF
--- a/headers/fmi3PlatformTypes.h
+++ b/headers/fmi3PlatformTypes.h
@@ -54,7 +54,7 @@ typedef void*           fmi3FMUState;             /* Pointer to internal FMU sta
 /* end::FMUState[] */
 
 /* tag::ValueReference[] */
-typedef unsigned int    fmi3ValueReference;       /* Handle to the value of a variable */
+typedef        uint32_t fmi3ValueReference;       /* Handle to the value of a variable */
 /* end::ValueReference[] */
 
 /* tag::VariableTypes[] */
@@ -68,15 +68,15 @@ typedef         int32_t fmi3Int32;    /* 32-bit signed integer */
 typedef        uint32_t fmi3UInt32;   /* 32-bit unsigned integer */
 typedef         int64_t fmi3Int64;    /* 64-bit signed integer */
 typedef        uint64_t fmi3UInt64;   /* 64-bit unsigned integer */
-typedef            char fmi3Boolean;  /* Data type to be used with fmi3True and fmi3False */
+typedef           _Bool fmi3Boolean;  /* Data type to be used with fmi3True and fmi3False */
 typedef            char fmi3Char;     /* Data type for one character */
 typedef const fmi3Char* fmi3String;   /* Data type for character strings
                                          ('\0' terminated, UTF-8 encoded) */
-typedef            char fmi3Byte;     /* Smallest addressable unit of the machine
+typedef         uint8_t fmi3Byte;     /* Smallest addressable unit of the machine
                                          (typically one byte) */
 typedef const fmi3Byte* fmi3Binary;   /* Data type for binary data
                                          (out-of-band length terminated) */
-typedef            char fmi3Clock;    /* Data type to be used with fmi3ClockActive and
+typedef           _Bool fmi3Clock;    /* Data type to be used with fmi3ClockActive and
                                          fmi3ClockInactive */
 
 /* Values for fmi3Boolean */


### PR DESCRIPTION
Given that we already depend on the C99 integer types for our integer
types, we might as well switch to use the C99 _Bool type and integer
types for all other typedefs to make the interface ABI more stable.

This reflects the discussions in the design meeting on 2021-02-19

Checklist

* [ ] Used a [personal fork](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo) of the repository to propose changes.
* [ ] [Built the specification](https://github.com/modelica/fmi-standard/blob/master/CONTRIBUTING.adoc#building-the-specification-document).
* [ ] [Re-generated schema figures](https://github.com/modelica/fmi-standard/blob/master/CONTRIBUTING.adoc#changing-the-xsd-schemas).
* [ ] [Linted the documents](https://github.com/modelica/fmi-standard/blob/master/CONTRIBUTING.adoc#building-the-specification-document).

See also PR #1102 which started the discussion.