### PR TITLE
allow getNominalsOfContinuous stats in intialization model in FMI 2.0.3, backport of #1284

### DIFF
--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -343,7 +343,7 @@ the other functions are available both for "Model Exchange" and "Co-Simulation")
 |fmi2GetEventIndicators            {set:cellbgcolor:yellow} |  {set:cellbgcolor!} |  |x |x |x |x |7 |
 |fmi2GetContinuousStates           {set:cellbgcolor:yellow} |  {set:cellbgcolor!} |  |x |x |x |x |7 |
 |fmi2GetDerivatives                {set:cellbgcolor:yellow} |  {set:cellbgcolor!} |  |x |x |x |x |7 |
-|fmi2GetNominalsOfContinuousStates {set:cellbgcolor:yellow} |  {set:cellbgcolor!} |x |  |x |x |x |7 |
+|fmi2GetNominalsOfContinuousStates {set:cellbgcolor:yellow} |  {set:cellbgcolor!} |x |x |x |x |x |7 |
 |====
 
 *x* means: call is allowed in the corresponding state +
@@ -356,8 +356,8 @@ or `causality` = `"input"` +
 *4* for a variable with `causality` = `"input"`,
 or (`causality` = `"parameter"` and `variability` = `"tunable"`) +
 *5* for a variable with `causality` = `"input"` and `variability` = `"continuous"`, and for a continuous-time state variable +
-_[Clarification in FMI 2.0.1: This rule regarding  a continuous-time state variable is not shown in the state machine diagram above but shall be applied.]_ + 
-*7* always, but retrieved values are usable for debugging only + 
+_[Clarification in FMI 2.0.1: This rule regarding  a continuous-time state variable is not shown in the state machine diagram above but shall be applied.]_ +
+*7* always, but retrieved values are usable for debugging only +
 *8* only for a Pure Discrete-Time FMU. This exits the current event mode and sets the time for the next event instant. `fmi2NewDiscreteStates` must have been called with `newDiscreteStatesNeeded` = `fmi2False` at least once before this can be done:
 
 ==== Pseudocode Example
@@ -480,7 +480,7 @@ do
 
   // detect  events, if any
   timeEvent = time >= tNext
-  stateEvent = sign(z) <> sign(previous_z) or previous_z != 0 && z == 0 
+  stateEvent = sign(z) <> sign(previous_z) or previous_z != 0 && z == 0
   previous_z = z
 
   // inform the model about an accepted step

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -356,7 +356,7 @@ or `causality` = `"input"` +
 *4* for a variable with `causality` = `"input"`,
 or (`causality` = `"parameter"` and `variability` = `"tunable"`) +
 *5* for a variable with `causality` = `"input"` and `variability` = `"continuous"`, and for a continuous-time state variable +
-_[Clarification in FMI 2.0.1: This rule regarding  a continuous-time state variable is not shown in the state machine diagram above but shall be applied.]_ +
+_[Clarification in FMI 2.0.1: This rule regarding a continuous-time state variable is not shown in the state machine diagram above but shall be applied.]_ +
 *7* always, but retrieved values are usable for debugging only +
 *8* only for a Pure Discrete-Time FMU. This exits the current event mode and sets the time for the next event instant. `fmi2NewDiscreteStates` must have been called with `newDiscreteStatesNeeded` = `fmi2False` at least once before this can be done:
 


### PR DESCRIPTION
resolves #1301 
