### PR TITLE
remove tick relationship from glossary

### DIFF
--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -237,11 +237,6 @@ Therefore, this event can be handled efficiently.
 |[[time-instant,time instant]]_time instant_
 |A moment in time, either a continuous-time instant latexmath:[\mathbf{t} = \mathbf{t}_R], or a super-dense time instant latexmath:[\mathbf{t} = (\mathbf{t}_R, \mathbf{t}_I)], see also <<super-dense-time>>.
 
-|_tick relationshipt_
-|_Event_ that is defined by a predefined time instant.
-Since the time instant is known in advance, the integrator can select its step size so that the event point is directly reached.
-Therefore, this event can be handled efficiently.
-
 | TLM
 | _see Transmission Line Method_
 


### PR DESCRIPTION
... as it is not used in the spec.  (and was mis-spelled as tick relationshipt :-) )