### PR TITLE
Recommend file name and static symbols for source code FMUs

### DIFF
--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -95,8 +95,10 @@ Each <<BuildConfiguration>> provides the necessary information to compile and li
 An FMU importing tool may not regard more than one <<BuildConfiguration>> when building the FMU for a specific <<platform>>.
 The importer chooses the matching <<BuildConfiguration>> based on the <<platform>> and <<modelIdentifier>> attributes.
 
-If only a single <<SourceFile>> is provided in the <<BuildConfiguration>> it should have a unique name (e.g. `<model_identifier>.c`) and all symbols except for the FMI functions should be defined as `static` to avoid name conflicts when compiling and linking multiple source code FMUs into one binary.
+In order to avoid symbol name conflicts when compiling and linking multiple source FMUs, source files should keep the exported symbols to a minimum by declaring all symbols not needed for linking as `static`.
+If only a single <<SourceFile>> is provided in the <<BuildConfiguration>> all symbols except for the FMI functions should be defined as `static`.
 _[This source file may include other source files that are not listed in the <<BuildConfiguration>>.]_
+It is also recommended to use a descriptive name (e.g. `<model_identifier>.c`) for this single <<SourceFile>> instead of generic names (like `all.c`, or `model.c`) in order to aid readability and reduce integration effort.
 
 .BuildConfiguration attribute details.
 [[table-BuildConfiguration-details]]

--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -95,7 +95,7 @@ Each <<BuildConfiguration>> provides the necessary information to compile and li
 An FMU importing tool may not regard more than one <<BuildConfiguration>> when building the FMU for a specific <<platform>>.
 The importer chooses the matching <<BuildConfiguration>> based on the <<platform>> and <<modelIdentifier>> attributes.
 
-In order to avoid symbol name conflicts when compiling and linking multiple source FMUs, source files should keep the exported symbols to a minimum by declaring all symbols not needed for linking as `static`.
+In order to avoid symbol name conflicts when compiling and linking multiple source code FMUs, source files should keep the exported symbols to a minimum by declaring all symbols not needed for linking as `static`.
 If only a single <<SourceFile>> is provided in the <<BuildConfiguration>> all symbols except for the FMI functions should be defined as `static`.
 _[This source file may include other source files that are not listed in the <<BuildConfiguration>>.]_
 It is also recommended to use a descriptive name (e.g. `<model_identifier>.c`) for this single <<SourceFile>> instead of generic names (like `all.c`, or `model.c`) in order to aid readability and reduce integration effort.

--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -95,7 +95,7 @@ Each <<BuildConfiguration>> provides the necessary information to compile and li
 An FMU importing tool may not regard more than one <<BuildConfiguration>> when building the FMU for a specific <<platform>>.
 The importer chooses the matching <<BuildConfiguration>> based on the <<platform>> and <<modelIdentifier>> attributes.
 
-If only a single <<SourceFile>> is provided in the <<BuildConfiguration>> it should have a unique name (e.g. `<model_identifier>.c`) and all symbols except for the FMI functions should be defined as `static` to avoid name conflicts when importing multiple source code FMUs.
+If only a single <<SourceFile>> is provided in the <<BuildConfiguration>> it should have a unique name (e.g. `<model_identifier>.c`) and all symbols except for the FMI functions should be defined as `static` to avoid name conflicts when compiling and linking multiple source code FMUs into one binary.
 _[This source file may include other source files that are not listed in the <<BuildConfiguration>>.]_
 
 .BuildConfiguration attribute details.

--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -95,6 +95,9 @@ Each <<BuildConfiguration>> provides the necessary information to compile and li
 An FMU importing tool may not regard more than one <<BuildConfiguration>> when building the FMU for a specific <<platform>>.
 The importer chooses the matching <<BuildConfiguration>> based on the <<platform>> and <<modelIdentifier>> attributes.
 
+If only a single <<SourceFile>> is provided in the <<BuildConfiguration>> it should have a unique name (e.g. `<model_identifier>.c`) and all symbols except for the FMI functions should be defined as `static` to avoid name conflicts when importing multiple source code FMUs.
+_[This source file may include other source files that are not listed in the <<BuildConfiguration>>.]_
+
 .BuildConfiguration attribute details.
 [[table-BuildConfiguration-details]]
 [cols="1,3a",options="header"]
@@ -143,7 +146,7 @@ An importer of the FMU has to regard every `<SourceFileSet>` of the matching <<B
 |The compiler flags that have to be used when compiling the sources (e.g. `-fno-rtti`, `/Od`)
 |====
 
-====== SourceFile
+====== SourceFile [[SourceFile,`<SourceFile>`]]
 
 .SourceFile attribute details.
 [[table-SourceFile-details]]

--- a/docs/examples/build_description_simple.xml
+++ b/docs/examples/build_description_simple.xml
@@ -3,7 +3,7 @@
 
   <BuildConfiguration modelIdentifier="PIDContoller">
     <SourceFileSet>
-      <SourceFile name="all.c"/>
+      <SourceFile name="PIDContoller.c"/>
     </SourceFileSet>
   </BuildConfiguration>
 


### PR DESCRIPTION
This will avoid duplicate object names and symbols when compiling and linking multiple source code FMUs into the same binary, e.g. for a HiL application.