### PR TITLE
Unify naming of "continuous states" and "derivatives" in API and XML

### DIFF
--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -1040,12 +1040,12 @@ where
 
 ** <<InitializationMode>>: The exposed unknowns listed as elements <<InitialUnknown>> in `<ModelStructure>` that have a floating point type.
 
-** <<ContinuousTimeMode>> (Model Exchange): The continuous-time outputs and state derivatives (= the variables listed as elements <<Output>> of `<ModelStructure>` with a floating point type and <<variability>> = <<continuous>> and the variables listed as elements <<StateDerivative>> in `<ModelStructure>`).
+** <<ContinuousTimeMode>> (Model Exchange): The continuous-time outputs and state derivatives (= the variables listed as elements <<Output>> of `<ModelStructure>` with a floating point type and <<variability>> = <<continuous>> and the variables listed as elements <<ContinuousStateDerivative>> in `<ModelStructure>`).
 
 ** <<EventMode>> (Model Exchange): The same variables as in the <<ContinuousTimeMode>> and additionally variables listed as elements <<Output>> of `<ModelStructure>` with a floating point type and <<variability>> = <<discrete>>.
 
 ** <<StepMode>> (Co-Simulation): The variables listed as elements <<Output>> of `<ModelStructure>` with a floating point type and <<variability>> = <<continuous>> or <<discrete>>.
-Each state derivative variable listed as elements <<StateDerivative>> in `<ModelStructure>`, if present.
+Each continuous state derivative variable listed as elements <<ContinuousStateDerivative>> in `<ModelStructure>`, if present.
 
 * latexmath:[\mathbf{v}_{\mathit{known}}] is the vector of <<input>> variables of function *f* which can be changed by the importer in the current state.
 Details about which variables are in latexmath:[\mathbf{v}_{\mathit{known}}] are given in the description of element <<dependencies>> in <<ModelStructure>>.

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -480,7 +480,7 @@ These functions are only supported by the FMU, if the optional capability flags 
 ==== Selective Computation of Variables [[selectiv-computation]]
 
 Depending on the phase of the solver algorithm, different FMU variables need to be computed.
