### PR TITLE
Rename Transmission Line Method to Transmission Line Modeling

### DIFF
--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -693,7 +693,7 @@ This state is only available in Co-Simulation and Scheduled Execution.
 
 _[The following use cases are enabled:_
 
-* _Access to intermediate variables enables advanced Co-Simulation with interpolation/extrapolation techniques (such as polynomial extrapolation, Transmission Line Modeling (TLM) co-simulation, anti-alias filtering, smoothing of input among others)._
+* _Access to intermediate variables enables advanced Co-Simulation with interpolation/extrapolation techniques (such as polynomial extrapolation, <<transmission-line-modeling>> (<<tlm>>) co-simulation, anti-alias filtering, smoothing of input among others)._
 * _<<IntermediateUpdateMode>> enables the same input approximation that was possible in FMI 2.0 with `fmi2SetInputDerivatives`, by evaluation of the approximation polynomial by the importer and not within the FMU as in FMI 2.0_
 * _FMUs can inform the importer about an event, which occurs during an <<fmi3DoStep>> in case of CS (see <<fmi-for-co-simulation>>)._
 * _The Co-Simulation algorithm can request an <<early-return,early return>> from <<fmi3DoStep>>, because of an event between communication points (see <<early-return>>)._

--- a/docs/6___literature.adoc
+++ b/docs/6___literature.adoc
@@ -26,3 +26,5 @@
 - [[[CGM84]]] Coleman, Garbow, Mor&#233; (1984): **Software for estimating sparse Jacobian matrices, ACM Transactions on Mathematical Software**. TOMS , vol. 10, no. 3, pp. 346-347
 
 - [[[PW13]]] Preston-Werner, T. (2013): **Semantic Versioning 2.0.0**.  https://semver.org/spec/v2.0.0.html
+
+- [[[FBH18]]] Fritzson D., Braun R. and Hartford J. (2018): **Composite modelling in 3-D mechanics utilizing Transmission Line Modelling (TLM) and Functional Mock-up Interface (FMI)**. Modeling, Idenfitication and Control, vol. 39, no. 3, pp. 179-190.

--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -243,12 +243,12 @@ Therefore, this event can be handled efficiently.
 |[[time-instant,time instant]]_time instant_
 |A moment in time, either a continuous-time instant latexmath:[\mathbf{t} = \mathbf{t}_R], or a super-dense time instant latexmath:[\mathbf{t} = (\mathbf{t}_R, \mathbf{t}_I)], see also <<super-dense-time>>.
 
-| TLM
-| _see Transmission Line Method_
+| [[tlm,TLM]]_TLM_
+| See <<transmission-line-modeling>>
 
-| Transmission Line Method
+|[[transmission-line-modeling,Transmission Line Modeling]]_Transmission Line Modeling_
 |A mathematical method which uses physically motivated time delays to decouple an equation system into independent parts during a specified time frame without compromising numerical stability.
-Also known as the _bi-lateral delay line_ method.
+Also known as the _bi-lateral delay line_ method. For more details see <<FBH18>>.
 
 |_user interface_
 |The part of the simulation program that gives the user control over the simulation and allows watching results.


### PR DESCRIPTION
Renamed "Transmission Line Method" to "Transmission Line Modeling", which is the most commonly used name for the method.

Also added anchors and a reference.