### PR TITLE
Don't mention that variables are an ordered set

### DIFF
--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -822,7 +822,7 @@ It provides the static information of all exposed variables and is defined as fo
 [[figure-schema-ModelVariables]]
 image::images/schema/ModelVariables.png[width=60%, align="center"]
 
-The `<ModelVariables>` element consists of an ordered set of variable elements (see <<figure-schema-ModelVariables>>).
+The `<ModelVariables>` element consists of variable elements (see <<figure-schema-ModelVariables>>).
 Variable elements can uniformly represent variables of primitive (atomic) types, like single floating point or integer variables, as well as arrays of an arbitrary (but fixed) number of dimensions.
 The schema definition is present in a separate file `fmi3Variable.xsd`.
 


### PR DESCRIPTION
The current spec still mentions that the variable elements of <ModelVariables> are an ordered set.
I think this is not necessary anymore and even confusing for the reader.
The ordering was only important when indices were used and got obsolete after we switched to use valueReferences.