### PR TITLE
Clean up Clocks API and schema

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -341,7 +341,7 @@ typedef fmi3Status fmi3SetIntervalDecimalTYPE(fmi3Instance instance,
                                               const fmi3Float64 interval[]);
 ----
 
-A clock interval is set by the environment for the current time instant by the function <<fmi3SetIntervalDecimal>>.
+A Clock interval is set by the environment for the current time instant by the function <<fmi3SetIntervalDecimal>>.
 ....
 
 === Spelling and Capitalization

--- a/docs/1___overview.adoc
+++ b/docs/1___overview.adoc
@@ -12,7 +12,7 @@ Concrete features to support vECU export are:
 
 * introduction of <<graphicalRepresentation,icons>> to define a graphical representation of the FMU and its terminals,
 
-* introduction of clocks to more exactly control timing of events and evaluation of model partitions across FMUs,
+* introduction of <<Clock,Clocks>> to more exactly control timing of events and evaluation of model partitions across FMUs,
 
 * introduction of more integer types and a 32-bit float type (see <<fmi-description-schema>>) to communicate native controller types to the outside,
 
@@ -31,7 +31,7 @@ New features, like
 
 * the <<IntermediateUpdateMode, intermediate update>>, or
 
-* <<clocks,clocks and clocked variables>>,
+* <<Clocks,Clocks and clocked variables>>,
 
 allow implementation of more robust and efficient co-simulation algorithms to handle the growing system simulations the community is facing.
 
@@ -99,7 +99,7 @@ image::images/co-simulation-data-flow.svg[width=40%, align="center"]
 ==== FMI for Scheduled Execution (SE)
 
 The Scheduled Execution interface exposes individual model partitions (e.g. tasks of a control algorithm), to be called by a scheduler that acts as external scheduler.
-The scheduler is responsible for advancing the overall simulation time, triggering of time-based and triggered clocks for all exposed model partitions of a set of FMUs, and handling events (e.g. clock ticks) signaled by the FMUs.
+The scheduler is responsible for advancing the overall simulation time, triggering of time-based and triggered <<Clock,Clocks>> for all exposed model partitions of a set of FMUs, and handling events (e.g. clock ticks) signaled by the FMUs.
 
 In many ways, the Scheduled Execution interface is the equivalent of the Model Exchange interface: the first externalizes a scheduling algorithm usually found in a controller algorithm and the second interface externalizes the ODE solver.
 (See <<fmi-for-scheduled-execution>>.)
@@ -151,10 +151,10 @@ image::images/fmi-types-overview.svg[width=50%, align="center"]
 |<<IntermediateUpdateMode,Intermediate Update>>
 |Includes similar or better mechanism
 |icon:check[]
-|Signal output clock ticks: icon:check[] +
+|Signal output <<Clock>> ticks: icon:check[] +
 Inputs/Outputs: icon:times[]
 
-|<<clocks,Clocks>>
+|<<Clock,Clocks>>
 |icon:check[]
 |icon:check[]
 |icon:check[]

--- a/docs/2_1_common_math.adoc
+++ b/docs/2_1_common_math.adoc
@@ -89,7 +89,7 @@ The following variable subscripts are used to describe the timing behavior of th
 Such a variable can change multiple times at the same continuous-time instant, but only at subsequent super-dense time instants latexmath:[n \in \mathbb{N} = \{0, 1, 2, \ldots\}].
 
 |`k`
