### PR TITLE
Add missing function defines for shift accessors

### DIFF
--- a/headers/fmi3Functions.h
+++ b/headers/fmi3Functions.h
@@ -169,6 +169,8 @@ Common Functions
 #define fmi3SetClock                 fmi3FullName(fmi3SetClock)
 #define fmi3GetIntervalDecimal       fmi3FullName(fmi3GetIntervalDecimal)
 #define fmi3GetIntervalFraction      fmi3FullName(fmi3GetIntervalFraction)
+#define fmi3GetShiftDecimal          fmi3FullName(fmi3GetShiftDecimal)
+#define fmi3GetShiftFraction         fmi3FullName(fmi3GetShiftFraction)
 #define fmi3SetIntervalDecimal       fmi3FullName(fmi3SetIntervalDecimal)
 #define fmi3SetIntervalFraction      fmi3FullName(fmi3SetIntervalFraction)
 #define fmi3UpdateDiscreteStates     fmi3FullName(fmi3UpdateDiscreteStates)


### PR DESCRIPTION
The function defines in fmi3Functions.h for the newly introduced clock shift accessor functions were missing.