### PR TITLE
fix order in example tuples

### DIFF
--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -413,35 +413,35 @@ The following table lists the most common platform tuples for shared libraries a
 |FMI 2.0
 |Description
 
-|darwin-x86_64
+|x86_64-darwin
 |darwin64
 |macOS on 64-bit x86
 
-|darwin-aarch64
+|aarch64-darwin
 |
 |macOS on Apple Silicon
 
-|linux-i386
+|i386-linux
 |linux32
 |Linux on 32-bit x86
 
-|linux-x86_64
+|x86_64-linux
 |linux64
 |Linux on 64-bit x86
 
-|linux-aarch64
+|aarch64-linux
 |
 |Linux on ARM64
 
-|windows-i386
+|i386-windows
 |win32
 |Windows on 32-bit x86
 
-|windows-x86_64
+|x86_64-windows
 |win64
 |Windows on 64-bit x86
 
-|windows-aarch64
+|aarch64-windows
 |
 |Windows on ARM64
 |====


### PR DESCRIPTION
The example tuples in 2.5.1.4.2. had the wrong order.