-|A <<clocked-variable,clocked variable>> is a discrete-time variable associated with a <<clock>>. Clock variables synchronize events with the importer and across FMUs, they carry the information that a specific event happens.
+|A <<clocked-variable,clocked variable>> is a discrete-time variable associated with a <<Clock>>. Clock variables synchronize events with the importer and across FMUs, they carry the information that a specific event happens.
 
 |`c`+`d`
 |A set of continuous-time and discrete-time variables.

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -890,15 +890,19 @@ The attribute <<supportsFraction>> of a <<clock>> declares, if the `fmi3SetXXXFr
 include::../headers/fmi3FunctionTypes.h[tag=SetIntervalDecimal]
 ----
 
+`valueReferences`:: An array of size `nValueReferences` holding the value references of the `Clock` variables.
+
+`intervals`:: An array of size `nIntervals` holding the clock intervals to be set.
+
 [[fmi3SetIntervalFraction,`fmi3SetIntervalFraction`]]
 [source, C]
 ----
 include::../headers/fmi3FunctionTypes.h[tag=SetIntervalFraction]
 ----
 
-* `interval` is a vector of size `nValues` containing the clock interval to be set.
+`valueReferences`:: An array of size `nValueReferences` holding the value references of the `Clock` variables.
 
-* `intervalCounter` and `resolution` are vectors of size `nValues` containing the clock intervals specified in the <<modelDescription.xml>>, see <<resolution>>.
+`intervalCounters` and `resolutions`:: Arrays of size `nIntervals` holding the clock <<intervalCounter>> and <<resolution>> to be set.
 
 [[fmi3GetInterval,`fmi3GetInterval`]]
 For other clock types, the importer calls <<fmi3GetIntervalDecimal>> or <<fmi3GetIntervalFraction>> to query the next clock interval:
@@ -909,15 +913,27 @@ For other clock types, the importer calls <<fmi3GetIntervalDecimal>> or <<fmi3Ge
 include::../headers/fmi3FunctionTypes.h[tag=GetIntervalDecimal]
 ----
 
+`valueReferences`:: An array of size `nValueReferences` holding the value references of the `Clock` variables.
+
+`intervals`:: An array of size `nIntervals` to retrieve the clock intervals.
+
+`qualifiers`:: An array of size `nIntervals` to retrieve the clock <<qualifier>>.
+
 [[fmi3GetIntervalFraction,`fmi3GetIntervalFraction`]]
 [source, C]
 ----
 include::../headers/fmi3FunctionTypes.h[tag=GetIntervalFraction]
 ----
 
+`valueReferences`:: An array of size `nValueReferences` holding the value references of the `Clock` variables.
+
+`intervalCounters` and `resolutions`:: Arrays of size `nIntervals` to retrieve the clock <<intervalCounter>> and <<resolution>>.
+
+`qualifiers`:: An array of size `nIntervals` to retrieve the clock <<qualifier>>.
+
 [[qualifier,`qualifier`]]
-* `qualifier` describes how to treat the `interval` and `intervalCounter` arguments and is defined as:
-[[fmi3IntervalQualifier,`fmi3IntervalQualifier`]]
+`qualifier` describes how to treat the `interval` and `intervalCounter` arguments and is defined as:
+
 [source, C]
 ----
 include::../headers/fmi3FunctionTypes.h[tag=IntervalQualifier]
@@ -932,13 +948,19 @@ For <<table-overview-clocks,some clocks>>, the importer has to query the delay t
 include::../headers/fmi3FunctionTypes.h[tag=GetShiftDecimal]
 ----
 
+`valueReferences`:: An array of size `nValueReferences` holding the value references of the `Clock` variables.
+
+`shifts`:: An array of length `nShifts` that defines the time of the first clock activation (see <<shiftCounter>>).
+
 [[fmi3GetShiftFraction,`fmi3GetShiftFraction`]]
 [source, C]
 ----
 include::../headers/fmi3FunctionTypes.h[tag=GetShiftFraction]
 ----
 
-* `shift` and `shiftCounter` define the time of the first clock activation, as defined in <<shiftCounter>>.
+`valueReferences`:: An array of size `nValueReferences` holding the value references of the `Clock` variables.
+
+`shifts` and `shiftCounters`:: Arrays of length `nShifts` that define the time of the first clock activation (see <<shiftCounter>>).
 
 ==== Dependencies of Variables [[model-dependencies]]
 

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -619,13 +619,13 @@ The importer calls <<fmi3GetClock>> to inquire the clock activation state.
 [cols="9,9,16,9,40,40",options="header"]
 |====
 2+|Clock type
-|Attribute <<causality>>
-|Attribute <<interval>>
+|<<causality>>
+|<<interval>>
 |Related API calls and arguments
 |Example
 
 .6+|time-based
-.4+|[[periodic,`periodic`]]`periodic`
+.4+|[[periodic]]periodic
 .4+|<<input>>
 |[[constant-interval,`constant`]]`constant`
 |<<fmi3SetClock>> in <<EventMode>>,
@@ -652,7 +652,7 @@ The importer calls <<fmi3GetClock>> to inquire the clock activation state.
 <<fmi3GetInterval>> in <<EventMode>> and in <<ClockActivationMode>>
 |clocked PI-controller with interval defined by tunable parameter(s) of the FMU
 
-.2+|[[aperiodic,`aperiodic`]]`aperiodic`
+.2+|[[aperiodic]]aperiodic
 .2+|<<input>>
 |[[changing,`changing`]]`changing`
 |<<fmi3SetClock>> in <<EventMode>>,

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -403,7 +403,7 @@ _[This can be, for example, used to perform an expensive steady-state initializa
 _Whenever needed, the byte vector can be loaded from file and deserialized, and the simulation can be restarted from this FMU state, in other words, from the steady-state initialization.]_
 
 [[fmi3GetFMUState, `fmi3GetFMUState`]]
-Function <<fmi3GetFMUState>>::
+Function `fmi3GetFMUState`::
 
 [source, C]
 ----
@@ -417,7 +417,7 @@ In particular, <<fmi3FreeFMUState>> had not been called with this <<FMUState>> a
 _[Function <<fmi3GetFMUState>> typically reuses the memory of this <<FMUState>> in this case and returns the same pointer to it, but with the actual <<FMUState>>.]_
 
 [[fmi3SetFMUState, `fmi3SetFMUState`]]
-Function <<fmi3SetFMUState>>::
+Function `fmi3SetFMUState`::
 
 [source, C]
 ----
@@ -429,7 +429,7 @@ The <<FMUState>> copy still exists.
 _[The simulation is restarted at this state, when calling <<fmi3SetFMUState>> with <<FMUState>>.]_
 
 [[fmi3FreeFMUState, `fmi3FreeFMUState`]]
-Function <<fmi3FreeFMUState>>::
+Function `fmi3FreeFMUState`::
 
 [source, C]
 ----
@@ -444,7 +444,7 @@ The function returns a null pointer in argument <<FMUState>>.
 These functions can be called, if the optional capability flag <<canGetAndSetFMUState>> is set to `true`.
 
 [[fmi3SerializedFMUStateSize,`fmi3SerializedFMUStateSize`]]
-Function <<fmi3SerializedFMUStateSize>>::
+Function `fmi3SerializedFMUStateSize`::
 
 [source, C]
 ----
@@ -455,7 +455,7 @@ This function returns the `size` of the byte vector, in order that <<FMUState>> 
 With this information, the environment has to allocate an `fmi3Byte` vector of the required length `size`.
 
 [[fmi3SerializeFMUState,`fmi3SerializeFMUState`]]
-Function <<fmi3SerializeFMUState>>::
+Function `fmi3SerializeFMUState`::
 
 [source, C]
 ----
@@ -465,7 +465,7 @@ include::../headers/fmi3FunctionTypes.h[tags=SerializeFMUState]
 This function serializes the data which is referenced by pointer <<FMUState>> and copies this data in to the byte vector `serializedState` of length `size`, that must be provided by the environment.
 
 [[fmi3DeSerializeFMUState,`fmi3DeSerializeFMUState`]]
-Function <<fmi3DeSerializeFMUState>>::
+Function `fmi3DeSerializeFMUState`::
 
 [source, C]
 ----
@@ -1291,7 +1291,7 @@ Restrictions on calling the function are the same as for the <<get-and-set-varia
 The returned values correspond to the current time of the FMU.
 For example, after a successful call to <<fmi3DoStep>>, the returned values are related to the end of the communication step.
 
-Function <<fmi3GetOutputDerivatives>>::
+Function `fmi3GetOutputDerivatives`::
 
 [[fmi3GetOutputDerivatives,`fmi3GetOutputDerivatives`]]
 [source, C]

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -349,7 +349,7 @@ include::../headers/fmi3FunctionTypes.h[tags=SetClock]
 With two exceptions, all variables that are allowed to be set with <<get-and-set-variable-values,`fmi3Set{VariableType}`>> keep their respective values until the next call to <<get-and-set-variable-values,`fmi3Set{VariableType}`>>.
 Exceptions:
 
-. Variables of type clock must be deactivated during <<fmi3UpdateDiscreteStates>> by the FMU.
+. Variables of type <<Clock>> must be deactivated during <<fmi3UpdateDiscreteStates>> by the FMU.
 . By setting the complete <<get-set-fmu-state,FMU state>> using <<fmi3SetFMUState>>, all variables are potentially changed.
 
 All strings passed as arguments to `fmi3SetString`, as well as all binary values passed as arguments to `fmi3SetBinary`, must be copied during these function calls, because there is no guarantee of the lifetime of strings or binary values, when these functions return.
@@ -579,7 +579,7 @@ fmi3EnterStepMode(FMUy); // for CS
 
 _When solving algebraic loops in <<EventMode>>, limitations to variable manipulations declared with XML attribute <<canHandleMultipleSetPerTimeInstant>> must be considered.]_
 
-==== Clocks [[clocks,clocks]]
+==== Clocks [[Clock,Clock]]
 
 FMI 3.0 specifies the behavior of a clocked FMU.
 FMI 3.0 does not specify how the importer uses this functionality.
@@ -600,18 +600,18 @@ The second point solves the issue that computing exactly when an event happens i
 
 Clocks are <<discrete>> <<fmu-variables,variables>> with a special semantic.
 
-The following clock types are described in detail after the table.
+The following Clock types are described in detail after the table.
 
-Input clocks::
-[[inputClock, `input clock`]]
-denote all clocks with <<causality>> <<input>>.
+Input Clocks::
+[[inputClock, `input Clock`]]
+denote all Clocks with <<causality>> == <<input>>.
 The importer will activate <<inputClock, `input clocks`>> using <<fmi3SetClock>> or <<fmi3ActivateModelPartition>>.
 Contrary to the importer being the source of the actual clock activations, the definition of the clock timing comes from the FMU, either through the <<modelDescription.xml>> or calling <<fmi3GetInterval>>, or from another clock connected to a <<triggered>> input clock.
 
-Output clocks::
-[[outputClock, `output clock`]]
+Output Clocks::
+[[outputClock, `output Clock`]]
 denote the <<triggered>> <<outputClock>>.
-There is only one such <<clock>> type.
+There is only one such <<Clock>> type.
 We still refer to it as <<outputClock>> for simplicity.
 The importer calls <<fmi3GetClock>> to inquire the clock activation state.
 
@@ -626,7 +626,7 @@ The importer calls <<fmi3GetClock>> to inquire the clock activation state.
 |Example
 
 .6+|time-based
-.4+|[[periodic]]periodic clock
+.4+|[[periodic]]periodic Clock
 .4+|`input`
 |`constant`
 |[[constantClock,`constant`]]<<fmi3SetClock>> in <<EventMode>>,
@@ -653,24 +653,24 @@ The importer calls <<fmi3GetClock>> to inquire the clock activation state.
 <<fmi3GetInterval>> in <<EventMode>> and in <<ClockActivationMode>>
 |clocked PI-controller with interval defined by tunable parameter(s) of the FMU
 
-.2+|[[aperiodic]]aperiodic clock
+.2+|[[aperiodic]]aperiodic Clock
 .2+|`input`
 |`changing`
 |[[changing,`changing`]]<<fmi3SetClock>> in <<EventMode>>,
 <<fmi3ActivateModelPartition>> in <<ClockActivationMode>>,
 <<fmi3GetInterval>> in <<InitializationMode>>,
-<<fmi3GetInterval>> in both <<EventMode>> and <<ClockActivationMode>> if and only if this clock ticked
+<<fmi3GetInterval>> in both <<EventMode>> and <<ClockActivationMode>> if and only if this Clock ticked
 |simulation of the behavior of a control algorithm with variable execution time, generation of pulse sequences
 
 |`countdown`
 |[[countdown,`countdown`]]<<fmi3SetClock>> in <<EventMode>>,
 <<fmi3ActivateModelPartition>> in <<ClockActivationMode>>,
 <<fmi3GetInterval>> in <<InitializationMode>>, in every <<EventMode>>, and in <<IntermediateUpdateMode>>.
-In Scheduled Execution the FMU has to inform the importer by calling <<fmi3CallbackIntermediateUpdate>> that the clock is about to tick.
+In Scheduled Execution the FMU has to inform the importer by calling <<fmi3CallbackIntermediateUpdate>> that the Clock is about to tick.
 |time-delayed actions after an event, for example, ignition signal some time after specific crank shaft angle
 
 .2+|triggered
-|input clock
+|input Clock
 |`input`
 |`triggered`
 |[[triggered,`triggered`]]<<fmi3SetClock>> in <<EventMode>>,
@@ -678,7 +678,7 @@ In Scheduled Execution the FMU has to inform the importer by calling <<fmi3Callb
 argument <<clocksTicked>> of <<fmi3CallbackIntermediateUpdate>>
 |triggered by a hardware interrupt of an embedded system, e.g. a control algorithm, triggered by a crankshaft angle
 
-|output clock
+|output Clock
 |`output`
 |`triggered`
 |<<fmi3GetClock>> in both <<EventMode>> and <<IntermediateUpdateMode>>,
@@ -687,12 +687,12 @@ and argument <<clocksTicked>> of <<fmi3CallbackIntermediateUpdate>>
 
 |====
 
-[[time-based-clocks,time-based clocks]]Time-based clocks::
+[[time-based-clocks,time-based Clocks]]Time-based Clocks::
 
-are in a sense predictable and help the importer to take these clock ticks into account a priori.
-All time-based clocks are defined to be input clocks because the importer calls <<fmi3SetClock>> or <<fmi3ActivateModelPartition>> on these clocks.
-The importer queries the FMU about when a time-based clock should be activated.
-The importer will then activate the clock by calling <<fmi3SetClock>> with `values == fmi3ClockActive`.
+are in a sense predictable and help the importer to take these Clock ticks into account a priori.
+All time-based Clocks are defined to be input Clocks because the importer calls <<fmi3SetClock>> or <<fmi3ActivateModelPartition>> on these Clocks.
+The importer queries the FMU about when a time-based Clock should be activated.
+The importer will then activate the Clock by calling <<fmi3SetClock>> with `values == fmi3ClockActive`.
 +
 The mathematical descriptions of <<time-based-clocks>> will use the following notations:
 
@@ -702,16 +702,16 @@ The mathematical descriptions of <<time-based-clocks>> will use the following no
 [cols="1,2"]
 |===
 |latexmath:[\mathbf{t}_0]
-|The time instant at which the <<clock>> is activated the first time.
+|The time instant at which the <<Clock>> is activated the first time.
 
 |latexmath:[\mathbf{t}_\mathit{i-1}]
-|The previous time instant, where the <<clock>> ticked.
+|The previous time instant, where the <<Clock>> ticked.
 
 |latexmath:[\mathbf{T}_{\mathit{shift}}]
-|Delay for the first clock activation relative to latexmath:[\mathbf{t}_{\mathit{start}}]. latexmath:[\mathbf{T}_{\mathit{shift}}] is defined differently for the different clock types, and can be retrieved from the FMU with <<fmi3GetShiftDecimal>> as floating point value, or with <<fmi3GetShiftFraction>> as rational number: latexmath:[\mathit{shiftCounter} / \mathit{resolution}] (see <<resolution>>).
+|Delay for the first Clock activation relative to latexmath:[\mathbf{t}_{\mathit{start}}]. latexmath:[\mathbf{T}_{\mathit{shift}}] is defined differently for the different Clock types, and can be retrieved from the FMU with <<fmi3GetShiftDecimal>> as floating point value, or with <<fmi3GetShiftFraction>> as rational number: latexmath:[\mathit{shiftCounter} / \mathit{resolution}] (see <<resolution>>).
 
 |latexmath:[\mathbf{T}_{interval, i}]
-|The time interval until the next <<clock>> tick, defined differently for the different clock types.
+|The time interval until the next <<Clock>> tick, defined differently for the different Clock types.
 latexmath:[\mathbf{T}_{interval, i}] can be set with <<fmi3SetIntervalDecimal>> or retrieved with <<fmi3GetIntervalDecimal>> as floating point value, or as rational number using <<fmi3SetIntervalFraction>> or <<fmi3GetIntervalFraction>>: latexmath:[\mathit{intervalCounter} / \mathit{resolution}] (see <<resolution>>).
 
 |latexmath:[\mathbf{t}_\mathit{event}]
@@ -720,10 +720,10 @@ latexmath:[\mathbf{T}_{interval, i}] can be set with <<fmi3SetIntervalDecimal>> 
 |===
 
 [[periodic-clock-ticks]]Periodic clocks::
-are time-based clocks which have a constant interval, except when `interval = tunable` which indicates that the interval can change when <<tunable>> parameters change.
-The time instant of the first clock activation is defined by a <<shift>>.
+are time-based Clocks which have a constant interval, except when `interval = tunable` which indicates that the interval can change when <<tunable>> parameters change.
+The time instant of the first Clock activation is defined by a <<shift>>.
 +
-The next <<clock>> activation at time instant latexmath:[t_i] is defined as: +
+The next <<Clock>> activation at time instant latexmath:[t_i] is defined as: +
 latexmath:[\begin{align*}
 \mathbf{t}_0 &:= \mathbf{t}_{\mathit{start}} + \mathbf{T}_{\mathit{shift}} \\
 \mathbf{t}_i &:= \mathbf{t}_{i-1} + \mathbf{T}_{interval, i} \qquad i = 1,2,3,{...}
@@ -736,35 +736,35 @@ latexmath:[\begin{align*}
 |===
 
 |latexmath:[\mathbf{T}_{interval, i} > 0]
-|The time interval from the previous <<clock>> tick to the current <<clock>> tick, specified differently for the different clock types.
+|The time interval from the previous <<Clock>> tick to the current <<Clock>> tick, specified differently for the different Clock types.
 |===
 
 Constant periodic clocks::
 are time-based periodic clocks that define their <<interval>> and <<shift>> in the <<modelDescription.xml>>.
 
-[[fixed-periodic-clocks,fixed periodic clocks]]Fixed periodic clocks::
+[[fixed-periodic-clocks,fixed periodic Clocks]]Fixed periodic Clocks::
 are time-base periodic clocks which can be activated by the importer with an arbitrary, but constant interval starting after an arbitrary <<shift>>.
 The importer informs the FMU about the interval using <<fmi3SetInterval>>.
 
-Calculated periodic clocks::
-are time-base periodic clocks where the interval and <<shift>> depend on <<fixed>> <<parameter, parameters>>.
-The importer must use <<fmi3GetInterval>> and <<fmi3GetShift>> to retrieve the clock interval and <<shift>> in <<InitializationMode>>.
+Calculated periodic Clocks::
+are time-base periodic Clocks where the interval and <<shift>> depend on <<fixed>> <<parameter, parameters>>.
+The importer must use <<fmi3GetInterval>> and <<fmi3GetShift>> to retrieve the Clock interval and <<shift>> in <<InitializationMode>>.
 
-Tunable periodic clocks::
-are time-base periodic clocks where the interval depends on <<tunable>> <<parameter, parameters>>.
-The importer must use <<fmi3GetInterval>> to retrieve the clock interval in <<EventMode>> or <<ClockActivationMode>>, if any of the <<tunable>> <<parameter, parameters>> it depends on was changed.
+Tunable periodic Clocks::
+are time-base periodic Clocks where the interval depends on <<tunable>> <<parameter, parameters>>.
+The importer must use <<fmi3GetInterval>> to retrieve the Clock interval in <<EventMode>> or <<ClockActivationMode>>, if any of the <<tunable>> <<parameter, parameters>> it depends on was changed.
 <<shift>> may only depend on <<fixed>> <<parameter, parameters>>.
-The importer must use <<fmi3GetShift>> to retrieve the clock <<shift>> in <<InitializationMode>>.
+The importer must use <<fmi3GetShift>> to retrieve the Clock <<shift>> in <<InitializationMode>>.
 
-[[aperiodic-clocks,aperiodic clocks]]Aperiodic clocks::
-are time-based clocks which have a nonconstant interval.
+[[aperiodic-clocks,aperiodic Clocks]]Aperiodic Clocks::
+are time-based Clocks which have a nonconstant interval.
 <<fmi3GetInterval>> must be called to retrieve the first interval in <<InitializationMode>>.
 Calling <<fmi3GetShift>> is not allowed.
 
-[[changing-aperiodic-clocks,changing aperiodic clocks]]Changing aperiodic clocks::
-are time-based clocks where the next interval is unchangeably known right after the clock just ticked.
+[[changing-aperiodic-clocks,changing aperiodic Clocks]]Changing aperiodic Clocks::
+are time-based Clocks where the next interval is unchangeably known right after the Clock just ticked.
 +
-The next <<clock>> activation at time instant latexmath:[t_i] is defined as: +
+The next <<Clock>> activation at time instant latexmath:[t_i] is defined as: +
 latexmath:[\begin{align*}
 \mathbf{t}_0 &:= \mathbf{t}_{\mathit{start}} + \mathbf{T}_{interval, 0} \\
 \mathbf{t}_i &:= \mathbf{t}_{i-1} + \mathbf{T}_{interval, i} \qquad i = 1,2,3,{...}
@@ -777,20 +777,20 @@ latexmath:[\begin{align*}
 |===
 
 |latexmath:[\mathbf{T}_{interval, 0} \geq 0]
-|The time interval from latexmath:[\mathbf{t}_{\mathit{start}}] to first <<clock>> tick.
+|The time interval from latexmath:[\mathbf{t}_{\mathit{start}}] to first <<Clock>> tick.
 Must be retrieved in <<InitializationMode>>.
 
 |latexmath:[\mathbf{T}_{interval, i} > 0, \qquad i = 1,2,3,{...}]
-|The time interval from the current <<clock>> tick to the next <<clock>> tick.
-Must be retrieved in <<EventMode>> or <<ClockActivationMode>> if and only if the corresponding clock ticked.
+|The time interval from the current <<Clock>> tick to the next <<Clock>> tick.
+Must be retrieved in <<EventMode>> or <<ClockActivationMode>> if and only if the corresponding Clock ticked.
 
 |===
 
-[[countdown-aperiodic-clocks,countdown aperiodic clocks]]Countdown aperiodic clocks::
-are time-based clocks where the next interval is not yet known right after the clock just ticked, forcing the importer to call <<fmi3GetInterval>> in every <<EventMode>> and in <<IntermediateUpdateMode>> if <<clocksTicked, `clocksTicked == fmi3True`>> in <<fmi3CallbackIntermediateUpdate>>.
+[[countdown-aperiodic-clocks,countdown aperiodic clocks]]Countdown aperiodic Clocks::
+are time-based Clocks where the next interval is not yet known right after the Clock just ticked, forcing the importer to call <<fmi3GetInterval>> in every <<EventMode>> and in <<IntermediateUpdateMode>> if <<clocksTicked, `clocksTicked == fmi3True`>> in <<fmi3CallbackIntermediateUpdate>>.
 The return argument <<qualifier>> of <<fmi3GetInterval>> is used to indicate if the next interval is already known.
 +
-The next <<clock>> activation at time instant latexmath:[t_i] is defined as: +
+The next <<Clock>> activation at time instant latexmath:[t_i] is defined as: +
 latexmath:[\begin{align*}
 \mathbf{t}_0 &:= \mathbf{t}_{\mathit{start}} + \mathbf{T}_{interval, 0} \\
 \mathbf{t}_i &:= \mathbf{t}_{event} + \mathbf{T}_{interval, i} \qquad i = 1,2,3,{...}
@@ -803,69 +803,69 @@ latexmath:[\begin{align*}
 |===
 
 |latexmath:[\mathbf{T}_{interval, 0} \geq 0]
-|The time interval from latexmath:[\mathbf{t}_\mathit{start}] to the first <<clock>> tick.
+|The time interval from latexmath:[\mathbf{t}_\mathit{start}] to the first <<Clock>> tick.
 Must be retrieved in <<InitializationMode>>.
 
 |latexmath:[\mathbf{T}_{interval, i} \geq 0, \qquad i = 1,2,3,{...}]
-|The time interval from the event time at which the argument <<qualifier,`qualifier == fmi3IntervalChanged`>> of <<fmi3GetInterval>> to the next <<clock>> tick.
+|The time interval from the event time at which the argument <<qualifier,`qualifier == fmi3IntervalChanged`>> of <<fmi3GetInterval>> to the next <<Clock>> tick.
 
 |===
 
-Triggered clocks::
+Triggered Clocks::
 tick unpredictably.
 
-Triggered input clocks::
+Triggered input Clocks::
 are activated with <<fmi3SetClock>> by the importer in <<EventMode>>, or with <<fmi3ActivateModelPartition>> in <<ClockActivationMode>>.
 
-Triggered output clocks::
+Triggered output Clocks::
 are activated within the FMU and the importer must call <<fmi3GetClock>> in <<EventMode>> or in <<IntermediateUpdateMode>>.
 
-_[Output clocks are intended to enable an FMU to provide a trigger to the outside world, e.g. to a <<triggered, `triggered input clock`>> of another FMU._
-_Note, that if intended to activate model partitions or a clock of the same FMU calling <<fmi3GetInterval>> for a <<countdown, `countdown clock`>> and evaluating the <<qualifier>> is recommended._
+_[Output Clocks are intended to enable an FMU to provide a trigger to the outside world, e.g. to a <<triggered, `triggered input Clock`>> of another FMU._
+_Note, that if intended to activate model partitions or a Clock of the same FMU calling <<fmi3GetInterval>> for a <<countdown, `countdown Clock`>> and evaluating the <<qualifier>> is recommended._
 _An example is provided in <<example-scheduled-execution>>.]_
 
 ===== Model Partitions and Clocked Variables [[clocked-variable]]
 
-A <<clocks, `clock`>> with <<causality, `causality == input`>> activates its specific <<model-partition>>.
+A <<Clock>> with <<causality>>  == <<input>> activates its specific <<model-partition>>.
 
 _[Such a model partition may represent a task or an interrupt service routine of an embedded system, or a discretized part of a plant model.]_
 
 Discrete-time variables computed in such a model partition are called <<clocked-variable,clocked variables>>.
-Therefore, the value of a <<clocked-variable,clocked variable>> changes only when its clock is active.
-Model partitions are initialized at their first clock activation, not in <<InitializationMode>>.
+Therefore, the value of a <<clocked-variable,clocked variable>> changes only when its Clock is active.
+Model partitions are initialized at their first Clock activation, not in <<InitializationMode>>.
 
-In some clock semantics (e.g. <<MLS12>>), a clocked variable has a value only when its associated clock is active.
-However, <<get-and-set-variable-values,`fmi3Get{VariableType}`>> will return the value computed at the last clock activation time.
-Before the first clock tick, clocked variables have their initial value.
+In some Clock semantics (e.g. <<MLS12>>), a clocked variable has a value only when its associated Clock is active.
+However, <<get-and-set-variable-values,`fmi3Get{VariableType}`>> will return the value computed at the last Clock activation time.
+Before the first Clock tick, clocked variables have their initial value.
 
-The association between <<clocked-variable,clocked variables>> and their <<clock,clocks>> is defined by the <<model-dependencies,model dependency>> elements <<ClockElement>>.
-<<clocked-variable,Clocked variables>> can depend on multiple clocks.
-_[For example, a global counter could be incremented by multiple tasks, each controlled by a different clock.]_
+The association between <<clocked-variable,clocked variables>> and their <<Clock,Clocks>> is defined by the <<model-dependencies,model dependency>> elements <<ClockElement>>.
+<<clocked-variable,Clocked variables>> can depend on multiple Clocks.
+_[For example, a global counter could be incremented by multiple tasks, each controlled by a different Clock.]_
 
 ===== Scheduled Execution
 
-During <<ClockActivationMode>> after <<fmi3ActivateModelPartition>> has been called for a <<calculated>>, <<tunable>> or <<changing>> <<clocks, `clock`>> the FMU provides the information on when the clock will tick again, i.e. when the corresponding model partition has to be scheduled the next time.
-To retrieve this information the importer calls <<fmi3GetInterval>> on the clock.
+During <<ClockActivationMode>> after <<fmi3ActivateModelPartition>> has been called for a <<calculated>>, <<tunable>> or <<changing>> <<Clock>> the FMU provides the information on when the Clock will tick again, i.e. when the corresponding model partition has to be scheduled the next time.
+To retrieve this information the importer calls <<fmi3GetInterval>> on the Clock.
 
 The FMU may request to schedule another model partition even while currently a model partition is being executed.
 <<countdown, `countdown clocks`>> can tick at any time during the execution of any model partition.
-The FMU signals their ticking by calling <<fmi3CallbackIntermediateUpdate>> with argument <<clocksTicked,`clocksTicked == fmi3True`>>.
-The importer calls <<fmi3GetInterval>> for all countdown clocks.
+The FMU signals their ticking by calling <<fmi3CallbackIntermediateUpdate>> with argument <<clocksTicked>> == `fmi3True`.
+The importer calls <<fmi3GetInterval>> for all countdown Clocks.
 If a new interval is provided, the importer initiates the scheduling of the associated model partitions with the returned <<interval>>.
-<<qualifier,`qualifier == fmi3IntervalChanged`>> indicates that the corresponding <<clocks, `clock`>> has to be scheduled.
+<<qualifier,`qualifier == fmi3IntervalChanged`>> indicates that the corresponding <<Clock>> has to be scheduled.
 
-In case more than one clock has to be activated at the same time instant, the scheduler needs a priority to define the activation sequence.
-This ordering is defined by the <<priority>> attributes of the <<clocks, `clocks`>>.
+In case more than one Clock has to be activated at the same time instant, the scheduler needs a priority to define the activation sequence.
+This ordering is defined by the <<priority>> attributes of the <<Clock>>.
 
 _[For real-time computation use cases, the priority information is used also for task preemption configurations._
 _It is therefore important to restrict the number of distinct priority levels for an FMU to available priority levels on the target platform and/or to avoid unnecessary computational overhead._
 _A common number of different priority levels is, e.g., 100 (0 to 99), as defined in Linux based operating systems.]_
 
-_[The clock priorities are local to an FMU._
+_[The Clock priorities are local to an FMU._
 _It is not possible for an FMU exporting tool to know in advance the priorities of other FMUs that will be connected to an FMU in a simulation setup._
-_It is the task of the importer to derive a computational order for the computation of two or more distinct FMUs based on the local FMU clock priorities and input-output relationships of connected FMUs.]_
+_It is the task of the importer to derive a computational order for the computation of two or more distinct FMUs based on the local FMU Clock priorities and input-output relationships of connected FMUs.]_
 
-_[For periodic <<clocks, `clocks`>> it is recommended to derive the priorities based on a rate monotonic scheduling scheme (smallest period leads to highest priority, that is, has the smallest priority value.]_
+_[For periodic <<Clock, `Clocks`>> it is recommended to derive the priorities based on a rate monotonic scheduling scheme (smallest period leads to highest priority, that is, has the smallest priority value.]_
 
 ===== [[fmi3SetInterval]] API
 
@@ -879,10 +879,10 @@ include::../headers/fmi3FunctionTypes.h[tags=GetClock]
 include::../headers/fmi3FunctionTypes.h[tags=SetClock]
 ----
 
-For some <<clock>> types, the interval [[fmi3SetInterval,`fmi3SetInterval`]] is set by the environment for the current time instant by the function <<fmi3SetIntervalDecimal>> or <<fmi3SetIntervalFraction>>.
+For some <<Clock>> types, the interval [[fmi3SetInterval,`fmi3SetInterval`]] is set by the environment for the current time instant by the function <<fmi3SetIntervalDecimal>> or <<fmi3SetIntervalFraction>>.
 The values of the arguments `interval`, `intervalCounter`, `resolution`, `shift` and `shiftCounter` refer to the unit of the <<independent>> variable.
 
-The attribute <<supportsFraction>> of a <<clock>> declares, if the `fmi3SetXXXFraction` and/or `fmi3GetXXXFraction` functions are allowed to be called.
+The attribute <<supportsFraction>> of a <<Clock>> declares, if the `fmi3SetXXXFraction` and/or `fmi3GetXXXFraction` functions are allowed to be called.
 
 [[fmi3SetIntervalDecimal,`fmi3SetIntervalDecimal`]]
 [source, C]
@@ -890,9 +890,9 @@ The attribute <<supportsFraction>> of a <<clock>> declares, if the `fmi3SetXXXFr
 include::../headers/fmi3FunctionTypes.h[tag=SetIntervalDecimal]
 ----
 
