### PR TITLE
Add check empty figure in generate_figures.ps1 script

### DIFF
--- a/.circleci/generate_figures.ps1
+++ b/.circleci/generate_figures.ps1
@@ -40,6 +40,12 @@ function Export-Schema() {
 	$out = Join-Path $pngOutDir $outName
 	Check-Existing $out
 	& $generator -o $out -r $element -e $expand -d -c -z 300 -a -no-gui -y (Resolve-Path (Join-Path $PSScriptRoot "..\schema\$schema"))
+
+	If ((Get-Item $out).length -eq 0kb) {
+		Write-Output "Error generating file $out"
+		exit 1
+	}
+
 	if ($preview) {
 		Start-Process $out
 	}

--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -1075,7 +1075,7 @@ The default value of this attribute is `false`.
 |
 [[previous,`previous`]]
 If present, this variable is a <<ClockedState>> and this attribute is a value reference to the variable with the previous value.
-The following constraints apply: only clocked variables (i.e. variables with the attribute <<clocks>>) may have the <<previous>> attribute; only variables with <<variability,`variability == discrete`>> may have a previous value; and the variable referenced by the previous attribute must have the same numeric type.
+The following constraints apply: only clocked variables (i.e. variables with the attribute <<clocks>>) may have the <<previous>> attribute; only variables with <<variability,`variability == discrete`>> may have a previous value; and the variable referenced by the previous attribute must have the same numeric type, <<variability,`variability == discrete`>>, and cannot have <<causality,`causality == input`>>.
 
 _[For example, if `previous == 3` for variable `8`, then variable `3` is the previous value of variable `8`. See also <<fmi3UpdateDiscreteStates>>._
 _Note: This is reverse compared to the <<derivative>> attribute.]_


### PR DESCRIPTION
This small change helps prevent inconsistencies like https://github.com/modelica/fmi-standard/issues/1454
