### PR TITLE
Introduces clocked states when clocked variables are introduced.

### DIFF
--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -798,12 +798,14 @@ _[Such a model partition may represent a task or an interrupt service routine of
 
 Discrete-time variables computed in such a model partition are called <<clocked-variable,clocked variables>>.
 
-The value of a clocked variable can be queried, and can acquire a new value, only when its Clock is active, except during <<InitializationMode>>.
+The value of a clocked variable can acquire a new value and can be queried only when its Clock is active, except during <<InitializationMode>>.
 _[This is common in clock semantics. See, e.g., <<MLS12>>.]_
-During <<InitializationMode>>, if a clocked variable is declared as an <<InitialUnknown>>, then it should be initialized as a discrete variable (see <<InitializationMode>>). Declaring a clocked variable as an <<InitialUnknown>> is optional for the Exporter. Non-initialized clocked variables will still be initialized in the corresponding clock's first tick.
+During <<InitializationMode>>, if a clocked variable is declared as an <<InitialUnknown>>, then it must be initialized as a discrete variable.
+Declaring a clocked variable as an <<InitialUnknown>> is optional.
+Uninitialized clocked variables must be initialized in the corresponding Clock's first tick.
 
-A <<ClockedState>> is a clocked variable whose value depends on its previous value (i.e., the value at the last clock tick).
-Clocked states declare the value reference of the previous variable using the <<previous>> attribute.
+A <<ClockedState>> is a clocked variable whose value depends on its previous value (i.e., the value computed at the last clock tick).
+Clocked states declare the <<valueReference>> of their previous variable using the <<previous>> attribute.
 
 The association between <<clocked-variable,clocked variables>> and their <<Clock,Clocks>> is defined by the attribute <<clocks>>.
 <<clocked-variable,Clocked variables>> can depend on multiple Clocks.

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -797,12 +797,13 @@ An input Clock activates its specific <<model-partition>>.
 _[Such a model partition may represent a task or an interrupt service routine of an embedded system, or a discretized part of a plant model.]_
 
 Discrete-time variables computed in such a model partition are called <<clocked-variable,clocked variables>>.
-Therefore, the value of a <<clocked-variable,clocked variable>> changes only when its Clock is active.
-Model partitions are initialized at their first Clock activation, not in <<InitializationMode>>.
 
-In some clock semantics (e.g. <<MLS12>>), a clocked variable has a value only when its associated Clock is active.
-However, <<get-and-set-variable-values,`fmi3Get{VariableType}`>> will return the value computed at the last Clock activation time.
-Before the first Clock tick, clocked variables have their initial value.
+The value of a clocked variable can be queried, and can acquire a new value, only when its Clock is active, except during <<InitializationMode>>.
+_[This is common in clock semantics. See, e.g., <<MLS12>>.]_
+During <<InitializationMode>>, if a clocked variable is declared as an <<InitialUnknown>>, then it should be initialized as a discrete variable (see <<InitializationMode>>). Declaring a clocked variable as an <<InitialUnknown>> is optional for the Exporter. Non-initialized clocked variables will still be initialized in the corresponding clock's first tick.
+
+A <<ClockedState>> is a clocked variable whose value depends on its previous value (i.e., the value at the last clock tick).
+Clocked states declare the value reference of the previous variable using the <<previous>> attribute.
 
 The association between <<clocked-variable,clocked variables>> and their <<Clock,Clocks>> is defined by the attribute <<clocks>>.
 <<clocked-variable,Clocked variables>> can depend on multiple Clocks.

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -524,7 +524,8 @@ Getting variables might trigger <<selectiv-computation,computations>>.
 Function <<fmi3SetClock>>::
 For <<inputClock,`input Clocks`>>, <<fmi3SetClock>> is called to set the activation status of <<Clock,`Clocks`>> to `fmi3ClockActive` or `fmi3ClockInactive`.
 During the solution of algebraic loops, the activation condition of triggered input clocks may change and therefore <<fmi3SetClock>> can be called multiple times per super-dense time instant.
-When a Clock is deactivated, the FMU must reset all clocked variables of this Clock to the values computed during the last <<fmi3UpdateDiscreteStates>> when this Clock was active (latexmath:[{}^\bullet\mathbf{v}_{\mathit{k}}]).
+When a Clock is deactivated, the FMU must reset all clocked states of this Clock to the values computed during the last <<fmi3UpdateDiscreteStates>> when this Clock was active (latexmath:[{}^\bullet\mathbf{v}_{\mathit{k}}]).
+_[Rationale: a triggered output clock latexmath:[c] may depend on some variable latexmath:[v] that is involved in an algebraic loop. As part of the iterations to solve the algebraic loop, latexmath:[v] acquires a value that activates the clock. If the final (or some intermediate) value of latexmath:[v] no longer activates the clock. Such clock needs to be de-activated by the Importer during the same super-dense time instant.]_
 A Clock can only be set to inactive once activated if the attribute <<canBeDeactivated,`canBeDeactivated == true`>>. +
 Only <<time-based-clock,time-based Clocks>> must not be active for more than one call of <<fmi3UpdateDiscreteStates>> per <<EventMode>>.
 The importer must ensure that coinciding time-based Clocks are activated at the same instant of super-dense time. +

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -524,10 +524,10 @@ Getting variables might trigger <<selectiv-computation,computations>>.
 Function <<fmi3SetClock>>::
 For <<inputClock,`input Clocks`>>, <<fmi3SetClock>> is called to set the activation status of <<Clock,`Clocks`>> to `fmi3ClockActive` or `fmi3ClockInactive`.
 During the solution of algebraic loops, the activation condition of triggered input clocks may change and therefore <<fmi3SetClock>> can be called multiple times per super-dense time instant.
-When a Clock is deactivated, the FMU must reset all clocked states of this Clock to the values computed during the last <<fmi3UpdateDiscreteStates>> when this Clock was active (latexmath:[{}^\bullet\mathbf{v}_{\mathit{k}}]).
-_[Rationale: a triggered output clock latexmath:[c] may depend on some variable latexmath:[v] that is involved in an algebraic loop._
-_As part of the iterations to solve the algebraic loop, latexmath:[v] acquires a value that activates the clock._
-_If the final (or some intermediate) value of latexmath:[v] no longer activates the clock, then this Clock must be deactivated by the Importer during the same super-dense time instant.]_
+When a Clock is deactivated, the FMU must reset all clocked states of this Clock to the values computed during the last <<fmi3UpdateDiscreteStates>> when this Clock was active (latexmath:[{}^\bullet\mathbf{v}_{\mathit{k}}]). +
+_[Rationale: a triggered output Clock latexmath:[c] may depend on some variable latexmath:[v] that is involved in an algebraic loop._
+_As part of the iterations to solve the algebraic loop, latexmath:[v] acquires a value that activates the Clock._
+_If the final (or some intermediate) value of latexmath:[v] no longer activates the Clock, then this Clock must be deactivated by the Importer during the same super-dense time instant.]_ +
 A Clock can only be set to inactive once activated if the attribute <<canBeDeactivated,`canBeDeactivated == true`>>. +
 Only <<time-based-clock,time-based Clocks>> must not be active for more than one call of <<fmi3UpdateDiscreteStates>> per <<EventMode>>.
 The importer must ensure that coinciding time-based Clocks are activated at the same instant of super-dense time. +

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -525,7 +525,9 @@ Function <<fmi3SetClock>>::
 For <<inputClock,`input Clocks`>>, <<fmi3SetClock>> is called to set the activation status of <<Clock,`Clocks`>> to `fmi3ClockActive` or `fmi3ClockInactive`.
 During the solution of algebraic loops, the activation condition of triggered input clocks may change and therefore <<fmi3SetClock>> can be called multiple times per super-dense time instant.
 When a Clock is deactivated, the FMU must reset all clocked states of this Clock to the values computed during the last <<fmi3UpdateDiscreteStates>> when this Clock was active (latexmath:[{}^\bullet\mathbf{v}_{\mathit{k}}]).
-_[Rationale: a triggered output clock latexmath:[c] may depend on some variable latexmath:[v] that is involved in an algebraic loop. As part of the iterations to solve the algebraic loop, latexmath:[v] acquires a value that activates the clock. If the final (or some intermediate) value of latexmath:[v] no longer activates the clock. Such clock needs to be de-activated by the Importer during the same super-dense time instant.]_
+_[Rationale: a triggered output clock latexmath:[c] may depend on some variable latexmath:[v] that is involved in an algebraic loop._
+_As part of the iterations to solve the algebraic loop, latexmath:[v] acquires a value that activates the clock._
+_If the final (or some intermediate) value of latexmath:[v] no longer activates the clock, then this Clock must be deactivated by the Importer during the same super-dense time instant.]_
 A Clock can only be set to inactive once activated if the attribute <<canBeDeactivated,`canBeDeactivated == true`>>. +
 Only <<time-based-clock,time-based Clocks>> must not be active for more than one call of <<fmi3UpdateDiscreteStates>> per <<EventMode>>.
 The importer must ensure that coinciding time-based Clocks are activated at the same instant of super-dense time. +

--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -1717,7 +1717,7 @@ This list consists of all variables which
 
 - are continuous-time <<state,`states`>> or state derivatives (defined with elements <<ContinuousStateDerivative>>) with <<initial>> = <<approx>> or <<calculated>> _[if a Co-Simulation FMU does not define the <<ContinuousStateDerivative>> elements, (3) cannot be present]_, or
 
-- are <<clocked-variable,clocked variables>> that the FMU wishes to be initialized.
+- are <<clocked-variable,clocked variables>> that the FMU wishes to initialize in initialization mode.
 
 The resulting list is not allowed to have duplicates (for example, if a <<state>> is also an <<output>>, it is included only once in the list). +
 Attribute <<dependencies>> defines the dependencies of the unknowns from the knowns in <<InitializationMode>> at the initial time.

--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -1081,8 +1081,7 @@ The default value of this attribute is `false`.
 |
 [[previous,`previous`]]
 If present, this variable is a <<ClockedState>> and this attribute is a value reference to the variable with the previous value.
-Only clocked variables (i.e. variables with the attribute <<clocks>>) may have the <<previous>> attribute.
-Only variables with <<variability,`variability == discrete`>> may have a previous value.
+The following constraints apply: only clocked variables (i.e. variables with the attribute <<clocks>>) may have the <<previous>> attribute; only variables with <<variability,`variability == discrete`>> may have a previous value; and the variable referenced by the previous attribute must have a type that is compatible with this variable.
 
 _[For example, if `previous == 3` for variable `8`, then variable `3` is the previous value of variable `8`. See also <<fmi3UpdateDiscreteStates>>._
 _Note: This is reverse compared to the <<derivative>> attribute.]_
@@ -1700,7 +1699,7 @@ latexmath:[{\dot{\mathbf{x}_c} := \mathbf{f}_{\mathit{der}}(\mathbf{x}_c, \mathb
 
 |`ClockedState`
 |
-[[ClockedState,`<ClockedState>`]]
+[[ClockedState,`ClockedState`]]
 A <<ClockedState>> is part of the discrete state of a model partition and represented by a clocked variable.
 To which Clock or Clocks it belongs is described by the attribute <<clocks>>.
 Each <<ClockedState>> must have the attribute <<previous>> to represent the previous value of this <<ClockedState>>.
@@ -1710,13 +1709,15 @@ All <<ClockedState,clocked states>> must have <<variability,`variability == disc
 |
 [[InitialUnknown,`<InitialUnknown>`]]
 Ordered list of all exposed unknowns in <<InitializationMode>>.
-This list consists of all variables with
+This list consists of all variables which
 
-- <<causality>> = <<output>> and (<<initial>> = <<approx>> or <<calculated>>), and
+- are not <<clocked-variable,clocked variables>> and have <<causality>> = <<output>> (with <<initial>> = <<approx>> or <<calculated>>), or
 
-- <<causality>> = <<calculatedParameter>> and
+- have <<causality>> = <<calculatedParameter>>, or
 
-- all continuous-time <<state,`states`>> and all state derivatives (defined with elements <<ContinuousStateDerivative>>) with <<initial>> = <<approx>> or <<calculated>> _[if a Co-Simulation FMU does not define the <<ContinuousStateDerivative>> elements, (3) cannot be present]_.
+- are continuous-time <<state,`states`>> or state derivatives (defined with elements <<ContinuousStateDerivative>>) with <<initial>> = <<approx>> or <<calculated>> _[if a Co-Simulation FMU does not define the <<ContinuousStateDerivative>> elements, (3) cannot be present]_, or
+
+- are <<clocked-variable,clocked variables>> that the FMU wishes to be initialized.
 
 The resulting list is not allowed to have duplicates (for example, if a <<state>> is also an <<output>>, it is included only once in the list). +
 Attribute <<dependencies>> defines the dependencies of the unknowns from the knowns in <<InitializationMode>> at the initial time.

--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -1081,7 +1081,7 @@ The default value of this attribute is `false`.
 |
 [[previous,`previous`]]
 If present, this variable is a <<ClockedState>> and this attribute is a value reference to the variable with the previous value.
-The following constraints apply: only clocked variables (i.e. variables with the attribute <<clocks>>) may have the <<previous>> attribute; only variables with <<variability,`variability == discrete`>> may have a previous value; and the variable referenced by the previous attribute must have a type that is compatible with this variable.
+The following constraints apply: only clocked variables (i.e. variables with the attribute <<clocks>>) may have the <<previous>> attribute; only variables with <<variability,`variability == discrete`>> may have a previous value; and the variable referenced by the previous attribute must have the same type.
 
 _[For example, if `previous == 3` for variable `8`, then variable `3` is the previous value of variable `8`. See also <<fmi3UpdateDiscreteStates>>._
 _Note: This is reverse compared to the <<derivative>> attribute.]_

--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -1081,7 +1081,7 @@ The default value of this attribute is `false`.
 |
 [[previous,`previous`]]
 If present, this variable is a <<ClockedState>> and this attribute is a value reference to the variable with the previous value.
-The following constraints apply: only clocked variables (i.e. variables with the attribute <<clocks>>) may have the <<previous>> attribute; only variables with <<variability,`variability == discrete`>> may have a previous value; and the variable referenced by the previous attribute must have the same type.
+The following constraints apply: only clocked variables (i.e. variables with the attribute <<clocks>>) may have the <<previous>> attribute; only variables with <<variability,`variability == discrete`>> may have a previous value; and the variable referenced by the previous attribute must have the same numeric type.
 
 _[For example, if `previous == 3` for variable `8`, then variable `3` is the previous value of variable `8`. See also <<fmi3UpdateDiscreteStates>>._
 _Note: This is reverse compared to the <<derivative>> attribute.]_


### PR DESCRIPTION
Introduces clocked states when clocked variables are introduced.
Removes the sample-and-hold semantics for clocked variables.
Explains that clocked states can be optionally declared in Initial Unknowns to be initialized.

This PR closes https://github.com/modelica/fmi-standard/issues/1402

Addresses items 2,3, and 5, of the summary here: https://github.com/modelica/fmi-standard/issues/1407#issuecomment-819509403

@andreas-junghanns can you add the content to address item 1 of  [the summary](https://github.com/modelica/fmi-standard/issues/1407#issuecomment-819509403)? I was not able to figure out where to describe it.
