### PR TITLE
Fix SE concepts intro

### DIFF
--- a/docs/5_1_scheduled_execution_math.adoc
+++ b/docs/5_1_scheduled_execution_math.adoc
@@ -6,7 +6,7 @@ The Scheduled Execution interface has a different timing concept compared to FMI
 This is required to handle activations of <<triggered, triggered input Clocks>> which may tick at a time instant that is unpredictable for the simulation algorithm.
 Typically, hardware I/O or virtual ECU software events belong to this category.
 
-A simulation algorithm's activation of a model partition will invoke the computation of the model partition defined by a <<input, input Clock>> for the current <<Clock>> tick time latexmath:[\mathbf{t}_i].
+A simulation algorithm's activation of a model partition will invoke the computation of the model partition defined by an <<input, input Clock>> for the current <<Clock>> tick time latexmath:[\mathbf{t}_i].
 
 A model partition can only be activated once per activation time point latexmath:[\mathbf{t}_i].
 

--- a/docs/5_1_scheduled_execution_math.adoc
+++ b/docs/5_1_scheduled_execution_math.adoc
@@ -13,7 +13,7 @@ A model partition can only be activated once per activation time point latexmath
 During the computation of a model partition of an <<inputClock, `input Clock`>> the FMU may inform the importer that an <<outputClock>> ticked or a <<countdown, `countdown Clock`>> has to be activated.
 To do so the FMU switches into <<IntermediateUpdateMode>>.
 Subsequently it is up to the importer to react on this information.
-I.e. the importer may activate potential sinks (e.g. a model partition of another FMU) connected to this <<outputClock>> or it may activate the respective <<countdown, `countdown Clock`>>.
+I.e. the importer may activate potential sinks (e.g. a model partition of another FMU) connected to this <<outputClock>> or it may activate the model partition of the respective <<countdown, `countdown Clock`>>.
 
 More details can be found in <<Clock,Clocks>>.
 

--- a/docs/5_1_scheduled_execution_math.adoc
+++ b/docs/5_1_scheduled_execution_math.adoc
@@ -1,16 +1,19 @@
 === Concepts [[concepts-scheduled-execution]]
 
+==== Timing Concepts and Clocks [[concepts-timing-scheduled-execution]]
+
 The Scheduled Execution interface has a different timing concept compared to FMI for Co-Simulation.
 This is required to handle activations of <<triggered, triggered input Clocks>> which may tick at a time instant that is unpredictable for the simulation algorithm.
 Typically, hardware I/O or virtual ECU software events belong to this category.
 
-A simulation algorithm's activation of a model partition will invoke the computation of the model partition defined by a <<triggered, triggered input Clock>> for the current <<Clock>> tick time latexmath:[\mathbf{t}_i].
-Refer to the Clock time progress definition for <<periodic-clock,periodic Clocks>>.
+A simulation algorithm's activation of a model partition will invoke the computation of the model partition defined by a <<input, input Clock>> for the current <<Clock>> tick time latexmath:[\mathbf{t}_i].
 
 A model partition can only be activated once per activation time point latexmath:[\mathbf{t}_i].
 
-Model partitions that are associated to <<countdown, `countdown Clocks`>> will accordingly provide the result values of the model partition's variables for the current <<countdown, `countdown Clock`>> tick time latexmath:[\mathbf{t}_i] of the active countdown Clock.
-The FMU informs the importer that the countdown clock has to be activated, but it is up to the importer to activate the countdown clock.
+During the computation of a model partition of an <<inputClock, `input Clock`>> the FMU may inform the importer that an <<outputClock>> ticked or a <<countdown, `countdown Clock`>> has to be activated.
+To do so the FMU switches into <<IntermediateUpdateMode>>.
+Subsequently it is up to the importer to react on this information.
+I.e. the importer may activate potential sinks (e.g. a model partition of another FMU) connected to this <<outputClock>> or it may activate the respective <<countdown, `countdown Clock`>>.
 
 More details can be found in <<Clock,Clocks>>.
 

--- a/docs/5_1_scheduled_execution_math.adoc
+++ b/docs/5_1_scheduled_execution_math.adoc
@@ -4,7 +4,7 @@ The Scheduled Execution interface has a different timing concept compared to FMI
 This is required to handle activations of <<triggered, triggered input Clocks>> which may tick at a time instant that is unpredictable for the simulation algorithm.
 Typically, hardware I/O or virtual ECU software events belong to this category.
 
-A simulation algorithm's activation of a model partition will invoke the computation the results of the model partition defined by a <<triggered, triggered input Clock>> for the current <<Clock>> tick time latexmath:[\mathbf{t}_i].
+A simulation algorithm's activation of a model partition will invoke the computation of the model partition defined by a <<triggered, triggered input Clock>> for the current <<Clock>> tick time latexmath:[\mathbf{t}_i].
 Refer to the Clock time progress definition for <<periodic-clock,periodic Clocks>>.
 
 A model partition can only be activated once per activation time point latexmath:[\mathbf{t}_i].

--- a/docs/5_1_scheduled_execution_math.adoc
+++ b/docs/5_1_scheduled_execution_math.adoc
@@ -4,13 +4,13 @@ The Scheduled Execution interface has a different timing concept compared to FMI
 This is required to handle activations of <<triggered, triggered input Clocks>> which may tick at a time instant that is unpredictable for the simulation algorithm.
 Typically, hardware I/O or virtual ECU software events belong to this category.
 
-A simulation algorithm's activation of a model partition will compute the results of the model partition defined by a <<triggered, triggered input Clock>> for the current <<Clock>> tick time latexmath:[\mathbf{t}_i].
+A simulation algorithm's activation of a model partition will invoke the computation the results of the model partition defined by a <<triggered, triggered input Clock>> for the current <<Clock>> tick time latexmath:[\mathbf{t}_i].
 Refer to the Clock time progress definition for <<periodic-clock,periodic Clocks>>.
 
 A model partition can only be activated once per activation time point latexmath:[\mathbf{t}_i].
 
-Model partitions that are associated to <<outputClock,`output Clocks`>> will accordingly provide the result values of the model partition's variables for the current <<outputClock>> tick time latexmath:[\mathbf{t}_i] of the active <<outputClock>>.
-The activation of such an <<outputClock>> is not controlled by the simulation algorithm but internally by the FMU.
+Model partitions that are associated to <<countdown, `countdown Clocks`>> will accordingly provide the result values of the model partition's variables for the current <<countdown, `countdown Clock`>> tick time latexmath:[\mathbf{t}_i] of the active countdown Clock.
+The FMU informs the importer that the countdown clock has to be activated, but it is up to the importer to activate the countdown clock.
 
 More details can be found in <<Clock,Clocks>>.
 


### PR DESCRIPTION
DRAFT. Fixing a false remark on output clocks by using a new formulation about countdown Cloks from https://github.com/chrbertsch/fmi3pap. Compare chrbertsch/fmi3paper#4 (comment)