-`valueReferences`:: An array of size `nValueReferences` holding the value references of the `Clock` variables.
+`valueReferences`:: An array of size `nValueReferences` holding the value references of the <<Clock>> variables.
 
-`intervals`:: An array of size `nIntervals` holding the clock intervals to be set.
+`intervals`:: An array of size `nIntervals` holding the Clock intervals to be set.
 
 [[fmi3SetIntervalFraction,`fmi3SetIntervalFraction`]]
 [source, C]
@@ -902,10 +902,10 @@ include::../headers/fmi3FunctionTypes.h[tag=SetIntervalFraction]
 
 `valueReferences`:: An array of size `nValueReferences` holding the value references of the `Clock` variables.
 
-`intervalCounters` and `resolutions`:: Arrays of size `nIntervals` holding the clock <<intervalCounter>> and <<resolution>> to be set.
+`intervalCounters` and `resolutions`:: Arrays of size `nIntervals` holding the Clock <<intervalCounter>> and <<resolution>> to be set.
 
 [[fmi3GetInterval,`fmi3GetInterval`]]
-For other clock types, the importer calls <<fmi3GetIntervalDecimal>> or <<fmi3GetIntervalFraction>> to query the next clock interval:
+For other Clock types, the importer calls <<fmi3GetIntervalDecimal>> or <<fmi3GetIntervalFraction>> to query the next Clock interval:
 
 [[fmi3GetIntervalDecimal,`fmi3GetIntervalDecimal`]]
 [source, C]
@@ -915,9 +915,9 @@ include::../headers/fmi3FunctionTypes.h[tag=GetIntervalDecimal]
 
 `valueReferences`:: An array of size `nValueReferences` holding the value references of the `Clock` variables.
 
-`intervals`:: An array of size `nIntervals` to retrieve the clock intervals.
+`intervals`:: An array of size `nIntervals` to retrieve the Clock intervals.
 
-`qualifiers`:: An array of size `nIntervals` to retrieve the clock <<qualifier>>.
+`qualifiers`:: An array of size `nIntervals` to retrieve the Clock <<qualifier>>.
 
 [[fmi3GetIntervalFraction,`fmi3GetIntervalFraction`]]
 [source, C]
@@ -927,9 +927,9 @@ include::../headers/fmi3FunctionTypes.h[tag=GetIntervalFraction]
 
 `valueReferences`:: An array of size `nValueReferences` holding the value references of the `Clock` variables.
 
-`intervalCounters` and `resolutions`:: Arrays of size `nIntervals` to retrieve the clock <<intervalCounter>> and <<resolution>>.
+`intervalCounters` and `resolutions`:: Arrays of size `nIntervals` to retrieve the Clock <<intervalCounter>> and <<resolution>>.
 
-`qualifiers`:: An array of size `nIntervals` to retrieve the clock <<qualifier>>.
+`qualifiers`:: An array of size `nIntervals` to retrieve the Clock <<qualifier>>.
 
 [[qualifier,`qualifier`]]
 `qualifier` describes how to treat the `interval` and `intervalCounter` arguments and is defined as:
@@ -940,7 +940,7 @@ include::../headers/fmi3FunctionTypes.h[tag=IntervalQualifier]
 ----
 
 [[shift, `shift`]]
-For <<table-overview-clocks,some clocks>>, the importer has to query the delay to the first clock tick from the FMU using the following functions[[fmi3GetShift,`fmi3GetShift`]]:
+For <<table-overview-clocks,some Clocks>>, the importer has to query the delay to the first Clock tick from the FMU using the following functions[[fmi3GetShift,`fmi3GetShift`]]:
 
 [[fmi3GetShiftDecimal,`fmi3GetShiftDecimal`]]
 [source, C]
@@ -948,9 +948,9 @@ For <<table-overview-clocks,some clocks>>, the importer has to query the delay t
 include::../headers/fmi3FunctionTypes.h[tag=GetShiftDecimal]
 ----
 
-`valueReferences`:: An array of size `nValueReferences` holding the value references of the `Clock` variables.
+`valueReferences`:: An array of size `nValueReferences` holding the value references of the Clock variables.
 
-`shifts`:: An array of length `nShifts` that defines the time of the first clock activation (see <<shiftCounter>>).
+`shifts`:: An array of length `nShifts` that defines the time of the first Clock activation (see <<shiftCounter>>).
 
 [[fmi3GetShiftFraction,`fmi3GetShiftFraction`]]
 [source, C]
@@ -958,9 +958,9 @@ include::../headers/fmi3FunctionTypes.h[tag=GetShiftDecimal]
 include::../headers/fmi3FunctionTypes.h[tag=GetShiftFraction]
 ----
 
-`valueReferences`:: An array of size `nValueReferences` holding the value references of the `Clock` variables.
+`valueReferences`:: An array of size `nValueReferences` holding the value references of the Clock variables.
 
-`shifts` and `shiftCounters`:: Arrays of length `nShifts` that define the time of the first clock activation (see <<shiftCounter>>).
+`shifts` and `shiftCounters`:: Arrays of length `nShifts` that define the time of the first Clock activation (see <<shiftCounter>>).
 
 ==== Dependencies of Variables [[model-dependencies]]
 
@@ -970,7 +970,7 @@ Dependencies between variables of an FMU:
 * associate continuous states and derivatives with each other and variables.
 * associate event indicators with variables.
 * define the sparseness when computing <<partial-derivatives,partial derivatives>>, avoiding unnecessary calls to <<fmi3GetDirectionalDerivative>> and <<fmi3GetAdjointDerivative>>.
-* assign <<clocked-variable,clocked variables>> to <<clock,clocks>>.
+* assign <<clocked-variable,clocked variables>> to <<Clock,Clocks>>.
 
 The dependencies are encoded in the <<modelDescription.xml>> with the element <<ModelStructure,`<ModelStructure>`>> up to <<valueReference>> resolution, not individual elements of array variables.
 

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -752,11 +752,12 @@ The importer must use <<fmi3GetInterval>> to retrieve the Clock interval in <<Ev
 The importer must use <<fmi3GetShift>> to retrieve the Clock <<shift>> in <<InitializationMode>>.
 
 Aperiodic Clock::
-is a time-based Clock with an interval that is not <<constant-interval>>.
+is a time-based Clock with an interval that can change during runtime by FMU-internal mechanisms.
 <<fmi3GetInterval>> must be called to retrieve the first interval in <<InitializationMode>>.
 Calling <<fmi3GetShift>> is not allowed.
 
-[[changing-aperiodic-clock,changing aperiodic Clock]]Changing aperiodic Clock::
+[[changing-aperiodic-clock,changing aperiodic Clock]]
+Changing aperiodic Clock::
 is a time-based Clock whose next interval is unchangeably known right after the Clock just ticked.
 +
 The next Clock activation at time instant latexmath:[t_i] is defined as: +
@@ -781,7 +782,8 @@ Must be retrieved in <<EventMode>> or <<ClockActivationMode>> if and only if the
 
 |===
 
-[[countdown-aperiodic-clock,countdown aperiodic Clock]]Countdown aperiodic Clock::
+[[countdown-aperiodic-clock,countdown aperiodic Clock]]
+Countdown aperiodic Clock::
 is a time-based Clock whose next interval is not yet known right after the Clock just ticked, forcing the importer to call <<fmi3GetInterval>> in every <<EventMode>> and in <<IntermediateUpdateMode>> if <<clocksTicked>> == `fmi3True` in <<fmi3CallbackIntermediateUpdate>>.
 The return argument <<qualifier>> of <<fmi3GetInterval>> is used to indicate if the next interval is already known.
 +

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -349,7 +349,7 @@ include::../headers/fmi3FunctionTypes.h[tags=SetClock]
 With two exceptions, all variables that are allowed to be set with <<get-and-set-variable-values,`fmi3Set{VariableType}`>> keep their respective values until the next call to <<get-and-set-variable-values,`fmi3Set{VariableType}`>>.
 Exceptions:
 
-. Variables of type <<Clock>> must be deactivated during <<fmi3UpdateDiscreteStates>> by the FMU.
+. Variables of type Clock must be deactivated during <<fmi3UpdateDiscreteStates>> by the FMU.
 . By setting the complete <<get-set-fmu-state,FMU state>> using <<fmi3SetFMUState>>, all variables are potentially changed.
 
 All strings passed as arguments to `fmi3SetString`, as well as all binary values passed as arguments to `fmi3SetBinary`, must be copied during these function calls, because there is no guarantee of the lifetime of strings or binary values, when these functions return.
@@ -602,128 +602,123 @@ Clocks are <<discrete>> <<fmu-variables,variables>> with a special semantic.
 
 The following Clock types are described in detail after the table.
 
-Input Clocks::
+Input Clock::
 [[inputClock, `input Clock`]]
-denote all Clocks with <<causality>> == <<input>>.
-The importer will activate <<inputClock, `input clocks`>> using <<fmi3SetClock>> or <<fmi3ActivateModelPartition>>.
-Contrary to the importer being the source of the actual clock activations, the definition of the clock timing comes from the FMU, either through the <<modelDescription.xml>> or calling <<fmi3GetInterval>>, or from another clock connected to a <<triggered>> input clock.
+is a variable of type Clock with <<causality>> == <<input>>.
+The importer will activate input Clocks using <<fmi3SetClock>> or <<fmi3ActivateModelPartition>>.
+While the importer is the source of the actual Clock activations, the timing of the Clocks is defined by the FMU, either through the <<modelDescription.xml>> or calling <<fmi3GetInterval>>, or by another Clock connected to a <<triggered>> input Clock.
 
-Output Clocks::
+Output Clock::
 [[outputClock, `output Clock`]]
-denote the <<triggered>> <<outputClock>>.
-There is only one such <<Clock>> type.
-We still refer to it as <<outputClock>> for simplicity.
+is a variable of type Clock with <<causality>> == <<output>>.
+The attribute <<interval>> must be <<triggered>> for output Clocks.
 The importer calls <<fmi3GetClock>> to inquire the clock activation state.
 
-.Overview of Clock Types.
+.Overview of Clock types.
 [[table-overview-clocks]]
 [cols="9,9,16,9,40,40",options="header"]
 |====
-2+|Clock Type
+2+|Clock type
 |Attribute <<causality>>
 |Attribute <<interval>>
-|Related API Calls and Arguments
+|Related API calls and arguments
 |Example
 
 .6+|time-based
-.4+|[[periodic]]periodic Clock
-.4+|`input`
-|`constant`
-|[[constantClock,`constant`]]<<fmi3SetClock>> in <<EventMode>>,
+.4+|[[periodic,`periodic`]]`periodic`
+.4+|<<input>>
+|[[constant-interval,`constant`]]`constant`
+|<<fmi3SetClock>> in <<EventMode>>,
 <<fmi3ActivateModelPartition>> in <<ClockActivationMode>>,
 <<fmi3GetInterval>> and <<fmi3GetShift>> in <<InitializationMode>>
 |clocked PI-controller with a defined constant interval
 
-|`fixed`
+|<<fixed>>
 |[[fixedClock,`fixed`]]<<fmi3SetClock>> in <<EventMode>>,
 <<fmi3ActivateModelPartition>> in <<ClockActivationMode>>,
 <<fmi3SetInterval>> in <<InitializationMode>>
 |clocked PI-controller with an adaptable interval
 
-|`calculated`
+|<<calculated>>
 |[[calculateClock,`calculated`]]<<fmi3SetClock>> in <<EventMode>>,
 <<fmi3ActivateModelPartition>> in <<ClockActivationMode>>,
 <<fmi3GetInterval>> and <<fmi3GetShift>> in <<InitializationMode>>
 |clocked PI-controller with interval defined by fixed parameter(s) of the FMU
 
-|`tunable`
+|<<tunable>>
 |[[tunableClock,`tunable`]]<<fmi3SetClock>> in <<EventMode>>,
 <<fmi3ActivateModelPartition>> in <<ClockActivationMode>>,
 <<fmi3GetShift>> in <<InitializationMode>>,
 <<fmi3GetInterval>> in <<EventMode>> and in <<ClockActivationMode>>
 |clocked PI-controller with interval defined by tunable parameter(s) of the FMU
 
-.2+|[[aperiodic]]aperiodic Clock
-.2+|`input`
-|`changing`
-|[[changing,`changing`]]<<fmi3SetClock>> in <<EventMode>>,
+.2+|[[aperiodic,`aperiodic`]]`aperiodic`
+.2+|<<input>>
+|[[changing,`changing`]]`changing`
+|<<fmi3SetClock>> in <<EventMode>>,
 <<fmi3ActivateModelPartition>> in <<ClockActivationMode>>,
 <<fmi3GetInterval>> in <<InitializationMode>>,
 <<fmi3GetInterval>> in both <<EventMode>> and <<ClockActivationMode>> if and only if this Clock ticked
 |simulation of the behavior of a control algorithm with variable execution time, generation of pulse sequences
 
-|`countdown`
-|[[countdown,`countdown`]]<<fmi3SetClock>> in <<EventMode>>,
+|[[countdown,`countdown`]]`countdown`
+|<<fmi3SetClock>> in <<EventMode>>,
 <<fmi3ActivateModelPartition>> in <<ClockActivationMode>>,
 <<fmi3GetInterval>> in <<InitializationMode>>, in every <<EventMode>>, and in <<IntermediateUpdateMode>>.
 In Scheduled Execution the FMU has to inform the importer by calling <<fmi3CallbackIntermediateUpdate>> that the Clock is about to tick.
 |time-delayed actions after an event, for example, ignition signal some time after specific crank shaft angle
 
-.2+|triggered
-|input Clock
-|`input`
-|`triggered`
-|[[triggered,`triggered`]]<<fmi3SetClock>> in <<EventMode>>,
+2.2+|[[triggered,`triggered`]]triggered
+|<<input>>
+|<<triggered>>
+|<<fmi3SetClock>> in <<EventMode>>,
 <<fmi3ActivateModelPartition>> in <<ClockActivationMode>>,
 argument <<clocksTicked>> of <<fmi3CallbackIntermediateUpdate>>
 |triggered by a hardware interrupt of an embedded system, e.g. a control algorithm, triggered by a crankshaft angle
 
-|output Clock
-|`output`
-|`triggered`
-|<<fmi3GetClock>> in both <<EventMode>> and <<IntermediateUpdateMode>>,
-and argument <<clocksTicked>> of <<fmi3CallbackIntermediateUpdate>>
+|<<output>>
+|<<triggered>>
+|<<fmi3GetClock>> in both <<EventMode>> and <<IntermediateUpdateMode>>, and argument <<clocksTicked>> of <<fmi3CallbackIntermediateUpdate>>
 |crankshaft angle sensor ticking several times per revolution
-
 |====
 
-[[time-based-clocks,time-based Clocks]]Time-based Clocks::
+[[time-based-clock,time-based Clock]]Time-based Clock::
 
-are in a sense predictable and help the importer to take these Clock ticks into account a priori.
+is in a sense predictable and helps the importer to take its Clock ticks into account a priori.
 All time-based Clocks are defined to be input Clocks because the importer calls <<fmi3SetClock>> or <<fmi3ActivateModelPartition>> on these Clocks.
 The importer queries the FMU about when a time-based Clock should be activated.
-The importer will then activate the Clock by calling <<fmi3SetClock>> with `values == fmi3ClockActive`.
+The importer will then activate the Clock by calling <<fmi3SetClock>>.
 +
