### PR TITLE
Remove reference to Modelisar glossary 

### DIFF
--- a/docs/6___literature.adoc
+++ b/docs/6___literature.adoc
@@ -21,8 +21,6 @@
 
 - [[[MLS12]]] Modelica (2012): **Modelica, A Unified Object-Oriented Language for Systems Modeling**. Language Specification, Version 3.3, May 9, 2012. https://www.modelica.org/documents/ModelicaSpec33.pdf
 
-- [[[MG09]]] MODELISAR Glossary (2009): **MODELISAR WP2 Glossary and Abbreviations**. Version 1.0, June 9, 2009.
-
 - [[[PZ06]]] Pouzet M. (2006): **Lucid Synchrone**. Version 3.0, Tutorial and Reference Manual. http://www.di.ens.fr/~pouzet/lucid-synchrone/
 
 - [[[CGM84]]] Coleman, Garbow, Mor&#233; (1984): **Software for estimating sparse Jacobian matrices, ACM Transactions on Mathematical Software**. TOMS , vol. 10, no. 3, pp. 346-347

--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -62,6 +62,9 @@ See <<state-event>>, <<step-event>> and <<time-event>>.
 |A variable that changes sign exactly at an event.
 See <<state-event,event indicator>>.
 
+|_event iteration_
+|At an event, the importer for a given _super dense time_ intance can iteratively call set and get calls e.g. to solve _algebraic loops_. When by this a new consistent state is reacched, this can trigger the change of discrete variables. This cause the next solution of an algebraic loop in the next super dense time instance. These discontinuous changes can repeat until the participating FMUs or the master decide that no further iteration is needed (when the discrete variables no longer changes) or possible. An example for system that can be simulated with event iteration is a powertrain with multiple clutches distributed in several FMUs. There the decision, which clutch is open and which closed can be determined with event iteration.
+
 |_exporter_
 |A program that creates an FMU.
 

--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -61,7 +61,12 @@ See <<state-event>>, <<step-event>> and <<time-event>>.
 See <<state-event,event indicator>>.
 
 |_event iteration_
-|At an event, the importer for a given _super dense time_ intance can iteratively call set and get calls e.g. to solve _algebraic loops_. When by this a new consistent state is reacched, this can trigger the change of discrete variables. This cause the next solution of an algebraic loop in the next super dense time instance. These discontinuous changes can repeat until the participating FMUs or the master decide that no further iteration is needed (when the discrete variables no longer changes) or possible. An example for system that can be simulated with event iteration is a powertrain with multiple clutches distributed in several FMUs. There the decision, which clutch is open and which closed can be determined with event iteration.
+|An importer can iteratively call <<get-and-set-variable-values,`fmi3Set{VariableType}`>> and <<get-and-set-variable-values,`fmi3Get{VariableType}`>> e.g. to solve _algebraic loops_ during an event and during a _super-dense time instant_.
+When reaching a consistent state, changes to discrete variables may be triggered.
+Such a discrete (state) change may require another solution of an algebraic loop in the next super-dense time instant.
+These discontinuous changes can repeat until the participating FMUs or the master decide that no further iteration is needed.
+An example for a system that can be simulated with event iteration is a powertrain with multiple clutches distributed in several FMUs.
+The decision which clutch is open, which is closed and which is slipping can be determined with event iteration.
 
 |_exporter_
 |A program that creates an FMU.

--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -3,8 +3,6 @@
 [appendix]
 ## Glossary [[glossary]]
 
-This glossary is a subset of (_MODELISAR Glossary, 2009_) with some extensions.
-
 [cols="1,3"]
 |====
 |Term


### PR DESCRIPTION
... as the glossary was almost completely re-written and the cited Modelisar glossary is not publicly available. It is anyway clear that FMI stems from the Modelisar ITEA project.