### PR TITLE
intermediateUpdateTime in SE

### DIFF
--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -715,7 +715,7 @@ The mathematical descriptions of <<time-based-clocks>> will use the following no
 latexmath:[\mathbf{T}_{interval, i}] can be set with <<fmi3SetIntervalDecimal>> or retrieved with <<fmi3GetIntervalDecimal>> as floating point value, or as rational number using <<fmi3SetIntervalFraction>> or <<fmi3GetIntervalFraction>>: latexmath:[\mathit{intervalCounter} / \mathit{resolution}] (see <<resolution>>).
 
 |latexmath:[\mathbf{t}_\mathit{event}]
-|Current event time in <<EventMode>>, or the current time in <<ClockActivationMode>> in SE.
+|Current event time in <<EventMode>>, or the current time in SE.
 
 |===
 

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -731,7 +731,7 @@ If an event happens or an <<outputClock>> ticks, <<intermediateUpdateTime>> is t
 In Co-Simulation, <<intermediateUpdateTime>> is restricted by the arguments to <<fmi3DoStep>> as follows: +
 <<currentCommunicationPoint>> latexmath:[\leq] <<intermediateUpdateTime>> latexmath:[\leq] (<<currentCommunicationPoint>> + <<communicationStepSize>>). +
 The FMU must not call the callback function <<fmi3CallbackIntermediateUpdate>> with an <<intermediateUpdateTime>> that is smaller than the <<intermediateUpdateTime>> given in a previous call of <<fmi3CallbackIntermediateUpdate>> with `intermediateStepFinished == fmi3True`.
-In Scheduled Execution the <<intermediateUpdateTime>> is equal or greater than <<activationTime>> of <<fmi3ActivateModelPartition>>.
+In Scheduled Execution the <<intermediateUpdateTime>> can be ignored.
 
 [[clocksTicked,`clocksTicked`]]
 * The <<clocksTicked>> parameter is only used in Scheduled Execution and is ignored in Co-Simulation.

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -731,7 +731,7 @@ If an event happens or an <<outputClock>> ticks, <<intermediateUpdateTime>> is t
 In Co-Simulation, <<intermediateUpdateTime>> is restricted by the arguments to <<fmi3DoStep>> as follows: +
 <<currentCommunicationPoint>> latexmath:[\leq] <<intermediateUpdateTime>> latexmath:[\leq] (<<currentCommunicationPoint>> + <<communicationStepSize>>). +
 The FMU must not call the callback function <<fmi3CallbackIntermediateUpdate>> with an <<intermediateUpdateTime>> that is smaller than the <<intermediateUpdateTime>> given in a previous call of <<fmi3CallbackIntermediateUpdate>> with `intermediateStepFinished == fmi3True`.
-In Scheduled Execution the <<intermediateUpdateTime>> can be ignored.
+In Scheduled Execution the <<intermediateUpdateTime>> should be ignored since in this case the simulation algorithm controls the time and not the FMU.
 
 [[clocksTicked,`clocksTicked`]]
 * The <<clocksTicked>> parameter is only used in Scheduled Execution and is ignored in Co-Simulation.


### PR DESCRIPTION
As discussed concerning in last design meeting the intermediateUpdateTime is not relevant in SE. @andreas-junghanns, @chrbertsch please have a look. FYI: @IZacharias Closes #1308 