-The mathematical descriptions of <<time-based-clocks>> will use the following notations:
+The mathematical descriptions of <<time-based-clock>> will use the following notations:
 
 +
 .Mathematical Notation Description.
 [#table-notation-description]
-[cols="1,2"]
+[cols="1,5"]
 |===
 |latexmath:[\mathbf{t}_0]
-|The time instant at which the <<Clock>> is activated the first time.
+|The time instant at which the Clock is activated the first time.
 
 |latexmath:[\mathbf{t}_\mathit{i-1}]
-|The previous time instant, where the <<Clock>> ticked.
+|The previous time instant, where the Clock ticked.
 
 |latexmath:[\mathbf{T}_{\mathit{shift}}]
-|Delay for the first Clock activation relative to latexmath:[\mathbf{t}_{\mathit{start}}]. latexmath:[\mathbf{T}_{\mathit{shift}}] is defined differently for the different Clock types, and can be retrieved from the FMU with <<fmi3GetShiftDecimal>> as floating point value, or with <<fmi3GetShiftFraction>> as rational number: latexmath:[\mathit{shiftCounter} / \mathit{resolution}] (see <<resolution>>).
+|The delay for the first Clock activation relative to latexmath:[\mathbf{t}_{\mathit{start}}]. latexmath:[\mathbf{T}_{\mathit{shift}}] is defined differently for the different Clock types, and can be retrieved from the FMU with <<fmi3GetShiftDecimal>> as floating point value, or with <<fmi3GetShiftFraction>> as rational number `shiftCounter / resolution` (see <<resolution>>).
 
 |latexmath:[\mathbf{T}_{interval, i}]
-|The time interval until the next <<Clock>> tick, defined differently for the different Clock types.
-latexmath:[\mathbf{T}_{interval, i}] can be set with <<fmi3SetIntervalDecimal>> or retrieved with <<fmi3GetIntervalDecimal>> as floating point value, or as rational number using <<fmi3SetIntervalFraction>> or <<fmi3GetIntervalFraction>>: latexmath:[\mathit{intervalCounter} / \mathit{resolution}] (see <<resolution>>).
+|The time interval until the next Clock tick, defined differently for the different Clock types.
+latexmath:[\mathbf{T}_{interval, i}] can be set with <<fmi3SetIntervalDecimal>> or retrieved with <<fmi3GetIntervalDecimal>> as floating point value, or as rational number using <<fmi3SetIntervalFraction>> or <<fmi3GetIntervalFraction>> `intervalCounter / resolution` (see <<resolution>>).
 
 |latexmath:[\mathbf{t}_\mathit{event}]
-|Current event time in <<EventMode>>, or the current time in SE.
+|The current event time in <<EventMode>>, or the current time in Scheduled Execution.
 
 |===
 
-[[periodic-clock-ticks]]Periodic clocks::
-are time-based Clocks which have a constant interval, except when `interval = tunable` which indicates that the interval can change when <<tunable>> parameters change.
+[[periodic-clock]]Periodic Clock::
+is a time-based Clock with a constant interval, except when <<interval>> == <<tunable>>, which indicates that the interval can change when tunable <<parameter, parameters>> change.
 The time instant of the first Clock activation is defined by a <<shift>>.
 +
-The next <<Clock>> activation at time instant latexmath:[t_i] is defined as: +
+The next Clock activation at time instant latexmath:[t_i] is defined as: +
 latexmath:[\begin{align*}
 \mathbf{t}_0 &:= \mathbf{t}_{\mathit{start}} + \mathbf{T}_{\mathit{shift}} \\
 \mathbf{t}_i &:= \mathbf{t}_{i-1} + \mathbf{T}_{interval, i} \qquad i = 1,2,3,{...}
@@ -736,35 +731,35 @@ latexmath:[\begin{align*}
 |===
 
 |latexmath:[\mathbf{T}_{interval, i} > 0]
-|The time interval from the previous <<Clock>> tick to the current <<Clock>> tick, specified differently for the different Clock types.
+|The time interval from the previous Clock tick to the current Clock tick, specified differently for the different Clock types.
 |===
 
-Constant periodic clocks::
+Constant periodic Clock::
 are time-based periodic clocks that define their <<interval>> and <<shift>> in the <<modelDescription.xml>>.
 
-[[fixed-periodic-clocks,fixed periodic Clocks]]Fixed periodic Clocks::
-are time-base periodic clocks which can be activated by the importer with an arbitrary, but constant interval starting after an arbitrary <<shift>>.
+[[fixed-periodic-clock,fixed periodic Clock]]Fixed periodic Clock::
+is a time-base periodic Clock which can be activated by the importer with an arbitrary, but constant interval starting after an arbitrary <<shift>>.
 The importer informs the FMU about the interval using <<fmi3SetInterval>>.
 
-Calculated periodic Clocks::
-are time-base periodic Clocks where the interval and <<shift>> depend on <<fixed>> <<parameter, parameters>>.
+Calculated periodic Clock::
+is a time-base periodic Clock whose interval and <<shift>> depend on <<fixed>> <<parameter, parameters>>.
 The importer must use <<fmi3GetInterval>> and <<fmi3GetShift>> to retrieve the Clock interval and <<shift>> in <<InitializationMode>>.
 
-Tunable periodic Clocks::
-are time-base periodic Clocks where the interval depends on <<tunable>> <<parameter, parameters>>.
+Tunable periodic Clock::
+is a time-base periodic Clock whose interval depends on <<tunable>> <<parameter, parameters>>.
 The importer must use <<fmi3GetInterval>> to retrieve the Clock interval in <<EventMode>> or <<ClockActivationMode>>, if any of the <<tunable>> <<parameter, parameters>> it depends on was changed.
 <<shift>> may only depend on <<fixed>> <<parameter, parameters>>.
 The importer must use <<fmi3GetShift>> to retrieve the Clock <<shift>> in <<InitializationMode>>.
 
-[[aperiodic-clocks,aperiodic Clocks]]Aperiodic Clocks::
-are time-based Clocks which have a nonconstant interval.
+Aperiodic Clock::
+is a time-based Clock with an interval that is not <<constant-interval>>.
 <<fmi3GetInterval>> must be called to retrieve the first interval in <<InitializationMode>>.
 Calling <<fmi3GetShift>> is not allowed.
 
-[[changing-aperiodic-clocks,changing aperiodic Clocks]]Changing aperiodic Clocks::
-are time-based Clocks where the next interval is unchangeably known right after the Clock just ticked.
+[[changing-aperiodic-clock,changing aperiodic Clock]]Changing aperiodic Clock::
+is a time-based Clock whose next interval is unchangeably known right after the Clock just ticked.
 +
-The next <<Clock>> activation at time instant latexmath:[t_i] is defined as: +
+The next Clock activation at time instant latexmath:[t_i] is defined as: +
 latexmath:[\begin{align*}
 \mathbf{t}_0 &:= \mathbf{t}_{\mathit{start}} + \mathbf{T}_{interval, 0} \\
 \mathbf{t}_i &:= \mathbf{t}_{i-1} + \mathbf{T}_{interval, i} \qquad i = 1,2,3,{...}
@@ -777,20 +772,20 @@ latexmath:[\begin{align*}
 |===
 
 |latexmath:[\mathbf{T}_{interval, 0} \geq 0]
-|The time interval from latexmath:[\mathbf{t}_{\mathit{start}}] to first <<Clock>> tick.
+|The time interval from latexmath:[\mathbf{t}_{\mathit{start}}] to first Clock tick.
 Must be retrieved in <<InitializationMode>>.
 
 |latexmath:[\mathbf{T}_{interval, i} > 0, \qquad i = 1,2,3,{...}]
-|The time interval from the current <<Clock>> tick to the next <<Clock>> tick.
+|The time interval from the current Clock tick to the next Clock tick.
 Must be retrieved in <<EventMode>> or <<ClockActivationMode>> if and only if the corresponding Clock ticked.
 
 |===
 
-[[countdown-aperiodic-clocks,countdown aperiodic clocks]]Countdown aperiodic Clocks::
-are time-based Clocks where the next interval is not yet known right after the Clock just ticked, forcing the importer to call <<fmi3GetInterval>> in every <<EventMode>> and in <<IntermediateUpdateMode>> if <<clocksTicked, `clocksTicked == fmi3True`>> in <<fmi3CallbackIntermediateUpdate>>.
+[[countdown-aperiodic-clock,countdown aperiodic Clock]]Countdown aperiodic Clock::
+is a time-based Clock whose next interval is not yet known right after the Clock just ticked, forcing the importer to call <<fmi3GetInterval>> in every <<EventMode>> and in <<IntermediateUpdateMode>> if <<clocksTicked>> == `fmi3True` in <<fmi3CallbackIntermediateUpdate>>.
 The return argument <<qualifier>> of <<fmi3GetInterval>> is used to indicate if the next interval is already known.
 +
-The next <<Clock>> activation at time instant latexmath:[t_i] is defined as: +
+The next Clock activation at time instant latexmath:[t_i] is defined as: +
 latexmath:[\begin{align*}
 \mathbf{t}_0 &:= \mathbf{t}_{\mathit{start}} + \mathbf{T}_{interval, 0} \\
 \mathbf{t}_i &:= \mathbf{t}_{event} + \mathbf{T}_{interval, i} \qquad i = 1,2,3,{...}
@@ -803,22 +798,22 @@ latexmath:[\begin{align*}
 |===
 
 |latexmath:[\mathbf{T}_{interval, 0} \geq 0]
-|The time interval from latexmath:[\mathbf{t}_\mathit{start}] to the first <<Clock>> tick.
+|The time interval from latexmath:[\mathbf{t}_\mathit{start}] to the first Clock tick.
 Must be retrieved in <<InitializationMode>>.
 
 |latexmath:[\mathbf{T}_{interval, i} \geq 0, \qquad i = 1,2,3,{...}]
-|The time interval from the event time at which the argument <<qualifier,`qualifier == fmi3IntervalChanged`>> of <<fmi3GetInterval>> to the next <<Clock>> tick.
+|The time interval from the event time at which the argument <<qualifier,`qualifier == fmi3IntervalChanged`>> of <<fmi3GetInterval>> to the next Clock tick.
 
 |===
 
-Triggered Clocks::
-tick unpredictably.
+Triggered Clock::
+ticks unpredictably.
 
-Triggered input Clocks::
-are activated with <<fmi3SetClock>> by the importer in <<EventMode>>, or with <<fmi3ActivateModelPartition>> in <<ClockActivationMode>>.
+Triggered input Clock::
+is activated with <<fmi3SetClock>> by the importer in <<EventMode>>, or with <<fmi3ActivateModelPartition>> in <<ClockActivationMode>>.
 
-Triggered output Clocks::
-are activated within the FMU and the importer must call <<fmi3GetClock>> in <<EventMode>> or in <<IntermediateUpdateMode>>.
+Triggered output Clock::
+is activated within the FMU and the importer must call <<fmi3GetClock>> in <<EventMode>> or in <<IntermediateUpdateMode>>.
 
 _[Output Clocks are intended to enable an FMU to provide a trigger to the outside world, e.g. to a <<triggered, `triggered input Clock`>> of another FMU._
 _Note, that if intended to activate model partitions or a Clock of the same FMU calling <<fmi3GetInterval>> for a <<countdown, `countdown Clock`>> and evaluating the <<qualifier>> is recommended._
@@ -826,7 +821,7 @@ _An example is provided in <<example-scheduled-execution>>.]_
 
 ===== Model Partitions and Clocked Variables [[clocked-variable]]
 
-A <<Clock>> with <<causality>>  == <<input>> activates its specific <<model-partition>>.
+An input Clock activates its specific <<model-partition>>.
 
 _[Such a model partition may represent a task or an interrupt service routine of an embedded system, or a discretized part of a plant model.]_
 
@@ -834,7 +829,7 @@ Discrete-time variables computed in such a model partition are called <<clocked-
 Therefore, the value of a <<clocked-variable,clocked variable>> changes only when its Clock is active.
 Model partitions are initialized at their first Clock activation, not in <<InitializationMode>>.
 
-In some Clock semantics (e.g. <<MLS12>>), a clocked variable has a value only when its associated Clock is active.
+In some clock semantics (e.g. <<MLS12>>), a clocked variable has a value only when its associated Clock is active.
 However, <<get-and-set-variable-values,`fmi3Get{VariableType}`>> will return the value computed at the last Clock activation time.
 Before the first Clock tick, clocked variables have their initial value.
 
@@ -842,20 +837,20 @@ The association between <<clocked-variable,clocked variables>> and their <<Clock
 <<clocked-variable,Clocked variables>> can depend on multiple Clocks.
 _[For example, a global counter could be incremented by multiple tasks, each controlled by a different Clock.]_
 
-===== Scheduled Execution
+===== Scheduled Execution [[scheduled-execution]]
 
-During <<ClockActivationMode>> after <<fmi3ActivateModelPartition>> has been called for a <<calculated>>, <<tunable>> or <<changing>> <<Clock>> the FMU provides the information on when the Clock will tick again, i.e. when the corresponding model partition has to be scheduled the next time.
+During <<ClockActivationMode>> after <<fmi3ActivateModelPartition>> has been called for a <<calculated>>, <<tunable>> or <<changing>> Clock the FMU provides the information on when the Clock will tick again, i.e. when the corresponding model partition has to be scheduled the next time.
 To retrieve this information the importer calls <<fmi3GetInterval>> on the Clock.
 
 The FMU may request to schedule another model partition even while currently a model partition is being executed.
-<<countdown, `countdown clocks`>> can tick at any time during the execution of any model partition.
+<<countdown>> Clocks can tick at any time during the execution of any model partition.
 The FMU signals their ticking by calling <<fmi3CallbackIntermediateUpdate>> with argument <<clocksTicked>> == `fmi3True`.
 The importer calls <<fmi3GetInterval>> for all countdown Clocks.
 If a new interval is provided, the importer initiates the scheduling of the associated model partitions with the returned <<interval>>.
-<<qualifier,`qualifier == fmi3IntervalChanged`>> indicates that the corresponding <<Clock>> has to be scheduled.
+<<qualifier>> == `fmi3IntervalChanged` indicates that the corresponding Clock has to be scheduled.
 
 In case more than one Clock has to be activated at the same time instant, the scheduler needs a priority to define the activation sequence.
-This ordering is defined by the <<priority>> attributes of the <<Clock>>.
+This ordering is defined by the <<priority>> attributes of the Clock.
 
 _[For real-time computation use cases, the priority information is used also for task preemption configurations._
 _It is therefore important to restrict the number of distinct priority levels for an FMU to available priority levels on the target platform and/or to avoid unnecessary computational overhead._
@@ -867,7 +862,7 @@ _It is the task of the importer to derive a computational order for the computat
 
 _[For periodic <<Clock, `Clocks`>> it is recommended to derive the priorities based on a rate monotonic scheduling scheme (smallest period leads to highest priority, that is, has the smallest priority value.]_
 
-===== [[fmi3SetInterval]] API
+===== [[fmi3SetInterval]] Clocks specific API
 
 [[fmi3GetClock,`fmi3GetClock`]]
 [[fmi3SetClock,`fmi3SetClock`]]Clocks are get and set just like any other variable (see also <<get-and-set-variable-values>>):
@@ -879,10 +874,10 @@ include::../headers/fmi3FunctionTypes.h[tags=GetClock]
 include::../headers/fmi3FunctionTypes.h[tags=SetClock]
 ----
 
-For some <<Clock>> types, the interval [[fmi3SetInterval,`fmi3SetInterval`]] is set by the environment for the current time instant by the function <<fmi3SetIntervalDecimal>> or <<fmi3SetIntervalFraction>>.
+For some Clock types, the interval [[fmi3SetInterval,`fmi3SetInterval`]] is set by the environment for the current time instant by the function <<fmi3SetIntervalDecimal>> or <<fmi3SetIntervalFraction>>.
 The values of the arguments `interval`, `intervalCounter`, `resolution`, `shift` and `shiftCounter` refer to the unit of the <<independent>> variable.
 
-The attribute <<supportsFraction>> of a <<Clock>> declares, if the `fmi3SetXXXFraction` and/or `fmi3GetXXXFraction` functions are allowed to be called.
+The attribute <<supportsFraction>> of a Clock declares, if the `fmi3SetXXXFraction` and/or `fmi3GetXXXFraction` functions are allowed to be called.
 
 [[fmi3SetIntervalDecimal,`fmi3SetIntervalDecimal`]]
 [source, C]
@@ -890,7 +885,7 @@ The attribute <<supportsFraction>> of a <<Clock>> declares, if the `fmi3SetXXXFr
 include::../headers/fmi3FunctionTypes.h[tag=SetIntervalDecimal]
 ----
 
-`valueReferences`:: An array of size `nValueReferences` holding the value references of the <<Clock>> variables.
+`valueReferences`:: An array of size `nValueReferences` holding the value references of the Clock variables.
 
 `intervals`:: An array of size `nIntervals` holding the Clock intervals to be set.
 

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -885,9 +885,9 @@ The attribute <<supportsFraction>> of a Clock declares, if the `fmi3SetXXXFracti
 include::../headers/fmi3FunctionTypes.h[tag=SetIntervalDecimal]
 ----
 
-`valueReferences`:: An array of size `nValueReferences` holding the value references of the Clock variables.
+* `valueReferences` is an array of size `nValueReferences` holding the value references of the Clock variables.
 
-`intervals`:: An array of size `nIntervals` holding the Clock intervals to be set.
+* `intervals` is an array of size `nIntervals` holding the Clock intervals to be set.
 
 [[fmi3SetIntervalFraction,`fmi3SetIntervalFraction`]]
 [source, C]
@@ -895,9 +895,9 @@ include::../headers/fmi3FunctionTypes.h[tag=SetIntervalDecimal]
 include::../headers/fmi3FunctionTypes.h[tag=SetIntervalFraction]
 ----
 
-`valueReferences`:: An array of size `nValueReferences` holding the value references of the `Clock` variables.
+* `valueReferences` is an array of size `nValueReferences` holding the value references of the `Clock` variables.
 
-`intervalCounters` and `resolutions`:: Arrays of size `nIntervals` holding the Clock <<intervalCounter>> and <<resolution>> to be set.
+* `intervalCounters` and `resolutions` are arrays of size `nIntervals` holding the Clock <<intervalCounter>> and <<resolution>> to be set.
 
 [[fmi3GetInterval,`fmi3GetInterval`]]
 For other Clock types, the importer calls <<fmi3GetIntervalDecimal>> or <<fmi3GetIntervalFraction>> to query the next Clock interval:
@@ -908,23 +908,11 @@ For other Clock types, the importer calls <<fmi3GetIntervalDecimal>> or <<fmi3Ge
 include::../headers/fmi3FunctionTypes.h[tag=GetIntervalDecimal]
 ----
 
-`valueReferences`:: An array of size `nValueReferences` holding the value references of the `Clock` variables.
+* `valueReferences` is an array of size `nValueReferences` holding the value references of the `Clock` variables.
 
-`intervals`:: An array of size `nIntervals` to retrieve the Clock intervals.
+* `intervals` is an array of size `nIntervals` to retrieve the Clock intervals.
 
-`qualifiers`:: An array of size `nIntervals` to retrieve the Clock <<qualifier>>.
-
-[[fmi3GetIntervalFraction,`fmi3GetIntervalFraction`]]
-[source, C]
-----
-include::../headers/fmi3FunctionTypes.h[tag=GetIntervalFraction]
-----
-
-`valueReferences`:: An array of size `nValueReferences` holding the value references of the `Clock` variables.
-
-`intervalCounters` and `resolutions`:: Arrays of size `nIntervals` to retrieve the Clock <<intervalCounter>> and <<resolution>>.
-
-`qualifiers`:: An array of size `nIntervals` to retrieve the Clock <<qualifier>>.
+* `qualifiers` is an array of size `nIntervals` to retrieve the Clock <<qualifier>>.
 
 [[qualifier,`qualifier`]]
 `qualifier` describes how to treat the `interval` and `intervalCounter` arguments and is defined as:
@@ -933,6 +921,18 @@ include::../headers/fmi3FunctionTypes.h[tag=GetIntervalFraction]
 ----
 include::../headers/fmi3FunctionTypes.h[tag=IntervalQualifier]
 ----
+
+[[fmi3GetIntervalFraction,`fmi3GetIntervalFraction`]]
+[source, C]
+----
+include::../headers/fmi3FunctionTypes.h[tag=GetIntervalFraction]
+----
+
+* `valueReferences` is an array of size `nValueReferences` holding the value references of the `Clock` variables.
+
+* `intervalCounters` and `resolutions` are arrays of size `nIntervals` to retrieve the Clock <<intervalCounter>> and <<resolution>>.
+
+* `qualifiers` is an array of size `nIntervals` to retrieve the Clock <<qualifier>>.
 
 [[shift, `shift`]]
 For <<table-overview-clocks,some Clocks>>, the importer has to query the delay to the first Clock tick from the FMU using the following functions[[fmi3GetShift,`fmi3GetShift`]]:
@@ -943,9 +943,9 @@ For <<table-overview-clocks,some Clocks>>, the importer has to query the delay t
 include::../headers/fmi3FunctionTypes.h[tag=GetShiftDecimal]
 ----
 
-`valueReferences`:: An array of size `nValueReferences` holding the value references of the Clock variables.
+* `valueReferences` is an array of size `nValueReferences` holding the value references of the Clock variables.
 
-`shifts`:: An array of length `nShifts` that defines the time of the first Clock activation (see <<shiftCounter>>).
+* `shifts` is an array of length `nShifts` that defines the time of the first Clock activation (see <<shiftCounter>>).
 
 [[fmi3GetShiftFraction,`fmi3GetShiftFraction`]]
 [source, C]
@@ -953,9 +953,9 @@ include::../headers/fmi3FunctionTypes.h[tag=GetShiftDecimal]
 include::../headers/fmi3FunctionTypes.h[tag=GetShiftFraction]
 ----
 
-`valueReferences`:: An array of size `nValueReferences` holding the value references of the Clock variables.
+* `valueReferences` is an array of size `nValueReferences` holding the value references of the Clock variables.
 
-`shifts` and `shiftCounters`:: Arrays of length `nShifts` that define the time of the first Clock activation (see <<shiftCounter>>).
+* `shifts` and `shiftCounters` are arrays of length `nShifts` that define the time of the first Clock activation (see <<shiftCounter>>).
 
 ==== Dependencies of Variables [[model-dependencies]]
 

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -807,7 +807,7 @@ latexmath:[\begin{align*}
 Must be retrieved in <<InitializationMode>>.
 
 |latexmath:[\mathbf{T}_{interval, i} \geq 0, \qquad i = 1,2,3,{...}]
-|The time interval from the event time at which the argument <<qualifier,`qualifier == fmi3NewInterval`>> of <<fmi3GetInterval>> to the next <<clock>> tick.
+|The time interval from the event time at which the argument <<qualifier,`qualifier == fmi3IntervalChanged`>> of <<fmi3GetInterval>> to the next <<clock>> tick.
 
 |===
 
@@ -852,7 +852,7 @@ The FMU may request to schedule another model partition even while currently a m
 The FMU signals their ticking by calling <<fmi3CallbackIntermediateUpdate>> with argument <<clocksTicked,`clocksTicked == fmi3True`>>.
 The importer calls <<fmi3GetInterval>> for all countdown clocks.
 If a new interval is provided, the importer initiates the scheduling of the associated model partitions with the returned <<interval>>.
-<<qualifier,`qualifier == fmi3NewInterval`>> indicates that the corresponding <<clocks, `clock`>> has to be scheduled.
+<<qualifier,`qualifier == fmi3IntervalChanged`>> indicates that the corresponding <<clocks, `clock`>> has to be scheduled.
 
 In case more than one clock has to be activated at the same time instant, the scheduler needs a priority to define the activation sequence.
 This ordering is defined by the <<priority>> attributes of the <<clocks, `clocks`>>.

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -150,7 +150,8 @@ Additionally, a pointer to the environment is provided (`instanceEnvironment`) t
 
 Allowed Function Calls::
 
-[[fmi3SetDebugLogging,`fmi3SetDebugLogging`]]Function `fmi3SetDebugLogging`::
+[[fmi3SetDebugLogging,`fmi3SetDebugLogging`]]
+Function `fmi3SetDebugLogging`::
 +
 [source, C]
 ----
@@ -166,7 +167,8 @@ If `loggingOn == fmi3True` and `nCategories > 0`, then only debug messages accor
 The allowed values of `categories` are defined by the modeling environment that generated the FMU.
 Depending on the generating modeling environment, none, some or all allowed values for `categories` for this FMU are defined in the <<modelDescription.xml>> file via element `<fmiModelDescription><LogCategories>`, see <<definition-of-log-categories>>.
 
-[[fmi3Reset,`fmi3Reset`]]Function `fmi3Reset`::
+[[fmi3Reset,`fmi3Reset`]]
+Function `fmi3Reset`::
 +
 [source, C]
 ----
@@ -237,7 +239,7 @@ include::../headers/fmi3FunctionTypes.h[tags=EnterConfigurationMode]
 If the importer needs to change <<structuralParameter,`structural parameters`>>, it must move the FMU into <<ConfigurationMode>> using <<fmi3EnterConfigurationMode>>.
 
 [[fmi3GetNumberOfContinuousStates,`fmi3GetNumberOfContinuousStates`]]
-Function <<fmi3GetNumberOfContinuousStates>>::
+Function `fmi3GetNumberOfContinuousStates`::
 +
 [source, C]
 ----
@@ -255,7 +257,7 @@ The number of <<state,continuous states>> might change if a variable representin
 As long as no <<structuralParameter,`structural parameters`>> changed, the number of states is given in the <<modelDescription.xml>>, alleviating the need to call this function.
 
 [[fmi3GetNumberOfEventIndicators,`fmi3GetNumberOfEventIndicators`]]
-Function <<fmi3GetNumberOfEventIndicators>>::
+Function `fmi3GetNumberOfEventIndicators`::
 +
 [source, C]
 ----
@@ -352,7 +354,7 @@ Function <<fmi3GetContinuousStateDerivatives>>::
 See <<fmi3GetContinuousStateDerivatives>> for Model Exchange only.
 
 [[fmi3GetContinuousStates,`fmi3GetContinuousStates`]]
-Function <<fmi3GetContinuousStates>>::
+Function `fmi3GetContinuousStates`::
 In Model Exchange only:
 +
 [source, C]
@@ -367,7 +369,7 @@ Return the current continuous state vector.
 * Argument `nContinuousStates` is the size of the `continuousStates` vector.
 
 [[fmi3GetNominalsOfContinuousStates,`fmi3GetNominalsOfContinuousStates`]]
-Function <<fmi3GetNominalsOfContinuousStates>>::
+Function `fmi3GetNominalsOfContinuousStates`::
 +
 [source, C]
 ----
@@ -592,7 +594,7 @@ Function <<fmi3EnterConfigurationMode>>::
 <<fmi3EnterConfigurationMode>> must not be called if the FMU contains no <<tunable>> <<structuralParameter,`structural parameters`>> (i.e. with <<causality>>= <<structuralParameter>> and <<variability>> = <<tunable>>).
 
 [[fmi3EnterContinuousTimeMode,`fmi3EnterContinuousTimeMode`]]
-Function <<fmi3EnterContinuousTimeMode>>::
+Function `fmi3EnterContinuousTimeMode`::
 +
 [source, C]
 ----
@@ -602,7 +604,7 @@ include::../headers/fmi3FunctionTypes.h[tags=EnterContinuousTimeMode]
 This function must be called to change from <<EventMode>> into <<ContinuousTimeMode>> in Model Exchange.
 
 [[fmi3EnterStepMode,`fmi3EnterStepMode`]]
-Function <<fmi3EnterStepMode>>::
+Function `fmi3EnterStepMode`::
 +
 [source, C]
 ----

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -526,7 +526,7 @@ is used to inquire the status of <<Clock,Clocks>>.
 
 Function <<fmi3GetIntervalDecimal>>::
 Function <<fmi3GetIntervalFraction>>::
-For <<input>> <<Clock,`clocks`>> it is allowed to call these functions to query the next activation interval. +
+For <<inputClock,`input Clocks`>> it is allowed to call these functions to query the next activation interval. +
 For <<changing-aperiodic-clock>>, these functions must be called in every <<EventMode>> where this clock was activated. +
 For <<countdown-aperiodic-clock>>, these functions must be called in every <<EventMode>>. +
 Clock intervals are computed in <<fmi3UpdateDiscreteStates>> (at the latest), therefore, these functions should be called after <<fmi3UpdateDiscreteStates>>.

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -517,16 +517,16 @@ Functions <<get-and-set-variable-values,`fmi3Get{VariableType}`>>::
 Getting variables might trigger <<selectiv-computation,computations>>.
 
 Function <<fmi3SetClock>>::
-For <<inputClock,`input clocks`>>, <<fmi3SetClock>> is called to set the activation status of <<clock,`clocks`>> to `fmi3ClockActive` or `fmi3ClockInactive`.
+For <<inputClock,`input Clocks`>>, <<fmi3SetClock>> is called to set the activation status of <<Clock,`Clocks`>> to `fmi3ClockActive` or `fmi3ClockInactive`.
 During the solution of algebraic loops, the activation condition of triggered input clocks may change and therefore <<fmi3SetClock>> can be called multiple times per super-dense time instant.
 Only <<time-based-clocks,Time-based clocks>> must not be active for more than one call of <<fmi3UpdateDiscreteStates>> per <<EventMode>>.
 
 Function <<fmi3GetClock>>::
-is used to inquire the status of <<clocks>>.
+is used to inquire the status of <<Clock,Clocks>>.
 
 Function <<fmi3GetIntervalDecimal>>::
 Function <<fmi3GetIntervalFraction>>::
-For <<clock,`input clocks`>> it is allowed to call these functions to query the next activation interval. +
+For <<input>> <<Clock,`clocks`>> it is allowed to call these functions to query the next activation interval. +
 For <<changing-aperiodic-clocks>>, these functions must be called in every <<EventMode>> where this clock was activated. +
 For <<countdown-aperiodic-clocks>>, these functions must be called in every <<EventMode>>. +
 Clock intervals are computed in <<fmi3UpdateDiscreteStates>> (at the latest), therefore, these functions should be called after <<fmi3UpdateDiscreteStates>>.
@@ -735,7 +735,7 @@ In Scheduled Execution the <<intermediateUpdateTime>> should be ignored since in
 
 [[clocksTicked,`clocksTicked`]]
 * The <<clocksTicked>> parameter is only used in Scheduled Execution and is ignored in Co-Simulation.
-When <<clocksTicked,`clocksTicked == fmi3True`>>, it means that <<fmi3GetClock>> function must be called for gathering all <<clock>> related information about ticking <<outputClock,`output clocks`>> and then activate the given model partitions accordingly.
+When <<clocksTicked,`clocksTicked == fmi3True`>>, it means that <<fmi3GetClock>> function must be called for gathering all <<Clock>> related information about ticking <<outputClock,`output clocks`>> and then activate the given model partitions accordingly.
 
 [[intermediateVariableSetRequested,`intermediateVariableSetRequested`]]
 * If <<intermediateVariableSetRequested,`intermediateVariableSetRequested == fmi3True`>>, the co-simulation algorithm may provide intermediate values for continuous <<input>> variables with <<intermediateUpdate,`intermediateUpdate = true`>> by calling <<get-and-set-variable-values,`fmi3Set{VariableType}`>>.
@@ -806,9 +806,9 @@ Additionally to the functions listed above, Scheduled Execution allows calling t
 Function <<fmi3GetClock>>::
 The scheduling algorithm uses <<fmi3GetClock>> to determine which clock is active. +
 _[For efficiency, <<fmi3GetClock>> should only be called if <<clocksTicked, `clocksTicked == fmi3True`>>.]_ +
-Depending on the clock activation state, the scheduling algorithm can call <<get-and-set-variable-values,`fmi3Set{VariableType}`>> and <<get-and-set-variable-values,`fmi3Get{VariableType}`>> for variables associated with the corresponding <<clock>>.
-For an <<outputClock>> only the first call of `fmi3GetClock` for a specific activation of this <<clock>> signals `fmi3ClockActive`.
-The FMU sets the reported activation state immediately back to `fmi3ClockInactive` for following `fmi3GetClock` calls for that <<clock>> until this <<outputClock>> is activated again.
+Depending on the clock activation state, the scheduling algorithm can call <<get-and-set-variable-values,`fmi3Set{VariableType}`>> and <<get-and-set-variable-values,`fmi3Get{VariableType}`>> for variables associated with the corresponding <<Clock>>.
+For an <<outputClock>> only the first call of `fmi3GetClock` for a specific activation of this <<Clock>> signals `fmi3ClockActive`.
+The FMU sets the reported activation state immediately back to `fmi3ClockInactive` for following `fmi3GetClock` calls for that <<Clock>> until this <<outputClock>> is activated again.
 
 Functions <<fmi3GetIntervalDecimal>> & <<fmi3GetIntervalFraction>>::
 These function calls are allowed for <<inputClock, input clocks>>.

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -405,7 +405,7 @@ See <<fmi3GetInterval>>.
 
 Function <<fmi3SetIntervalDecimal>>::
 Function <<fmi3SetIntervalFraction>>::
-One of these functions must be called for all <<fixed-periodic-clocks>>.
+One of these functions must be called for all <<fixed-periodic-clock,Fixed periodic Clocks>>.
 
 [[fmi3ExitInitializationMode,`fmi3ExitInitializationMode`]]
 Function `fmi3ExitInitializationMode`::
@@ -519,7 +519,7 @@ Getting variables might trigger <<selectiv-computation,computations>>.
 Function <<fmi3SetClock>>::
 For <<inputClock,`input Clocks`>>, <<fmi3SetClock>> is called to set the activation status of <<Clock,`Clocks`>> to `fmi3ClockActive` or `fmi3ClockInactive`.
 During the solution of algebraic loops, the activation condition of triggered input clocks may change and therefore <<fmi3SetClock>> can be called multiple times per super-dense time instant.
-Only <<time-based-clocks,Time-based clocks>> must not be active for more than one call of <<fmi3UpdateDiscreteStates>> per <<EventMode>>.
+Only <<time-based-clock,Time-based clocks>> must not be active for more than one call of <<fmi3UpdateDiscreteStates>> per <<EventMode>>.
 
 Function <<fmi3GetClock>>::
 is used to inquire the status of <<Clock,Clocks>>.
@@ -527,8 +527,8 @@ is used to inquire the status of <<Clock,Clocks>>.
 Function <<fmi3GetIntervalDecimal>>::
 Function <<fmi3GetIntervalFraction>>::
 For <<input>> <<Clock,`clocks`>> it is allowed to call these functions to query the next activation interval. +
-For <<changing-aperiodic-clocks>>, these functions must be called in every <<EventMode>> where this clock was activated. +
-For <<countdown-aperiodic-clocks>>, these functions must be called in every <<EventMode>>. +
+For <<changing-aperiodic-clock>>, these functions must be called in every <<EventMode>> where this clock was activated. +
+For <<countdown-aperiodic-clock>>, these functions must be called in every <<EventMode>>. +
 Clock intervals are computed in <<fmi3UpdateDiscreteStates>> (at the latest), therefore, these functions should be called after <<fmi3UpdateDiscreteStates>>.
 
 Function <<fmi3GetDirectionalDerivative>>::

--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -697,13 +697,13 @@ This value must be equal or greater than 0.0.
 |`supportsFraction`
 |
 [[supportsFraction,`supportsFraction`]]
-This attribute defines, if the functions `fmi3GetXXXFraction` and `fmi3SetXXXFraction` are allowed to be called for all <<time-based-clocks,time-based clocks>>.
+This attribute defines, if the functions `fmi3GetXXXFraction` and `fmi3SetXXXFraction` are allowed to be called for all <<time-based-clock,time-based Clocks>>.
 
 |[[resolution, `resolution`]]`resolution`
 |Instead of defining clock timing using floating point numbers, FMI allows the definition of rational numbers using <<intervalCounter,`intervalCounters`>> and <<shiftCounter,`shiftCounters`>>.
 The `resolution` defines the minimal quanta clock timing can be resolved by.
 
-This attribute is required for <<periodic-clock-ticks,time-based periodic clocks>> if <<supportsFraction,`supportsFraction = true`>> and either <<intervalCounter>> or <<shiftCounter>> is present.
+This attribute is required for <<periodic-clock,time-based periodic clocks>> if <<supportsFraction,`supportsFraction = true`>> and either <<intervalCounter>> or <<shiftCounter>> is present.
 
 |[[intervalCounter,`intervalCounter`]]`intervalCounter`
 |This attribute defines (together with <<resolution>>) the interval between consecutive clock ticks:

--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -980,7 +980,7 @@ _[<<causality>> = <<calculatedParameter>> and <<causality>> = <<local>> with <<v
 _The difference is that a <<calculatedParameter>> can be used in another model or FMU, whereas a <<local>> variable cannot._
 _For example, when importing an FMU in a Modelica environment, a <<calculatedParameter>> should be imported in a `public` section as `final parameter`, whereas a <<local>> variable should be imported in a `protected` section of the model.]_
 
-The causality of variables of type <<Clock>> must be either <<input>> or <<output>>. 
+The causality of variables of type <<Clock>> must be either <<input>> or <<output>>.
 
 |`variability`
 |

--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -667,9 +667,9 @@ An `<Enumeration>` element must have at least one `<Item>`.
 
 |`priority`
 |[[priority,`priority`]]
-<<clock,`Clocks`>> that have to be activated at the same time instant are ordered according to this attribute.
+<<Clock,`Clocks`>> that have to be activated at the same time instant are ordered according to this attribute.
 Smaller values signal higher priorities.
-No ordering is defined for multiple <<clock,`clocks`>> with the same <<priority>>.
+No ordering is defined for multiple <<Clock,`Clocks`>> with the same <<priority>>.
 
 This attribute is only considered in Scheduled Execution.
 
@@ -683,7 +683,7 @@ The attribute `interval` declares the clock type, see <<table-overview-clocks>>.
 |`intervalDecimal`
 |
 [[intervalDecimal,`intervalDecimal`]]
-The time interval latexmath:[\mathbf{T}_{interval}] between consecutive <<clock>> ticks.
+The time interval latexmath:[\mathbf{T}_{interval}] between consecutive <<Clock>> ticks.
 
 This value must be greater than 0.0.
 
@@ -1010,10 +1010,9 @@ _[If the simulation algorithm notices a change in a discrete variable during <<i
 `= continuous`: Only a variable of `type == fmi3GetFloat32` or `type == fmi3GetFloat64` can be <<continuous>>. +
 Model Exchange: No restrictions on value changes (see <<smoothness>>).
 
-[[clock,`clock`]]
-`= clock`: Only a variable of type `<Clock>` can have this variability.
-
 The default is <<continuous>> for variables of type `<Float32>` and `<Float64>`, and <<discrete>> for all other types.
+
+For variables of type `Clock` and <<clocked-variable,`clocked variables`>> the <<variability>> is always <<discrete>>.
 
 _[Note that the information about continuous <<state,`states`>> is defined with elements <<ContinuousStateDerivative>> in `<ModelStructure>`.]_
 
@@ -1044,8 +1043,8 @@ Examples: (a) automatic tests of FMUs are performed, and the FMU is tested by pr
 (b) For a Model Exchange FMU, the FMU might be part of an algebraic loop.
 If the <<input>> variable is iteration variable of this algebraic loop, then initialization starts with its <<start>> value.]_
 
-If <<causality>> = <<input>> and <<variability>> = <<clock>>, that is, the variable is an <<inputClock>>, it is required to provide a <<start>> value for describing the expected initial condition of the <<inputClock>> for that FMU.
-If an <<inputClock>> has `fmi3True` as a <<start>> value, the environment should activate the <<clock>> the first time it enters <<EventMode>>.
+If <<causality>> = <<input>> and <<variability>> = <<Clock>>, that is, the variable is an <<inputClock>>, it is required to provide a <<start>> value for describing the expected initial condition of the <<inputClock>> for that FMU.
+If an <<inputClock>> has `fmi3True` as a <<start>> value, the environment should activate the <<Clock>> the first time it enters <<EventMode>>.
 The environment can nevertheless choose different <<start>> values if it is not possible to fulfill the conditions in a simulation setup.
 
 If <<causality>> = <<output>> the <<initial>> attribute value is set to <<calculated>> and no <<start>> value is provided.
@@ -1146,7 +1145,7 @@ If <<initial>> is not present, its value is defined by <<table-definition-initia
 ^|[.underline]#calculated#, exact, approx
 ^|--
 
-^|<<clock,`clocks`>>
+^|<<Clock,`Clocks`>>
 ^|--
 ^|--
 ^|--
@@ -1221,7 +1220,7 @@ _The value of the variable is either the <<start>> value stored in a variable el
 ^|(14)
 ^|(15)
 
-^|<<clock,`clocks`>>
+^|<<Clock,`Clocks`>>
 ^|--
 ^|--
 ^|--
@@ -1344,8 +1343,8 @@ _Usually, this is `time`._
 |_<<parameter,`Parameter`>> used in  `<Dimension>` element;  can be changed before initialization in <<ConfigurationMode>> and in <<ReconfigurationMode>>._
 
 >|_(18)_
-|_<<clock>>_
-|_Variable that defines a <<clock>>._
+|_<<Clock>>_
+|_Variable that defines a <<Clock>>._
 
 |====
 
@@ -1659,7 +1658,7 @@ _The ordering of the variables in this list is defined by the exporting tool._
 _Usually, it is best to order according to the declaration order in the source model, since then the <<Output>> list does not change if the declaration order of <<output,`outputs`>> in the source model is not changed._
 _This is for example, important for linearization, in order that the interpretation of the output vector does not change for a re-exported FMU.]_
 Attribute <<dependencies>> defines the dependencies of the <<output,`outputs`>> from the knowns at the current super-dense time instant in Event and in <<ContinuousTimeMode>> (ME) and at the current communication point (CS and SE).
-Attribute <<dependencies>> for output clocks (variables with <<causality>> = <<output>> and <<variability>> = <<clock>>) lists all known variables (including input clocks) that contribute to trigger a clock tick for that output clock.
+Attribute <<dependencies>> for output clocks (variables with <<causality>> = <<output>> and <<variability>> = <<Clock>>) lists all known variables (including input clocks) that contribute to trigger a clock tick for that output clock.
 Beside the knowns, the <<output,`outputs`>> also depend on "frozen" variables (= variables which cannot be changed in the current mode) but these "frozen" variables are not listed as <<dependencies>>.
 The functional dependency is defined as (dependencies of variables that are fixed in Event and <<ContinuousTimeMode>> and at communication points are not shown): +
 latexmath:[{(\mathbf{y}_c, \mathbf{y}_d) := \mathbf{f}_{\mathit{output}}(\mathbf{x}_c, \mathbf{u}_c, \mathbf{u}_d, t, \mathbf{p}_{\mathit{tune}})}]
@@ -1774,7 +1773,7 @@ Knowns latexmath:[{\mathbf{v}_{\mathit{known}}}] in <<EventMode>> and <<Continuo
 
 * <<independent>> variable (usually time; <<causality>> = <<independent>>).
 
-_[The list of dependencies may include input clocks (variables with <<causality>> = <<input>> and <<variability>> = <<clock>>)._
+_[The list of dependencies may include input clocks (variables with <<causality>> = <<input>> and <<variability>> = <<Clock>>)._
 _If an <<outputClock>> depends on an <<inputClock>>, then clock ticks of the <<inputClock>> in <<EventMode>> or <<ClockActivationMode>> may create <<outputClock>> ticks during this event handling.]_
 
 Knowns latexmath:[{\mathbf{v}_{\mathit{known}}}] in <<InitializationMode>> (for elements <<InitialUnknown>>):

--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -980,6 +980,8 @@ _[<<causality>> = <<calculatedParameter>> and <<causality>> = <<local>> with <<v
 _The difference is that a <<calculatedParameter>> can be used in another model or FMU, whereas a <<local>> variable cannot._
 _For example, when importing an FMU in a Modelica environment, a <<calculatedParameter>> should be imported in a `public` section as `final parameter`, whereas a <<local>> variable should be imported in a `protected` section of the model.]_
 
+The causality of variables of type <<Clock>> must be either <<input>> or <<output>>. 
+
 |`variability`
 |
 [[variability,`variability`]]

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -55,7 +55,7 @@ a|
 Allowed Function Calls::
 
 [[fmi3SetTime,`fmi3SetTime`]]
-Function <<fmi3SetTime>>::
+Function `fmi3SetTime`::
 +
 [source, C]
 ----
@@ -78,7 +78,7 @@ Functions <<get-and-set-variable-values,`fmi3Get{VariableType}`>>::
 Getting variables might trigger <<selectiv-computation,computations>>.
 
 [[fmi3SetContinuousStates,`fmi3SetContinuousStates`]]
-Function <<fmi3SetContinuousStates>>::
+Function `fmi3SetContinuousStates`::
 +
 [source, C]
 ----
@@ -103,7 +103,7 @@ Function <<fmi3GetContinuousStates>>::
 Returns the current continuous state vector.
 
 [[fmi3GetContinuousStateDerivatives,`fmi3GetContinuousStateDerivatives`]]
-Function <<fmi3GetContinuousStateDerivatives>>::
+Function `fmi3GetContinuousStateDerivatives`::
 +
 [source, C]
 ----
@@ -119,7 +119,7 @@ Returns the first-order derivatives with respect to the independent variable (us
 _[<<fmi3Discard,`fmi3Status == fmi3Discard`>> should be returned if the FMU was not able to compute the derivatives according to_ latexmath:[\mathbf{f}_{\mathit{cont}}] _because, for example, a numerical issue, such as division by zero, occurred.]_
 
 [[fmi3GetEventIndicators,`fmi3GetEventIndicators`]]
-Function <<fmi3GetEventIndicators>>::
+Function `fmi3GetEventIndicators`::
 +
 [source, C]
 ----
@@ -136,7 +136,7 @@ Returns the event indicators signaling <<state-event,state events>> by their sig
 _[<<fmi3Discard,`fmi3Status == fmi3Discard`>> should be returned if the FMU was not able to compute the event indicators according to_ latexmath:[\mathbf{f}_{\mathit{cont}}] _because, for example, a numerical issue, such as division by zero, occurred.]_
 
 [[fmi3CompletedIntegratorStep,`fmi3CompletedIntegratorStep`]]
-Function <<fmi3CompletedIntegratorStep>>::
+Function `fmi3CompletedIntegratorStep`::
 +
 [source, C]
 ----
@@ -174,7 +174,7 @@ _The function <<fmi3CompletedIntegratorStep>> is not used to detect <<time-event
 _<<time-event,Time events>> and <<state-event,state events>> must be detected by the importer, which has to call <<fmi3EnterEventMode>> in these cases, even if the returning from <<fmi3CompletedIntegratorStep>> with `enterEventMode == fmi3False`.]_
 
 [[fmi3EnterEventMode,`fmi3EnterEventMode`]]
-Function <<fmi3EnterEventMode>>::
+Function `fmi3EnterEventMode`::
 +
 [source, C]
 ----

--- a/docs/3___model_exchange.adoc
+++ b/docs/3___model_exchange.adoc
@@ -26,7 +26,7 @@ FMI for Model Exchange enables the following features:
 
 * dedicated <<InitializationMode>>, which allows computation of consistent initial conditions over <<algebraic-loops,algebraic loops>>,
 
-* handling of <<clock,clocks>> and <<EventMode,events>>,
+* handling of <<Clock,Clocks>> and <<EventMode,events>>,
 
 * solution of algebraic loops involving inputs and output variables of this FMU (see <<algebraic-loops,algebraic loops>>),
 

--- a/docs/4_4_co-simulation_schema.adoc
+++ b/docs/4_4_co-simulation_schema.adoc
@@ -67,7 +67,7 @@ include::examples/co_simulation_early_return.xml[]
 // TODO: Add example and rewrite paragraph
 
 The example below is the same one as shown in <<xml-example-co-simulation>> for a Co-Simulation FMU.
-The only differences are, that the element `<fmiModelDescription><CoSimulation>` is present and <<clock,`clocks`>> are defined in the <<modelDescription.xml>>.
+The only differences are, that the element `<fmiModelDescription><CoSimulation>` is present and <<Clock,`Clocks`>> are defined in the <<modelDescription.xml>>.
 The XML file may have the following content:
 
 [source, xml]

--- a/docs/4___co-simulation.adoc
+++ b/docs/4___co-simulation.adoc
@@ -32,7 +32,7 @@ FMI for Co-Simulation enables the following features, allowing co-simulation alg
 
 * dedicated <<InitializationMode>>, which allows computation of consistent initial conditions over <<algebraic-loops,algebraic loops>>,
 
-* handling of <<clock,clocks>> and <<EventMode,events>>,
+* handling of <<Clock,Clocks>> and <<EventMode,events>>,
 
 * the ability of the FMU to provide <<derivative,`derivatives`>> of <<output,`outputs`>> w.r.t. time, to allow approximation techniques (<<getting-output-derivatives>>), and
 

--- a/docs/5_1_scheduled_execution_math.adoc
+++ b/docs/5_1_scheduled_execution_math.adoc
@@ -4,15 +4,15 @@ The Scheduled Execution interface has a different timing concept compared to FMI
 This is required to handle activations of <<triggered, triggered input clocks>> which may tick at a time instant that is unpredictable for the simulation algorithm.
 Typically, hardware I/O or virtual ECU software events belong to this category.
 
-A simulation algorithm's activation of a model partition will compute the results of the model partition defined by a <<triggered, triggered input clock>> for the current <<clocks, `clock`>> tick time latexmath:[\mathbf{t}_i].
-Refer to the clock time progress definition for <<periodic>> <<clocks>>.
+A simulation algorithm's activation of a model partition will compute the results of the model partition defined by a <<triggered, triggered input clock>> for the current <<Clock>> tick time latexmath:[\mathbf{t}_i].
+Refer to the clock time progress definition for <<periodic>> <<Clock,Clocks>>.
 
 A model partition can only be activated once per activation time point latexmath:[\mathbf{t}_i].
 
 Model partitions that are associated to <<outputClock,`output clocks`>> will accordingly provide the result values of the model partition's variables for the current <<outputClock>> tick time latexmath:[\mathbf{t}_i] of the active <<outputClock>>.
 The activation of such an <<outputClock>> is not controlled by the simulation algorithm but internally by the FMU.
 
-More details can be found in <<clocks>>.
+More details can be found in <<Clock,Clocks>>.
 
 ==== Preemption Support [[preemption-support]]
 
@@ -22,23 +22,23 @@ Usually a preemptive scheduling of the <<fmi3ActivateModelPartition>>, <<get-and
 The FMU's code has to be prepared for being able to correctly handle preemptive calls of <<fmi3ActivateModelPartition>>, <<get-and-set-variable-values,`fmi3Get{VariableType}`>>, <<get-and-set-variable-values,`fmi3Set{VariableType}`>>.
 That requires a secured internal and external access to global states and variable values.
 Thus in Scheduled Execution a support for a correct handling of the preemption of model partition computations is required.
-That also requires that the FMU reports the active state of an <<outputClock>> only with the first call of <<fmi3GetClock>> for a specific activation of this <<clocks, `clock`>> and sets the reported activation state immediately back to `false` for the following <<fmi3GetClock>> calls for that <<clocks, `clock`>> until this <<outputClock>> is internally activated again.
+That also requires that the FMU reports the active state of an <<outputClock>> only with the first call of <<fmi3GetClock>> for a specific activation of this <<Clock>> and sets the reported activation state immediately back to `false` for the following <<fmi3GetClock>> calls for that <<Clock>> until this <<outputClock>> is internally activated again.
 
-If a preemptive multitasking regime is intended, an individual task (or thread -- task and thread are used synonymously here) for each model partition (associated to a <<clocks, `clock`>> with <<causality, `causality == input`>>) has to be created.
+If a preemptive multitasking regime is intended, an individual task (or thread -- task and thread are used synonymously here) for each model partition (associated to a <<Clock>> with <<causality>> == <<input>>) has to be created.
 The task for computing each <<fmi3ActivateModelPartition>> is created and controlled by the simulation algorithm, not by the FMU.
 So the FMU exporting tool does not need to take care for that (except for preparing its code to support preemption).
 
 _[If only one single model partition is available via the interface of an FMU, preemptive calls of the related <<fmi3ActivateModelPartition>> function are possible by default since there are no external cross dependencies within one model partition between communication points.]_
 
-Based on the settings defined in the XML for <<clocks, `clocks`>> with <<causality, `causality == input`>> the simulation algorithm calls <<get-and-set-variable-values,`fmi3Set{VariableType}`>>, <<fmi3ActivateModelPartition>>, <<get-and-set-variable-values,`fmi3Get{VariableType}`>> calls.
-Set/get calls for each task are only allowed for variables that are associated to the <<inputClock>> associated to that task or - here preemption issues become important - to variables that are associated to no <<clocks, `clock`>> (global variables), based on the XML information (see <<table-overview-clocks>>).
+Based on the settings defined in the XML for <<Clock,`Clocks`>> with <<causality>> == <<input>> the simulation algorithm calls <<get-and-set-variable-values,`fmi3Set{VariableType}`>>, <<fmi3ActivateModelPartition>>, <<get-and-set-variable-values,`fmi3Get{VariableType}`>> calls.
+Set/get calls for each task are only allowed for variables that are associated to the <<inputClock>> associated to that task or - here preemption issues become important - to variables that are associated to no <<Clock>> (global variables), based on the XML information (see <<table-overview-clocks>>).
 
 _[The recommendation is to avoid global variable associations as much as possible in the XML._
 _It is also recommended to reduce dependencies (defined in XML model structure) between variables located in different model partitions of one FMU, since this also requires in most cases that the related variables have to be global variables.]_
 
 The simulation algorithm has no knowledge about the FMU internal communication between the model partitions of a single FMU and does not handle it.
 
-The simulation algorithm schedules the <<fmi3ActivateModelPartition>> (as well as related <<get-and-set-variable-values,`fmi3Get{VariableType}`>> and `fmi3Set{VariableType}`) calls based on given priorities for <<clocks, `clocks`>> with <<causality, `causality == input`>> defined in the <<modelDescription.xml>>.
+The simulation algorithm schedules the <<fmi3ActivateModelPartition>> (as well as related <<get-and-set-variable-values,`fmi3Get{VariableType}`>> and `fmi3Set{VariableType}`) calls based on given priorities for <<Clock, `Clocks`>> with <<causality>> == <<input>> defined in the <<modelDescription.xml>>.
 
 Priority (see <<priority>>):
 
@@ -49,13 +49,13 @@ Arbitrary evaluation order is possible for model partitions of the same priority
 
 _[If multiple tasks are needed to be scheduled for computation at a certain time instant a simulation algorithm must schedule a task of a higher priority always before a task of a lower priority]_
 
-A <<clocks, `clock`>> with <<causality, `causality == input`>> can hold fixed or modifiable periods as well as being triggered unpredictably.
-Refer to chapter on <<clocks>> for details.
+A <<Clock>> with <<causality>> == <<input>> can hold fixed or modifiable periods as well as being triggered unpredictably.
+Refer to chapter on <<Clock,Clocks>> for details.
 
 Based on the period and priority definitions the exporting tool can restrict the code evaluation order.
 It nevertheless has to secure its code against concurrent evaluation _[not against parallel evaluation, as this is not supported for model partitions of an FMU in the interface description of this mode]_ along the defined priority restrictions.
 Mostly this is required for internal inter-model-partition communication and in general for the joint use of global variables within the FMU.
-The exporting tool has to consider the effect of <<triggered>> <<input>> <<clocks>> and the influences of computing speed, because the exact occurrence of preemption points cannot be foreseen (within the given priority and period restrictions).
+The exporting tool has to consider the effect of <<triggered>> <<input>> <<Clock, 'clocks'>> and the influences of computing speed, because the exact occurrence of preemption points cannot be foreseen (within the given priority and period restrictions).
 
 To guard certain code parts against preemption they must be enclosed with the callback functions `lockPreemption` and `unlockPreemption`.
 

--- a/docs/5_1_scheduled_execution_math.adoc
+++ b/docs/5_1_scheduled_execution_math.adoc
@@ -24,13 +24,13 @@ That requires a secured internal and external access to global states and variab
 Thus in Scheduled Execution a support for a correct handling of the preemption of model partition computations is required.
 That also requires that the FMU reports the active state of an <<outputClock>> only with the first call of <<fmi3GetClock>> for a specific activation of this <<Clock>> and sets the reported activation state immediately back to `false` for the following <<fmi3GetClock>> calls for that <<Clock>> until this <<outputClock>> is internally activated again.
 
-If a preemptive multitasking regime is intended, an individual task (or thread -- task and thread are used synonymously here) for each model partition (associated to a <<Clock>> with <<causality>> == <<input>>) has to be created.
+If a preemptive multitasking regime is intended, an individual task (or thread -- task and thread are used synonymously here) for each model partition (associated to an <<inputClock>>) has to be created.
 The task for computing each <<fmi3ActivateModelPartition>> is created and controlled by the simulation algorithm, not by the FMU.
 So the FMU exporting tool does not need to take care for that (except for preparing its code to support preemption).
 
 _[If only one single model partition is available via the interface of an FMU, preemptive calls of the related <<fmi3ActivateModelPartition>> function are possible by default since there are no external cross dependencies within one model partition between communication points.]_
 
-Based on the settings defined in the XML for <<Clock,`Clocks`>> with <<causality>> == <<input>> the simulation algorithm calls <<get-and-set-variable-values,`fmi3Set{VariableType}`>>, <<fmi3ActivateModelPartition>>, <<get-and-set-variable-values,`fmi3Get{VariableType}`>> calls.
+Based on the settings defined in the XML for <<inputClock,input Clocks>> the simulation algorithm calls <<get-and-set-variable-values,`fmi3Set{VariableType}`>>, <<fmi3ActivateModelPartition>>, or <<get-and-set-variable-values,`fmi3Get{VariableType}`>>.
 Set/get calls for each task are only allowed for variables that are associated to the <<inputClock>> associated to that task or - here preemption issues become important - to variables that are associated to no <<Clock>> (global variables), based on the XML information (see <<table-overview-clocks>>).
 
 _[The recommendation is to avoid global variable associations as much as possible in the XML._
@@ -38,7 +38,7 @@ _It is also recommended to reduce dependencies (defined in XML model structure) 
 
 The simulation algorithm has no knowledge about the FMU internal communication between the model partitions of a single FMU and does not handle it.
 
-The simulation algorithm schedules the <<fmi3ActivateModelPartition>> (as well as related <<get-and-set-variable-values,`fmi3Get{VariableType}`>> and `fmi3Set{VariableType}`) calls based on given priorities for <<Clock, `Clocks`>> with <<causality>> == <<input>> defined in the <<modelDescription.xml>>.
+The simulation algorithm schedules the <<fmi3ActivateModelPartition>> (as well as related <<get-and-set-variable-values,`fmi3Get{VariableType}`>> and `fmi3Set{VariableType}`) calls based on given priorities for <<inputClock, inputClocks>> defined in the <<modelDescription.xml>>.
 
 Priority (see <<priority>>):
 
@@ -49,7 +49,7 @@ Arbitrary evaluation order is possible for model partitions of the same priority
 
 _[If multiple tasks are needed to be scheduled for computation at a certain time instant a simulation algorithm must schedule a task of a higher priority always before a task of a lower priority]_
 
-A <<Clock>> with <<causality>> == <<input>> can hold fixed or modifiable periods as well as being triggered unpredictably.
+An <<inputClock>> can hold fixed or modifiable periods, or be triggered unpredictably.
 Refer to chapter on <<Clock,Clocks>> for details.
 
 Based on the period and priority definitions the exporting tool can restrict the code evaluation order.

--- a/docs/5_1_scheduled_execution_math.adoc
+++ b/docs/5_1_scheduled_execution_math.adoc
@@ -55,7 +55,7 @@ Refer to chapter on <<Clock,Clocks>> for details.
 Based on the period and priority definitions the exporting tool can restrict the code evaluation order.
 It nevertheless has to secure its code against concurrent evaluation _[not against parallel evaluation, as this is not supported for model partitions of an FMU in the interface description of this mode]_ along the defined priority restrictions.
 Mostly this is required for internal inter-model-partition communication and in general for the joint use of global variables within the FMU.
-The exporting tool has to consider the effect of <<triggered>> <<input>> <<Clock, 'clocks'>> and the influences of computing speed, because the exact occurrence of preemption points cannot be foreseen (within the given priority and period restrictions).
+The exporting tool has to consider the effect of <<triggered>> <<inputClock, 'input Clocks'>> and the influences of computing speed, because the exact occurrence of preemption points cannot be foreseen (within the given priority and period restrictions).
 
 To guard certain code parts against preemption they must be enclosed with the callback functions `lockPreemption` and `unlockPreemption`.
 

--- a/docs/5_2_scheduled_execution_api.adoc
+++ b/docs/5_2_scheduled_execution_api.adoc
@@ -2,9 +2,9 @@
 
 This section contains the description of the Scheduled Execution interface for a C program.
 
-The direct scheduling of model partitions based on <<clocks, `clock`>> ticks requires an additional handling mode for FMUs.
+The direct scheduling of model partitions based on <<Clock>> ticks requires an additional handling mode for FMUs.
 The FMU signals its support for direct model partition scheduling in the <<modelDescription.xml>> via the element `<fmiModelDescription><ScheduledExecution>`.
-The simulation algorithm signals to the FMU that it supports and has recognized the <<clocks, `clocks`>> and model partition scheduling capabilities of the FMU by instantiating it as Scheduled Execution.
+The simulation algorithm signals to the FMU that it supports and has recognized the <<Clock,Clocks>> and model partition scheduling capabilities of the FMU by instantiating it as Scheduled Execution.
 
 Error, reset or terminate information is a global state of the FMU.
 If e.g. a function returns <<fmi3Discard>> or <<fmi3Error>> this is also assumed for all active or preempted model partitions.
@@ -33,7 +33,7 @@ After <<fmi3Terminate>> has been called no new tasks can be started (e.g. relate
 
 The FMU enters this state when the simulation algorithm calls <<fmi3ExitInitializationMode>> in state <<InitializationMode>> or <<fmi3ExitConfigurationMode>> in state <<ReconfigurationMode>>.
 
-In this state the simulation algorithm can create multiple concurrent tasks related to an FMU and in each task the simulation algorithm can activate one or multiple <<clocks, `clocks`>> with <<causality, `causality == input`>> of an FMU based on the defined <<clocks, `clock`>> properties via a <<fmi3ActivateModelPartition>> call for each clock.
+In this state the simulation algorithm can create multiple concurrent tasks related to an FMU and in each task the simulation algorithm can activate one or multiple <<Clock,Clocks>> with <<causality>> == <<input>> of an FMU based on the defined <<Clock>> properties via a <<fmi3ActivateModelPartition>> call for each clock.
 
 [cols="2,1",options="header",]
 |====
@@ -63,10 +63,10 @@ a|When an input clock latexmath:[\mathbf{k}_i] is active, activate the correspon
 Allowed Function Calls::
 
 Function <<get-and-set-variable-values,`fmi3Set{VariableTypeExclClock}`>>::
-This function can be called before scheduling a model partition for variables assigned to that model partition via its associated <<clocks, `clock`>> and all variables not associated to a <<clocks, `clock`>> (global variables).
+This function can be called before scheduling a model partition for variables assigned to that model partition via its associated <<Clock>> and all variables not associated to a <<Clock>> (global variables).
 
 Function <<get-and-set-variable-values,`fmi3Get{VariableTypeExclClock}`>>::
-These functions can be called after the computation of a model partition for variables assigned to that model partition via its associated <<clocks, `clock`>> and all variables not associated to a <<clocks, `clock`>> (global variables).
+These functions can be called after the computation of a model partition for variables assigned to that model partition via its associated <<Clock>> and all variables not associated to a <<Clock>> (global variables).
 
 +
 Set/get operations must be atomic for a single variable.
@@ -86,7 +86,7 @@ _[The reason is to avoid different interpretations of the caching, since contrar
 
 [[fmi3ActivateModelPartition, `fmi3ActivateModelPartition`]] Function <<fmi3ActivateModelPartition>>::
 
-Each <<fmi3ActivateModelPartition>> call is now associated to the computation of a (publicly disclosed, externally controlled) model partition of the model and therefore to a single defined <<clocks, `clock`>> with <<causality, `causality == input`>>.
+Each <<fmi3ActivateModelPartition>> call is now associated to the computation of a (publicly disclosed, externally controlled) model partition of the model and therefore to a single defined <<Clock>> with <<causality>> == <<input>>.
 +
 [source, C]
 ----
@@ -95,31 +95,31 @@ include::../headers/fmi3FunctionTypes.h[tag=ActivateModelPartition]
 +
 The <<fmi3ActivateModelPartition>> function has the following arguments:
 
-* [[clockReference,`clockReference`]] `clockReference`: <<valueReference>> of a <<clocks, `clock`>> with <<causality, `causality == input`>> which shall be activated
+* [[clockReference,`clockReference`]] `clockReference`: <<valueReference>> of a <<Clock>> with <<causality>> == <<input>> which shall be activated
 
-* [[clockElementIndex,`clockElementIndex`]] `clockElementIndex`: The element index of the <<clocks, `clock`>> variable which shall be activated.
-For a scalar <<clocks, `clock`>> variable this must be 0; for array <<clocks, `clock`>> variables, the element clock to activate is specified using the 1-based element index.
-Using the element index 0 means all elements of the <<clocks, `clock`>> variable.
+* [[clockElementIndex,`clockElementIndex`]] `clockElementIndex`: The element index of the <<Clock>> variable which shall be activated.
+For a scalar <<Clock>> variable this must be 0; for array <<Clock>> variables, the element clock to activate is specified using the 1-based element index.
+Using the element index 0 means all elements of the <<Clock>> variable.
 (Note: If an array has more than one dimension the indices are serialized in the same order as defined for values in <<serialization-of_variables>>).
 
-* [[activationTime, `activationTime`]] `activationTime`: value of the <<independent>> variable of the assigned <<clocks, `clock`>> tick time latexmath:[\mathbf{t}_i] _[typically: simulation (i.e. virtual) time]_ (which is known to the simulation algorithm).
+* [[activationTime, `activationTime`]] `activationTime`: value of the <<independent>> variable of the assigned <<Clock>> tick time latexmath:[\mathbf{t}_i] _[typically: simulation (i.e. virtual) time]_ (which is known to the simulation algorithm).
 
 +
 The importer schedules calls of <<fmi3ActivateModelPartition>> for each FMU.
-Calls are based on activations of <<clocks, `clocks`>> with <<causality, `causality == input`>>.
-These <<clocks, `clock`>> activations can be based on <<clocks, `clock`>> activations from FMU external sources (e.g. <<outputClock,`output clocks`>> of other FMUs).
+Calls are based on activations of <<Clock,Clocks>> with <<causality>> == <<input>>.
+These <<Clock>> activations can be based on <<Clock>> activations from FMU external sources (e.g. <<outputClock,`output clocks`>> of other FMUs).
 The <<inputClock>> activations can be based on <<outputClock>> ticks of another FMU.
 The <<fmi3ActivateModelPartition>> function must not be called on <<outputClock,`output clocks`>> of an FMU.
 
 +
 This is a different timing concept compared to <<fmi3DoStep>> calls for Co-Simulation FMUs or the <<fmi3SetTime>> for Model Exchange FMUs.
-An <<fmi3ActivateModelPartition>> call will compute the results of the model partition defined by <<clockReference>> and <<clockElementIndex>> (i.e. <<valueReference>> of the variable that defines a <<clocks, `clock`>> and an element index into that for arrays) for the current <<clocks, `clock`>> tick latexmath:[\mathbf{t}_i].
+An <<fmi3ActivateModelPartition>> call will compute the results of the model partition defined by <<clockReference>> and <<clockElementIndex>> (i.e. <<valueReference>> of the variable that defines a <<Clock>> and an element index into that for arrays) for the current <<Clock>> tick latexmath:[\mathbf{t}_i].
 
 +
-If required, the FMU can internally derive the <<clocks, `clock`>> interval latexmath:[\mathbf{T}_\mathit{interval, i}] based on the last <<clocks, `clock`>> tick time latexmath:[\mathbf{t}_\mathit{i-1}] i.e. last `activationTime` for this <<clockReference>> and <<clockElementIndex>> (based on last <<fmi3ActivateModelPartition>> call).
+If required, the FMU can internally derive the <<Clock>> interval latexmath:[\mathbf{T}_\mathit{interval, i}] based on the last <<Clock>> tick time latexmath:[\mathbf{t}_\mathit{i-1}] i.e. last `activationTime` for this <<clockReference>> and <<clockElementIndex>> (based on last <<fmi3ActivateModelPartition>> call).
 
 +
-Consecutive calls to <<fmi3ActivateModelPartition>> for a <<clockReference>> and <<clockElementIndex>> (i.e. <<valueReference>> of <<clocks, `clock`>> variable and element index into that for arrays) must have strictly monotonically increasing `activationTime` latexmath:[\mathbf{t}_i].
+Consecutive calls to <<fmi3ActivateModelPartition>> for a <<clockReference>> and <<clockElementIndex>> (i.e. <<valueReference>> of <<Clock>> variable and element index into that for arrays) must have strictly monotonically increasing `activationTime` latexmath:[\mathbf{t}_i].
 
 [[fmi3CallbackIntermediateUpdateSE,`fmi3CallbackIntermediateUpdate`]] Function <<fmi3CallbackIntermediateUpdate>>::
 <<fmi3CallbackIntermediateUpdate>> switches the FMU itself into the <<IntermediateUpdateMode>>.

--- a/docs/5_2_scheduled_execution_api.adoc
+++ b/docs/5_2_scheduled_execution_api.adoc
@@ -33,7 +33,7 @@ After <<fmi3Terminate>> has been called no new tasks can be started (e.g. relate
 
 The FMU enters this state when the simulation algorithm calls <<fmi3ExitInitializationMode>> in state <<InitializationMode>> or <<fmi3ExitConfigurationMode>> in state <<ReconfigurationMode>>.
 
-In this state the simulation algorithm can create multiple concurrent tasks related to an FMU and in each task the simulation algorithm can activate one or multiple <<Clock,Clocks>> with <<causality>> == <<input>> of an FMU based on the defined <<Clock>> properties via a <<fmi3ActivateModelPartition>> call for each clock.
+In this state the simulation algorithm can create multiple concurrent tasks related to an FMU and in each task the simulation algorithm can activate one or multiple <<inputClock,input Clocks>> of an FMU based on the defined <<Clock>> properties via a <<fmi3ActivateModelPartition>> call for each Clock.
 
 [cols="2,1",options="header",]
 |====
@@ -86,7 +86,7 @@ _[The reason is to avoid different interpretations of the caching, since contrar
 
 [[fmi3ActivateModelPartition, `fmi3ActivateModelPartition`]] Function <<fmi3ActivateModelPartition>>::
 
-Each <<fmi3ActivateModelPartition>> call is now associated to the computation of a (publicly disclosed, externally controlled) model partition of the model and therefore to a single defined <<Clock>> with <<causality>> == <<input>>.
+Each <<fmi3ActivateModelPartition>> call is now associated to the computation of a (publicly disclosed, externally controlled) model partition of the model and therefore to a single defined <<inputClock>>.
 +
 [source, C]
 ----
@@ -95,7 +95,7 @@ include::../headers/fmi3FunctionTypes.h[tag=ActivateModelPartition]
 +
 The <<fmi3ActivateModelPartition>> function has the following arguments:
 
-* [[clockReference,`clockReference`]] `clockReference`: <<valueReference>> of a <<Clock>> with <<causality>> == <<input>> which shall be activated
+* [[clockReference,`clockReference`]] `clockReference`: <<valueReference>> of an <<inputClock>> which shall be activated.
 
 * [[clockElementIndex,`clockElementIndex`]] `clockElementIndex`: The element index of the <<Clock>> variable which shall be activated.
 For a scalar <<Clock>> variable this must be 0; for array <<Clock>> variables, the element clock to activate is specified using the 1-based element index.
@@ -106,10 +106,10 @@ Using the element index 0 means all elements of the <<Clock>> variable.
 
 +
 The importer schedules calls of <<fmi3ActivateModelPartition>> for each FMU.
-Calls are based on activations of <<Clock,Clocks>> with <<causality>> == <<input>>.
-These <<Clock>> activations can be based on <<Clock>> activations from FMU external sources (e.g. <<outputClock,`output clocks`>> of other FMUs).
+Calls are based on activations of <<inputClock,input Clocks>>.
+These <<Clock>> activations can be based on <<Clock>> activations from FMU external sources (e.g. <<outputClock,output Clocks>> of other FMUs).
 The <<inputClock>> activations can be based on <<outputClock>> ticks of another FMU.
-The <<fmi3ActivateModelPartition>> function must not be called on <<outputClock,`output clocks`>> of an FMU.
+The <<fmi3ActivateModelPartition>> function must not be called on <<outputClock,output Clocks>> of an FMU.
 
 +
 This is a different timing concept compared to <<fmi3DoStep>> calls for Co-Simulation FMUs or the <<fmi3SetTime>> for Model Exchange FMUs.

--- a/docs/5_2_scheduled_execution_api.adoc
+++ b/docs/5_2_scheduled_execution_api.adoc
@@ -84,7 +84,8 @@ The restrictions related to variable <<causality>> and <<variability>> defined f
 It is not allowed to call <<get-and-set-variable-values,`fmi3Get{VariableTypeExclClock}`>> functions after <<get-and-set-variable-values,`fmi3Set{VariableTypeExclClock}`>> functions without an <<fmi3ActivateModelPartition>> call in between.
 _[The reason is to avoid different interpretations of the caching, since contrary to <<fmi-for-model-exchange, `FMI for Model Exchange`>>, <<fmi3ActivateModelPartition>> will perform the actual calculation instead of <<get-and-set-variable-values,`fmi3Get{VariableTypeExclClock}`>>, and therefore, dummy algebraic loops at communication points cannot be handled by an appropriate sequence of <<get-and-set-variable-values,`fmi3Get{VariableTypeExclClock}`>> and <<get-and-set-variable-values,`fmi3Set{VariableTypeExclClock}`>> calls as for Model Exchange.]_
 
-[[fmi3ActivateModelPartition, `fmi3ActivateModelPartition`]] Function <<fmi3ActivateModelPartition>>::
+[[fmi3ActivateModelPartition, `fmi3ActivateModelPartition`]]
+Function `fmi3ActivateModelPartition`::
 
 Each <<fmi3ActivateModelPartition>> call is now associated to the computation of a (publicly disclosed, externally controlled) model partition of the model and therefore to a single defined <<inputClock>>.
 +
@@ -121,7 +122,8 @@ If required, the FMU can internally derive the <<Clock>> interval latexmath:[\ma
 +
 Consecutive calls to <<fmi3ActivateModelPartition>> for a <<clockReference>> and <<clockElementIndex>> (i.e. <<valueReference>> of <<Clock>> variable and element index into that for arrays) must have strictly monotonically increasing `activationTime` latexmath:[\mathbf{t}_i].
 
-[[fmi3CallbackIntermediateUpdateSE,`fmi3CallbackIntermediateUpdate`]] Function <<fmi3CallbackIntermediateUpdate>>::
+[[fmi3CallbackIntermediateUpdateSE,`fmi3CallbackIntermediateUpdate`]]
+Function `fmi3CallbackIntermediateUpdate`::
 <<fmi3CallbackIntermediateUpdate>> switches the FMU itself into the <<IntermediateUpdateMode>>.
 The callback may be called from concurrent tasks within <<fmi3ActivateModelPartition>>.
 

--- a/docs/5_3_scheduled_execution_example.adoc
+++ b/docs/5_3_scheduled_execution_example.adoc
@@ -53,7 +53,7 @@ void CallbackIntermediateUpdate(...,fmi3Boolean clocksTicked, ...)
       // ask FMU if countdown clock is about to tick
       fmi3ValueReference aperiodicClockReferences = {6};
       fmi3GetIntervalDecimal(... aperiodicClockReferences, ... &interval, &qualifier, ...);
-      if (qualifier[0] == fmi3NewInterval)
+      if (qualifier[0] == fmi3IntervalChanged)
       {
          // schedule task for AperiodicClock with a delay
          Scheduler->ScheduleTask(TaskAperiodic, interval[0]);
@@ -106,7 +106,7 @@ void activateModelPartition10ms(fmi3Instance *instance, ...)
    ...
    if (...)
    {
-      CountdownClockQualifier = fmi3NewInterval;
+      CountdownClockQualifier = fmi3IntervalChanged;
       CountdownClockInterval = 0.0;
       // inform simulation algorithm that the countdown clock has ticked
       fmi3Boolean clocksTicked = fmi3True;
@@ -134,7 +134,7 @@ fmi3Status fmi3GetIntervalDecimal(..., fmi3ValueReference inputClockReferences[]
    {
       interval[0] = CountdownClockInterval;
       qualifier[0] = CountdownClockQualifier;
-      CountdownClockQualifier = fmi3NotYetKnown;
+      CountdownClockQualifier = fmi3IntervalNotYetKnown;
    }
 }
 ----

--- a/docs/5_3_scheduled_execution_example.adoc
+++ b/docs/5_3_scheduled_execution_example.adoc
@@ -21,7 +21,7 @@ image::images/se_example.png[width=90%, align="center"]
 ==== Simulation Algorithm Implementation
 
 To enable the computation of a Scheduled Execution FMU a simulation algorithm has to provide a task scheduler.
-Depending on the particular configuration the simulation algorithm sets up tasks for every <<Clock>> with <<causality>> == <<input>>.
+Depending on the particular configuration the simulation algorithm sets up tasks for every <<inputClock>>.
 When executed each task calls <<fmi3ActivateModelPartition>> for its respective <<Clock>>.
 The `activationTime` is provided by the simulation algorithm.
 Periodic tasks can be scheduled on initialization of the simulation application.
@@ -74,7 +74,7 @@ void CallbackIntermediateUpdate(...,fmi3Boolean clocksTicked, ...)
 
 ==== FMU Implementation
 
-The FMU implements <<fmi3ActivateModelPartition>> dispatching for every <<Clock>> with <<causality>> == <<input>> so the code might look like this:
+The FMU implements <<fmi3ActivateModelPartition>> dispatching for every <<inputClock>> so the code might look like this:
 
 [source, C]
 ----

--- a/docs/5_3_scheduled_execution_example.adoc
+++ b/docs/5_3_scheduled_execution_example.adoc
@@ -3,15 +3,15 @@
 The FMU ThreeInputClocks sketches the usage of the FMI functions.
 The example is given in a mix of pseudo-code and C, in order to keep it small and understandable.
 We consider one FMU with three model partitions.
-Two model partitions associated to two periodic <<clocks,`clocks`>> 10msClock and 50msClock (periods 10 ms and 50 ms) and one aperiodic <<countdown, `countdown clock`>> AperiodicClock.
+Two model partitions associated to two periodic <<Clock,Clocks>> `10msClock` and `50msClock` (periods 10 ms and 50 ms) and one aperiodic <<countdown, `countdown clock`>> `AperiodicClock`.
 
-During the execution of the model partition of <<clocks, `clock`>> 10msClock the FMU sets the <<interval>> for <<countdown, `countdown clock`>> AperiodicClock and calls <<fmi3CallbackIntermediateUpdate>> to invoke the execution of the coresponding model partition.
+During the execution of the model partition of <<Clock>> `10msClock` the FMU sets the <<interval>> for <<countdown, `countdown clock`>> `AperiodicClock` and calls <<fmi3CallbackIntermediateUpdate>> to invoke the execution of the corresponding model partition.
 
-The function calls <<fmi3ActivateModelPartition>> are executed in the context of preemptable tasks whose priorities are derived from the respective <<clocks, `clock`>> configurations of the FMU.
-In this example the execution of the task of <<countdown, `countdown clock`>> AperiodicClock is waiting for the task of <<clocks, `clock`>> 10msClock to finish.
-Likewise the task of AperiodicClock is suspended when the task of higher priority is scheduled again.
+The function calls <<fmi3ActivateModelPartition>> are executed in the context of preemptable tasks whose priorities are derived from the respective <<Clock>> configurations of the FMU.
+In this example the execution of the task of <<countdown, `countdown clock`>> `AperiodicClock` is waiting for the task of <<Clock>> `10msClock` to finish.
+Likewise the task of `AperiodicClock` is suspended when the task of higher priority is scheduled again.
 
-The example also depicts how a task associated to an even lower prior <<clocks, `clock`>> 50msClock is delayed several times by tasks of higher priority.
+The example also depicts how a task associated to an even lower prior <<Clock>> `50msClock` is delayed several times by tasks of higher priority.
 Note that the point of time when the task was scheduled is the `activationTime` of <<fmi3ActivateModelPartition>> (...Activate...(`clock`, `activationTime`)).
 
 .Scheduled Execution Example ThreeInputClocks
@@ -21,8 +21,8 @@ image::images/se_example.png[width=90%, align="center"]
 ==== Simulation Algorithm Implementation
 
 To enable the computation of a Scheduled Execution FMU a simulation algorithm has to provide a task scheduler.
-Depending on the particular configuration the simulation algorithm sets up tasks for every <<clocks, `clock`>> with <<causality, `causality == input`>>.
-When executed each task calls <<fmi3ActivateModelPartition>> for its respective <<clocks, `clock`>>.
+Depending on the particular configuration the simulation algorithm sets up tasks for every <<Clock>> with <<causality>> == <<input>>.
+When executed each task calls <<fmi3ActivateModelPartition>> for its respective <<Clock>>.
 The `activationTime` is provided by the simulation algorithm.
 Periodic tasks can be scheduled on initialization of the simulation application.
 Aperiodic tasks are scheduled explicitly during the execution.
@@ -40,8 +40,8 @@ Task10ms.Execute()
 };
 ----
 
-The FMU requests to schedule the model partition of AperiodicClock.
-It calls <<fmi3CallbackIntermediateUpdate>> to enable the importer to check whether the FMU has defined a new interval for AperiodicClock.
+The FMU requests to schedule the model partition of `AperiodicClock`.
+It calls <<fmi3CallbackIntermediateUpdate>> to enable the importer to check whether the FMU has defined a new interval for `AperiodicClock`.
 Evaluating the return values <<qualifier>> and <<interval>> of <<fmi3GetInterval>> the simulation algorithms determines if the respective task has to be scheduled and which delay has to be applied.
 
 [source, C]
@@ -74,7 +74,7 @@ void CallbackIntermediateUpdate(...,fmi3Boolean clocksTicked, ...)
 
 ==== FMU Implementation
 
-The FMU implements <<fmi3ActivateModelPartition>> dispatching for every <<clocks, `clock`>> with <<causality, `causality == input`>> so the code might look like this:
+The FMU implements <<fmi3ActivateModelPartition>> dispatching for every <<Clock>> with <<causality>> == <<input>> so the code might look like this:
 
 [source, C]
 ----
@@ -97,7 +97,7 @@ fmi3Status fmi3ActivateModelPartition(fmi3Instance *instance,
 }
 ----
 
-In the context of the task being executed every 10 ms, the FMU initiates the scheduling of a task by setting a new interval to <<countdown, `countdown clock`>> AperiodicClock and evoking <<fmi3CallbackIntermediateUpdate>>.
+In the context of the task being executed every 10 ms, the FMU initiates the scheduling of a task by setting a new interval to <<countdown, `countdown clock`>> `AperiodicClock` and evoking <<fmi3CallbackIntermediateUpdate>>.
 
 [source, C]
 ----

--- a/docs/5_4_scheduled_execution_schema.adoc
+++ b/docs/5_4_scheduled_execution_schema.adoc
@@ -28,7 +28,7 @@ See also <<header-files-and-naming-of-functions>>.
 
 ==== Example XML Description File
 
-The simulation algorithm collects the information about the number and properties of <<clock,`clocks`>> supported by the FMU via analyzing the <<modelDescription.xml>> as defined in <<fmi-description-schema>>.
+The simulation algorithm collects the information about the number and properties of <<Clock,`Clocks`>> supported by the FMU via analyzing the <<modelDescription.xml>> as defined in <<fmi-description-schema>>.
 For every <<inputClock>> the simulation algorithm defines a task.
 The properties `period` and `priority` are defined based on the <<inputClock,`input clocks'`>> `period` and `priority` defined in the <<modelDescription.xml>>.
 The simulation algorithm can read from the <<modelDescription.xml>> that <<outputClock>> OutClock may tick triggered by <<inputClock>> 10msClock and that <<inputClock>> AperiodicClock is triggered by OutClock.

--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -21,8 +21,8 @@ Not to be confused with _parameter_.
 |A variable to report events or trigger events or model partitions.
 
 |_clock tick_
-|When the <<clock>> ticks an event is present, otherwise the event is absent.
-This document calls a <<clock>> tick a <<clock>> activation.
+|When the <<Clock>> ticks an event is present, otherwise the event is absent.
+This document calls a <<Clock>> tick a <<Clock>> activation.
 
 |_communication points_
 |Time grid for data exchange between importer and FMU(s) in a (co-)simulation environment.
@@ -95,7 +95,7 @@ The zip file comprises essentially an XML file that defines the model variables,
 The implementations can be in source or binary form.
 
 |_FMU clock_
-|See <<clock>>.
+|See <<Clock>>.
 
 |_importer_
 |The tool that imports or loads one or more FMUs.
@@ -143,14 +143,14 @@ It can be used to compute its expected behavior under specified conditions.
 Most important, data for every variable is defined (variable name, handle, data type, variability, unit, etc.), see <<fmi-description-schema>>.
 
 |_model rate_
-|Inverse of time interval between two communication points associated to an exposed model partition within the FMU (i.e. <<clock>> is defined in interface).
+|Inverse of time interval between two communication points associated to an exposed model partition within the FMU (i.e. <<Clock>> is defined in interface).
 In general multiple rates i.e. multiple model partitions can be defined for an Co-Simulation FMU.
 
 |[[model-partition,model partition]]_model partition_
 |Model partitions can be associated to a discrete or (piecewise) continuous part of the FMU.
-The computation of model partitions can be externally controlled based on <<clock>> ticks of associated <<inputClock,`input clocks`>>.
+The computation of model partitions can be externally controlled based on <<Clock>> ticks of associated <<inputClock,`input clocks`>>.
 
-Not all FMU internal model partitions have to be exposed in the Co-Simulation interface as <<clock>> and can also be handled FMU internally (e.g. internal subsampling).
+Not all FMU internal model partitions have to be exposed in the Co-Simulation interface as <<Clock>> and can also be handled FMU internally (e.g. internal subsampling).
 Nevertheless, it is assumed that the activation of all exposed <<inputClock,`input clocks`>> results in the computation of the complete FMU.
 
 As stated above, continuous parts of the FMU are also associated to model partitions that define the communication points for the <<continuous>> values.

--- a/headers/fmi3FunctionTypes.h
+++ b/headers/fmi3FunctionTypes.h
@@ -465,53 +465,53 @@ typedef fmi3Status fmi3ExitConfigurationModeTYPE(fmi3Instance instance);
 typedef fmi3Status fmi3GetIntervalDecimalTYPE(fmi3Instance instance,
                                               const fmi3ValueReference valueReferences[],
                                               size_t nValueReferences,
-                                              fmi3Float64 interval[],
-                                              fmi3IntervalQualifier qualifier[],
-                                              size_t nValues);
+                                              fmi3Float64 intervals[],
+                                              fmi3IntervalQualifier qualifiers[],
+                                              size_t nIntervals);
 /* end::GetIntervalDecimal[] */
 
 /* tag::GetIntervalFraction[] */
 typedef fmi3Status fmi3GetIntervalFractionTYPE(fmi3Instance instance,
                                                const fmi3ValueReference valueReferences[],
                                                size_t nValueReferences,
-                                               fmi3UInt64 intervalCounter[],
-                                               fmi3UInt64 resolution[],
-                                               fmi3IntervalQualifier qualifier[],
-                                               size_t nValues);
+                                               fmi3UInt64 intervalCounters[],
+                                               fmi3UInt64 resolutions[],
+                                               fmi3IntervalQualifier qualifiers[],
+                                               size_t nIntervals);
 /* end::GetIntervalFraction[] */
 
 /* tag::GetShiftDecimal[] */
 typedef fmi3Status fmi3GetShiftDecimalTYPE(fmi3Instance instance,
                                            const fmi3ValueReference valueReferences[],
                                            size_t nValueReferences,
-                                           fmi3Float64 shift[],
-                                           size_t nValues);
+                                           fmi3Float64 shifts[],
+                                           size_t nShifts);
 /* end::GetShiftDecimal[] */
 
 /* tag::GetShiftFraction[] */
 typedef fmi3Status fmi3GetShiftFractionTYPE(fmi3Instance instance,
                                             const fmi3ValueReference valueReferences[],
                                             size_t nValueReferences,
-                                            fmi3UInt64 shiftCounter[],
-                                            fmi3UInt64 resolution[],
-                                            size_t nValues);
+                                            fmi3UInt64 shiftCounters[],
+                                            fmi3UInt64 resolutions[],
+                                            size_t nShifts);
 /* end::GetShiftFraction[] */
 
 /* tag::SetIntervalDecimal[] */
 typedef fmi3Status fmi3SetIntervalDecimalTYPE(fmi3Instance instance,
                                               const fmi3ValueReference valueReferences[],
                                               size_t nValueReferences,
-                                              const fmi3Float64 interval[],
-                                              size_t nValues);
+                                              const fmi3Float64 intervals[],
+                                              size_t nIntervals);
 /* end::SetIntervalDecimal[] */
 
 /* tag::SetIntervalFraction[] */
 typedef fmi3Status fmi3SetIntervalFractionTYPE(fmi3Instance instance,
                                                const fmi3ValueReference valueReferences[],
                                                size_t nValueReferences,
-                                               const fmi3UInt64 intervalCounter[],
-                                               const fmi3UInt64 resolution[],
-                                               size_t nValues);
+                                               const fmi3UInt64 intervalCounters[],
+                                               const fmi3UInt64 resolutions[],
+                                               size_t nIntervals);
 /* end::SetIntervalFraction[] */
 
 /* tag::UpdateDiscreteStates[] */

--- a/headers/fmi3FunctionTypes.h
+++ b/headers/fmi3FunctionTypes.h
@@ -72,9 +72,9 @@ typedef enum {
 
 /* tag::IntervalQualifier[] */
 typedef enum {
-    fmi3NewInterval,
-    fmi3NoChange,
-    fmi3NotYetKnown,
+    fmi3IntervalNotYetKnown,
+    fmi3IntervalUnchanged,
+    fmi3IntervalChanged
 } fmi3IntervalQualifier;
 /* end::IntervalQualifier[] */
 

--- a/schema/fmi3Variable.xsd
+++ b/schema/fmi3Variable.xsd
@@ -290,14 +290,14 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	<xs:complexType name="fmi3EnumerationBase" abstract="true">
 		<xs:complexContent>
 			<xs:extension base="fmi3VariableCore">
-				<xs:attribute name="declaredType" type="xs:normalizedString" use="required"/>				
+				<xs:attribute name="declaredType" type="xs:normalizedString" use="required"/>
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
 	<xs:complexType name="fmi3VariableBase" abstract="true">
 		<xs:complexContent>
 			<xs:extension base="fmi3VariableCore">
-				<xs:attribute name="declaredType" type="xs:normalizedString"/>		
+				<xs:attribute name="declaredType" type="xs:normalizedString"/>
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
@@ -335,7 +335,6 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 					<xs:enumeration value="tunable"/>
 					<xs:enumeration value="discrete"/>
 					<xs:enumeration value="continuous"/>
-					<xs:enumeration value="clock"/>
 				</xs:restriction>
 			</xs:simpleType>
 		</xs:attribute>


### PR DESCRIPTION
TODOs:

- [x] change "Clock with causality == input" to "input Clock"
- [x] remove excessive references to Clock within same chapter
- [x] write "Clock" w/o reference inside "Clocks" section
- [x] state that Clocks must have causality == input or output 