-FMI allows selective retrieval of FMU variables with specific get functions (e.g. <<get-and-set-variable-values,`fmi3Get{VariableType}`>>, <<fmi3GetEventIndicators>>, <<fmi3GetDerivatives>>).
+FMI allows selective retrieval of FMU variables with specific get functions (e.g. <<get-and-set-variable-values,`fmi3Get{VariableType}`>>, <<fmi3GetEventIndicators>>, <<fmi3GetContinuousStateDerivatives>>).
 This enables computation on demand with subsequent calls returning the same value until some set operation requires re-computation.
 
 For example, during the iteration of an integrator step, only the state derivatives need to be computed, provided the <<output>> of a model is not connected.

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -327,7 +327,7 @@ continuous-time <<state,`states`>> latexmath:[\mathbf{x}_{c,\mathit{initial=exac
 |<<get-and-set-variable-values,`fmi3Set{VariableType}`>>
 
 |latexmath:[(\mathbf{y}_{c+d}, \mathbf{\dot{x}}_c, \mathbf{x}_{c+d}, ^{\bullet}\mathbf{x}_d, \mathbf{z}, \mathbf{r}, \mathbf{w}_{c+d}, \mathbf{b}, \mathbf{T}_{\mathit{shift}}, \mathbf{T}_\mathit{interval}) := \mathbf{f}_{\mathit{init}}(\mathbf{u}_{c+d}, \mathbf{t}_{start}, \mathbf{v}_{\mathit{initial=exact}})]
-|<<get-and-set-variable-values,`fmi3Get{VariableType}`>>, <<fmi3GetDerivatives>>, <<fmi3GetContinuousStates>>, <<fmi3GetEventIndicators>>, <<fmi3GetShift>>, <<fmi3GetInterval>>
+|<<get-and-set-variable-values,`fmi3Get{VariableType}`>>, <<fmi3GetContinuousStateDerivatives>>, <<fmi3GetContinuousStates>>, <<fmi3GetEventIndicators>>, <<fmi3GetShift>>, <<fmi3GetInterval>>
 
 a|
 * Evaluate latexmath:[\mathbf{f}_{\mathit{init}}], if no `fmi3GetXXX` function was called
@@ -348,8 +348,8 @@ This function can be called for variables with <<variability>> latexmath:[\neq] 
 Functions <<get-and-set-variable-values,`fmi3Get{VariableType}`>>::
 Getting variables might trigger <<selectiv-computation,computations>>.
 
-Function <<fmi3GetDerivatives>>::
-See <<fmi3GetDerivatives>> for Model Exchange only.
+Function <<fmi3GetContinuousStateDerivatives>>::
+See <<fmi3GetContinuousStateDerivatives>> for Model Exchange only.
 
 [[fmi3GetContinuousStates,`fmi3GetContinuousStates`]]
 Function <<fmi3GetContinuousStates>>::
@@ -485,7 +485,7 @@ a|
 * Activate output clocks and respective model partitions in latexmath:[\mathbf{f}_{\mathit{event}}] +
 * latexmath:[(\mathbf{y}_{c+d}, \mathbf{\dot{x}}_c, \mathbf{x}_{c+d}, \mathbf{z}, \mathbf{r}, \mathbf{w}_{c+d}, \mathbf{b}, \mathbf{T}_{\mathit{next}}) := \mathbf{f}_{\mathit{event}}({}^\bullet\mathbf{x}_{c+d}, \mathbf{u}_{c+d}, \mathbf{p}, {}^\bullet\mathbf{b}, \mathbf{t})]
 |<<get-and-set-variable-values,`fmi3Get{VariableType}`>>, +
-<<fmi3GetDerivatives>>, +
+<<fmi3GetContinuousStateDerivatives>>, +
 <<fmi3GetContinuousStates>>, +
 <<fmi3GetEventIndicators>> +
 
@@ -541,7 +541,7 @@ Function <<fmi3GetContinuousStates>>::
 This function must be called if <<fmi3UpdateDiscreteStates>> returned with <<valuesOfContinuousStatesChanged, `valuesOfContinuousStatesChanged == fmi3True`>>.
 Can only be called in Model Exchange.
 
-Function <<fmi3GetDerivatives>>::
+Function <<fmi3GetContinuousStateDerivatives>>::
 Function <<fmi3GetEventIndicators>>::
 Function <<fmi3GetNumberOfContinuousStates>>::
 Function <<fmi3GetNumberOfEventIndicators>>::
@@ -826,7 +826,7 @@ In this state, the final values of all variables at the final time of a simulati
 |Functions Influencing Equations
 
 |latexmath:[(\mathbf{y}_{c+d}, \mathbf{\dot{x}}_c, \mathbf{x}_{c+d}, \mathbf{z}, \mathbf{w}_{c+d}) := \mathbf{f}_{\mathit{term}}({}^\bullet\mathbf{x}_{c+d}, \mathbf{u}_{c+d}, \mathbf{p}, \mathbf{t})]
-|<<get-and-set-variable-values,`fmi3Get{VariableType}`>>, <<fmi3GetDerivatives>>, <<fmi3GetContinuousStates>>, <<fmi3GetEventIndicators>>, <<fmi3GetOutputDerivatives>>
+|<<get-and-set-variable-values,`fmi3Get{VariableType}`>>, <<fmi3GetContinuousStateDerivatives>>, <<fmi3GetContinuousStates>>, <<fmi3GetEventIndicators>>, <<fmi3GetOutputDerivatives>>
 |====
 
 Allowed Function Calls::
@@ -835,7 +835,7 @@ Functions <<get-and-set-variable-values,`fmi3Get{VariableType}`>>::
 Getting variables might trigger <<selectiv-computation,computations>>.
 _[If <<Terminated>> is entered because of an `fmi3Error` return value, retrieved values should only be used for debugging purposes.]_
 
-Function <<fmi3GetDerivatives>>::
+Function <<fmi3GetContinuousStateDerivatives>>::
 Function <<fmi3GetContinuousStates>>::
 Function <<fmi3GetNominalsOfContinuousStates>>::
 Function <<fmi3GetEventIndicators>>::

--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -1628,7 +1628,7 @@ The structure of the model is defined in element `<fmiModelDescription><ModelStr
 It defines the <<model-dependencies,dependencies>> between variables.
 
 The required part of the model structure defines an ordering of the <<output,`outputs`>>, the (exposed) <<derivative,`derivatives`>>, the event indicators, and the unknowns that are available during Initialization.
-A Model Exchange FMU must expose all <<derivative,`derivatives`>> of its continuous <<state,`states`>> in <<ContinuousStateDerivative>> in `<ModelStructure>` elements and must expose all event indicators in <<EventIndicator>> elements.
+A Model Exchange FMU must expose all <<derivative,`derivatives`>> of its continuous-time <<state,`states`>> in <<ContinuousStateDerivative>> in `<ModelStructure>` elements and must expose all event indicators in <<EventIndicator>> elements.
 
 The optional part of the model structure defines in which way <<derivative,`derivatives`>>, <<output,`outputs`>>, and initial unknowns depend on <<input,`inputs`>> and/or <<parameter,`parameters`>>, and continuous-time <<state,`states`>>, at the current super-dense time instant (ME) or at the current communication point (CS and SE).
 The listed <<dependencies>> declare the dependencies between whole (multi-dimensional-)variables and not individual elements of the variables.

--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -125,7 +125,7 @@ _Since the XML files are also required to be encoded in UTF-8, string variables 
 
 _[Note that child information items, such as elements in a sequence are ordered lists according to document order, whereas attribute information items are unordered sets (see http://www.w3.org/TR/XML-infoset/#infoitem.element)._
 _The FMI schema is based on ordered lists in a sequence and therefore parsing must preserve this order._
-_For example, the information stored in <<StateDerivative>> in `<ModelStructure>` is only correct if this property is fulfilled.]_
+_For example, the information stored in <<ContinuousStateDerivative>> in `<ModelStructure>` is only correct if this property is fulfilled.]_
 
 All XML-based file formats defined in this standard allow optional `Annotation` elements to be inserted in all XML elements that represent entities of the underlying data model.
 This is achieved through the `Annotations` element:
@@ -940,7 +940,7 @@ The algebraic relationship to the <<input,`inputs`>> can be defined via the <<de
 [[local,`local`]]
 `= local`: Local variables are: +
 
-* continuous <<state,`states`>> and their <<StateDerivative,`StateDerivative`pass:[s]>>, <<ClockedState,`ClockedState`pass:[s]>>, <<EventIndicator,`EventIndicator`pass:[s]>> or <<InitialUnknown,`InitialUnknown`pass:[s]>>.
+* continuous <<state,`states`>> and their <<ContinuousStateDerivative,`ContinuousStateDerivative`pass:[s]>>, <<ClockedState,`ClockedState`pass:[s]>>, <<EventIndicator,`EventIndicator`pass:[s]>> or <<InitialUnknown,`InitialUnknown`pass:[s]>>.
 These variables are listed in the `<fmiModelDescription><ModelStructure>`. +
 * [[localClock,`local clock`]] internal, intermediate variables or local clocks which can be read for debugging purposes and are not listed in the `<fmiModelDescription><ModelStructure>`.
 
@@ -1015,7 +1015,7 @@ Model Exchange: No restrictions on value changes (see <<smoothness>>).
 
 The default is <<continuous>> for variables of type `<Float32>` and `<Float64>`, and <<discrete>> for all other types.
 
-_[Note that the information about continuous <<state,`states`>> is defined with elements <<StateDerivative>> in `<ModelStructure>`.]_
+_[Note that the information about continuous <<state,`states`>> is defined with elements <<ContinuousStateDerivative>> in `<ModelStructure>`.]_
 
 |`initial`
 |
@@ -1476,7 +1476,7 @@ If present, this variable is the derivative of variable with value reference `de
 _[For example, if there are 10 variables and `derivative = 3` for variable 8, then variable 8 is the derivative of variable 3 with respect to the <<independent>> variable (usually time)._
 _This information might be especially used if an <<input>> or an <<output>> is the derivative of another <<input>> or <<output>>, or to define the <<state,`states`>>.]_
 
-The <<state>> <<derivative,`derivatives`>> of an FMU are listed as elements <<StateDerivative>> in `<ModelStructure>`.
+The <<state>> <<derivative,`derivatives`>> of an FMU are listed as elements <<ContinuousStateDerivative>> in `<ModelStructure>`.
 All variables listed in this element must have attribute `derivative` (in order that the continuous-time <<state,`states`>> are uniquely defined).
 
 |`reinit`
@@ -1628,7 +1628,7 @@ The structure of the model is defined in element `<fmiModelDescription><ModelStr
 It defines the <<model-dependencies,dependencies>> between variables.
 
 The required part of the model structure defines an ordering of the <<output,`outputs`>>, the (exposed) <<derivative,`derivatives`>>, the event indicators, and the unknowns that are available during Initialization.
-A Model Exchange FMU must expose all <<derivative,`derivatives`>> of its continuous-time <<state,`states`>> in <<StateDerivative>> in `<ModelStructure>` elements and must expose all event indicators in <<EventIndicator>> elements.
+A Model Exchange FMU must expose all <<derivative,`derivatives`>> of its continuous <<state,`states`>> in <<ContinuousStateDerivative>> in `<ModelStructure>` elements and must expose all event indicators in <<EventIndicator>> elements.
 
 The optional part of the model structure defines in which way <<derivative,`derivatives`>>, <<output,`outputs`>>, and initial unknowns depend on <<input,`inputs`>> and/or <<parameter,`parameters`>>, and continuous-time <<state,`states`>>, at the current super-dense time instant (ME) or at the current communication point (CS and SE).
 The listed <<dependencies>> declare the dependencies between whole (multi-dimensional-)variables and not individual elements of the variables.
@@ -1664,22 +1664,22 @@ Beside the knowns, the <<output,`outputs`>> also depend on "frozen" variables (=
 The functional dependency is defined as (dependencies of variables that are fixed in Event and <<ContinuousTimeMode>> and at communication points are not shown): +
 latexmath:[{(\mathbf{y}_c, \mathbf{y}_d) := \mathbf{f}_{\mathit{output}}(\mathbf{x}_c, \mathbf{u}_c, \mathbf{u}_d, t, \mathbf{p}_{\mathit{tune}})}]
 
-|`StateDerivative`
-|[[StateDerivative,`<StateDerivative>`]]
+|`ContinuousStateDerivative`
+|[[ContinuousStateDerivative,`<ContinuousStateDerivative>`]]
 Ordered list of all state derivatives, in other words, a list of value references where every corresponding variable must be a state derivative.
 _[Note that only <<continuous>> floating point variables are listed here._
 _If a <<state>> or a <<derivative>> of a <<state>> shall not be exposed from the FMU, or if states are not statically associated with a variable (due to <<dynamic-state-selection,dynamic state selection>>), then dummy variables have to be introduced, for example, `x[4]`, or `xDynamicStateSet2[5]`._
 _The ordering of the variables in this list is defined by the exporting tool._
-_Usually, it is best to order according to the declaration order of the <<state,`states`>> in the source model, since then the <<StateDerivative>> list does not change if the declaration order of states in the source model is not changed._
+_Usually, it is best to order according to the declaration order of the <<state,`states`>> in the source model, since then the <<ContinuousStateDerivative>> list does not change if the declaration order of states in the source model is not changed._
 _This is for example, important for linearization, in order that the interpretation of the state vector does not change for a re-exported FMU.]_
 
 The corresponding continuous-time <<state,`states`>> are defined by attribute <<derivative>> of the corresponding variable state derivative element.
 _[Note that higher order derivatives must be mapped to first order derivatives but the mapping definition can be preserved due to attribute <<derivative>>._
 _Example: if_ latexmath:[{\frac{\text{ds}}{\text{dt}} = v,\ \frac{\text{dv}}{\text{dt}} =f(..)}] _,then_ latexmath:[{\left\{ v,\ \frac{\text{dv}}{\text{dt}} \right\}}] _is the vector of state derivatives and attribute <<derivative>> of_ latexmath:[{v}] _references_ latexmath:[{s}] _, and attribute <<derivative>> of_ latexmath:[{\frac{\text{dv}}{\text{dt}}}] _references_ latexmath:[{v}] _.]_ +
-For Co-Simulation, elements <<StateDerivative>> are ignored if capability flag <<providesDirectionalDerivatives>> has a value of `false`, in other words, it cannot be computed.
+For Co-Simulation, elements <<ContinuousStateDerivative>> are ignored if capability flag <<providesDirectionalDerivatives>> has a value of `false`, in other words, it cannot be computed.
 _[This is the default._
-_If an FMU supports more than Model Exchange , then the <<StateDerivative>> elements might be present, since it is needed for Model Exchange._
-_If the above flag is set to `false` for the Co-Simulation cases, then the <<StateDerivative>> elements are ignored for Co-Simulation._
+_If an FMU supports more than Model Exchange , then the <<ContinuousStateDerivative>> elements might be present, since it is needed for Model Exchange._
+_If the above flag is set to `false` for the Co-Simulation cases, then the <<ContinuousStateDerivative>> elements are ignored for Co-Simulation._
 _If "inline integration" is used for a co-simulation FMU, then the model still has continuous-time <<state,`states`>> and just a special solver is used (internally the implementation results in a discrete-time system, but from the outside, it is still a continuous-time system).]_ +
 Attribute <<dependencies>> defines the dependencies of the state derivatives from the knowns at the current super-dense time instant in Event and in <<ContinuousTimeMode>> (ME) and at the current communication point (CS and SE).
 Beside the knowns the derivatives also depend on the "frozen" variables (= variables which cannot be changed in the current mode) but these "frozen" variables are not listed as <<dependencies>>.
@@ -1704,7 +1704,7 @@ This list consists of all variables with
 
 - <<causality>> = <<calculatedParameter>> and
 
-- all continuous-time <<state,`states`>> and all state derivatives (defined with elements <<StateDerivative>>) with <<initial>> = <<approx>> or <<calculated>> _[if a Co-Simulation FMU does not define the <<StateDerivative>> elements, (3) cannot be present]_.
+- all continuous-time <<state,`states`>> and all state derivatives (defined with elements <<ContinuousStateDerivative>>) with <<initial>> = <<approx>> or <<calculated>> _[if a Co-Simulation FMU does not define the <<ContinuousStateDerivative>> elements, (3) cannot be present]_.
 
 The resulting list is not allowed to have duplicates (for example, if a <<state>> is also an <<output>>, it is included only once in the list). +
 Attribute <<dependencies>> defines the dependencies of the unknowns from the knowns in <<InitializationMode>> at the initial time.
@@ -1745,9 +1745,9 @@ _[More rigorous importers requiring a variable to be dependent on a single clock
 
 |====
 
-Elements <<Output>>, <<StateDerivative>>, <<ClockedState>>, <<InitialUnknown>>, <<EventIndicator>> and <<ClockElement>> have (partially) the following attributes:
+Elements <<Output>>, <<ContinuousStateDerivative>>, <<ClockedState>>, <<InitialUnknown>>, <<EventIndicator>> and <<ClockElement>> have (partially) the following attributes:
 
-.<<Output>>, <<StateDerivative>>, <<ClockedState>>, <<InitialUnknown>>, <<EventIndicator>> and <<ClockElement>> attribute details.
+.<<Output>>, <<ContinuousStateDerivative>>, <<ClockedState>>, <<InitialUnknown>>, <<EventIndicator>> and <<ClockElement>> attribute details.
 [[table-output-der-initialUknown-details]]
 [cols="1,5", options="header"]
 |====
@@ -1764,7 +1764,7 @@ Optional attribute defining the dependencies of the unknown latexmath:[{v_{\math
 If not present, it must be assumed that the unknown depends on all knowns.
 If present as empty list, the unknown depends on none of the knowns.
 Otherwise the unknown depends on the knowns defined by the given value references. +
-Knowns latexmath:[{\mathbf{v}_{\mathit{known}}}] in <<EventMode>> and <<ContinuousTimeMode>> (ME) and at communication points (CS and SE) for <<Output>> and <<StateDerivative>> elements:
+Knowns latexmath:[{\mathbf{v}_{\mathit{known}}}] in <<EventMode>> and <<ContinuousTimeMode>> (ME) and at communication points (CS and SE) for <<Output>> and <<ContinuousStateDerivative>> elements:
 
 * inputs (variables with <<causality>> = <<input>>),
 

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -33,7 +33,7 @@ In this state, the continuous-time equations are active and integrator steps are
 a|latexmath:[(\mathbf{y}_{c}, \mathbf{\dot{x}}_c, \mathbf{z}, \mathbf{w}_{c}) := \mathbf{f}_{\mathit{cont}}(\mathbf{x}_{c}, {}^\bullet\mathbf{x}_{d}, \mathbf{u}_{c}, {}^\bullet\mathbf{u}_{d}, \mathbf{p}, {}^\bullet\mathbf{r}, {}^\bullet\mathbf{b}, \mathbf{t})]
 a|
 <<get-and-set-variable-values,`fmi3Get{VariableType}`>>,
-<<fmi3GetDerivatives>>,
+<<fmi3GetContinuousStateDerivatives>>,
 <<fmi3GetEventIndicators>>
 
 a|
@@ -90,7 +90,7 @@ Set new continuous state values.
 * Argument `continuousStates` contains the new values for each <<state,continuous state>>.
 The order of the `continuousStates` vector must be the same as the ordered list of elements <<ContinuousStateDerivative>> in `<ModelStructure>`.
 Array variables are serialized as defined in <<serialization-of_variables>>.
-This order is also used in the arguments of the following functions: <<fmi3GetNominalsOfContinuousStates>>, <<fmi3GetContinuousStates>>, and <<fmi3GetDerivatives>>.
+This order is also used in the arguments of the following functions: <<fmi3GetNominalsOfContinuousStates>>, <<fmi3GetContinuousStates>>, and <<fmi3GetContinuousStateDerivatives>>.
 +
 * Argument `nContinuousStates` is the size of the `continuousStates` vector.
 +
@@ -102,8 +102,8 @@ Getting variables might trigger <<selectiv-computation,computations>>.
 Function <<fmi3GetContinuousStates>>::
 Returns the current continuous state vector.
 
-[[fmi3GetDerivatives,`fmi3GetDerivatives`]]
-Function <<fmi3GetDerivatives>>::
+[[fmi3GetContinuousStateDerivatives,`fmi3GetContinuousStateDerivatives`]]
+Function <<fmi3GetContinuousStateDerivatives>>::
 +
 [source, C]
 ----

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -88,7 +88,7 @@ include::../headers/fmi3FunctionTypes.h[tags=SetContinuousStates]
 Set new continuous state values.
 +
 * Argument `continuousStates` contains the new values for each <<state,continuous state>>.
-The order of the `continuousStates` vector must be the same as the ordered list of elements <<StateDerivative>> in `<ModelStructure>`.
+The order of the `continuousStates` vector must be the same as the ordered list of elements <<ContinuousStateDerivative>> in `<ModelStructure>`.
 Array variables are serialized as defined in <<serialization-of_variables>>.
 This order is also used in the arguments of the following functions: <<fmi3GetNominalsOfContinuousStates>>, <<fmi3GetContinuousStates>>, and <<fmi3GetDerivatives>>.
 +

--- a/docs/examples/model_exchange.xml
+++ b/docs/examples/model_exchange.xml
@@ -51,8 +51,8 @@
   <ModelStructure>
     <Output valueReference="805306368"/>
     <Output valueReference="805306369"/>
-    <StateDerivative valueReference="2"/>
-    <StateDerivative valueReference="3"/>
+    <ContinuousStateDerivative valueReference="2"/>
+    <ContinuousStateDerivative valueReference="3"/>
     <InitialUnknown valueReference="805306368"/>
     <InitialUnknown valueReference="805306369"/>
     <InitialUnknown valueReference="2" dependencies="0 536870912"/>

--- a/docs/examples/model_structure_example1.xml
+++ b/docs/examples/model_structure_example1.xml
@@ -22,9 +22,9 @@
 </ModelVariables>
 <ModelStructure>
    <Output valueReference="11" dependencies="6 7"/>
-   <StateDerivative valueReference="8"  dependencies="6"/>
-   <StateDerivative valueReference="9"  dependencies="2 4 5 6" dependenciesKind="constant constant dependent fixed"/>
-   <StateDerivative valueReference="10" dependencies="2 3 4 5 6" />
+   <ContinuousStateDerivative valueReference="8"  dependencies="6"/>
+   <ContinuousStateDerivative valueReference="9"  dependencies="2 4 5 6" dependenciesKind="constant constant dependent fixed"/>
+   <ContinuousStateDerivative valueReference="10" dependencies="2 3 4 5 6" />
    <InitialUnknown valueReference="6" dependencies="2 4 5"/>
    <InitialUnknown valueReference="7" dependencies="2 4 5 11"/>
    <InitialUnknown valueReference="8"/>

--- a/docs/examples/model_structure_example4.xml
+++ b/docs/examples/model_structure_example4.xml
@@ -15,7 +15,7 @@
 </ModelVariables>
 <ModelStructure>
   <Output valueReference="2" dependencies="3" dependenciesKind="constant"/>
-  <StateDerivative valueReference="4" dependencies="1" dependenciesKind="constant"/>
+  <ContinuousStateDerivative valueReference="4" dependencies="1" dependenciesKind="constant"/>
   <InitialUnknown valueReference="2" dependencies="3"/>
 </ModelStructure>
 <!-- end::VariablesAndStructure[] -->

--- a/headers/fmi3FunctionTypes.h
+++ b/headers/fmi3FunctionTypes.h
@@ -552,9 +552,9 @@ typedef fmi3Status fmi3SetContinuousStatesTYPE(fmi3Instance instance,
 
 /* Evaluation of the model equations */
 /* tag::GetDerivatives[] */
-typedef fmi3Status fmi3GetDerivativesTYPE(fmi3Instance instance,
-                                          fmi3Float64 derivatives[],
-                                          size_t nContinuousStates);
+typedef fmi3Status fmi3GetContinuousStateDerivativesTYPE(fmi3Instance instance,
+                                                         fmi3Float64 derivatives[],
+                                                         size_t nContinuousStates);
 /* end::GetDerivatives[] */
 
 /* tag::GetEventIndicators[] */

--- a/headers/fmi3Functions.h
+++ b/headers/fmi3Functions.h
@@ -13,8 +13,8 @@ Therefore, the typical usage is:
   #define FMI3_FUNCTION_PREFIX MyModel_
   #include "fmi3Functions.h"
 
-As a result, a function that is defined as "fmi3GetDerivatives" in this header file,
-is actually getting the name "MyModel_fmi3GetDerivatives".
+As a result, a function that is defined as "fmi3GetContinuousStateDerivatives" in this header file,
+is actually getting the name "MyModel_fmi3GetContinuousStateDerivatives".
 
 This only holds if the FMU is shipped in C source code, or is compiled in a
 static link library. For FMUs compiled in a DLL/sharedObject, the "actual" function
@@ -185,7 +185,7 @@ Functions for Model Exchange
 #define fmi3SetContinuousStates           fmi3FullName(fmi3SetContinuousStates)
 
 /* Evaluation of the model equations */
-#define fmi3GetDerivatives                fmi3FullName(fmi3GetDerivatives)
+#define fmi3GetContinuousStateDerivatives fmi3FullName(fmi3GetContinuousStateDerivatives)
 #define fmi3GetEventIndicators            fmi3FullName(fmi3GetEventIndicators)
 #define fmi3GetContinuousStates           fmi3FullName(fmi3GetContinuousStates)
 #define fmi3GetNominalsOfContinuousStates fmi3FullName(fmi3GetNominalsOfContinuousStates)
@@ -292,7 +292,7 @@ FMI3_Export fmi3SetTimeTYPE             fmi3SetTime;
 FMI3_Export fmi3SetContinuousStatesTYPE fmi3SetContinuousStates;
 
 /* Evaluation of the model equations */
-FMI3_Export fmi3GetDerivativesTYPE                fmi3GetDerivatives;
+FMI3_Export fmi3GetContinuousStateDerivativesTYPE fmi3GetContinuousStateDerivatives;
 FMI3_Export fmi3GetEventIndicatorsTYPE            fmi3GetEventIndicators;
 FMI3_Export fmi3GetContinuousStatesTYPE           fmi3GetContinuousStates;
 FMI3_Export fmi3GetNominalsOfContinuousStatesTYPE fmi3GetNominalsOfContinuousStates;

--- a/schema/fmi3ModelDescription.xsd
+++ b/schema/fmi3ModelDescription.xsd
@@ -93,7 +93,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 					<xs:complexType>
 						<xs:sequence>
 							<xs:element name="Output" type="fmi3Unknown" minOccurs="0" maxOccurs="unbounded"/>
-							<xs:element name="StateDerivative" type="fmi3Unknown" minOccurs="0" maxOccurs="unbounded"/>
+							<xs:element name="ContinuousStateDerivative" type="fmi3Unknown" minOccurs="0" maxOccurs="unbounded"/>
 							<xs:element name="ClockedState" type="fmi3Unknown" minOccurs="0" maxOccurs="unbounded"/>
 							<xs:element name="InitialUnknown" type="fmi3Unknown" minOccurs="0" maxOccurs="unbounded"/>
 							<xs:element name="EventIndicator" minOccurs="0" maxOccurs="unbounded">


### PR DESCRIPTION
to clearly distinguish the different types of derivatives in 

- fmi3GetContinuousStateDerivatives()
- fmi3GetOutputDerivatives()
- fmi3GetDirectionalDerivative()
- fmi3GetAdjointDerivative()

and

<ContinuousStateDerivative />

fixes #1343