### PR TITLE
Introduce f_disc to separate discrete state equations from f_event

### DIFF
--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -793,39 +793,39 @@ _An example is provided in <<example-scheduled-execution>>.]_
 
 ===== Model Partitions and Clocked Variables [[clocked-variable]]
 
-Each clock latexmath:[C] induces a discrete system, whose state advances at each of latexmath:[C]'s tick.
-Such system, also called the <<model-partition>> of latexmath:[C], is commonly written as:
+Each Clock latexmath:[\mathbf{k}] induces a discrete system.
+It's state advances at each tick of latexmath:[\mathbf{k}] at time latexmath:[\mathbf{t}_{k}].
+Such a system, also called the <<model-partition>> of latexmath:[\mathbf{k}], is commonly written as:
 
 latexmath:[\begin{align*}
-x^C_d(k) &= f^C(x^C_d(k-1), u^C(k), t(k)) \\
-y^C_d(k) &= g^C(x^C_d(k), u^C(k), t(k))
+\mathbf{x}_k(\mathbf{t}_{k}) &= \mathbf{f}_k(\mathbf{x}_k(\mathbf{t}_{k-1}), \mathbf{u}(\mathbf{t}_k), \mathbf{t}_k) \\
+\mathbf{y}_k(\mathbf{t}_{k}) &= \mathbf{g}_k(\mathbf{x}_k(\mathbf{t}_{k}), \mathbf{u}(\mathbf{t}_k), \mathbf{t}_k)
 \end{align*}]
 
 where:
 
-. latexmath:[x^C_d] denotes the state vector
-. latexmath:[k] denotes the latexmath:[k]-th tick
-. latexmath:[f^C] denotes the state transition function
-. latexmath:[x^C_d(k-1)] denotes previous state vector
-. latexmath:[u^C] denotes input state vector
-. latexmath:[t] denotes the simulation time
-. latexmath:[y^C_d] denotes output vector
-. latexmath:[g^C] denotes the output function
+. latexmath:[\mathbf{t}_k] denotes the simulation time of Clock latexmath:[\mathbf{k}] at time latexmath:[\mathbf{t}_{k}] and
+. latexmath:[\mathbf{x}_k(\mathbf{t}_k)] denotes the state vector at the current Clock tick at time latexmath:[\mathbf{t}_{k}] and
+. latexmath:[\mathbf{x}_k(\mathbf{t}_{k-1})] denotes the state vector at the previous Clock tick of latexmath:[\mathbf{k}] at latexmath:[\mathbf{t}_{k-1}],
+. latexmath:[\mathbf{f}_k] denotes the state transition function and
+. latexmath:[\mathbf{g}_k] denotes the output function of the <<model-partition>> of latexmath:[\mathbf{k}],
+. latexmath:[\mathbf{u}] denotes the input vector and
+. latexmath:[\mathbf{y}_k] denotes output vector computed by the <<model-partition>> of latexmath:[\mathbf{k}].
 
-_[Such a model partition may represent a task or an interrupt service routine of an embedded system, or a discretized part of a plant model.
-The name "model partition" refers to the fact that an model inside an FMU may declare multiple clocks, each with its own partition of the overall model.]_
+_[Such a model partition may represent a task or an interrupt service routine of an embedded system, or a discretized part of a plant model._
+_The name "model partition" refers to the fact that an model inside an FMU may declare multiple Clocks, each with its own partition of the overall model.]_
 
-When latexmath:[C] is active (i.e., ticking) invoking the FMI functions `fmi3Get{VariableType}` on variables in the output vector latexmath:[y^C_d] will trigger the execution of the output function latexmath:[g^C] to compute such variables.
-When FMI function <<fmi3EvaluateDiscreteStates>> is invoked, the state vector latexmath:[x^C_d] is updated according to state transition function latexmath:[f^C].
-The discrete-time variables (latexmath:[x^C_d] and latexmath:[y^C_d]) are called <<clocked-variable,clocked variables>>.
+When latexmath:[\mathbf{k}] is active (i.e., ticking) invoking the FMI functions `fmi3Get{VariableType}` on variables in the output vector latexmath:[\mathbf{y}_k] will trigger the execution of the output function latexmath:[\mathbf{g}_k] to compute such variables.
+When FMI function <<fmi3EvaluateDiscreteStates>> is invoked, the state vector latexmath:[\mathbf{x}_k] is updated according to state transition function latexmath:[\mathbf{f}_k].
+The discrete-time variables latexmath:[\mathbf{x}_k] and latexmath:[\mathbf{y}_k] are called <<clocked-variable,clocked variables>>.
 
-A clocked variable can acquire a new value and can be queried only when its Clock is active, except during <<InitializationMode>>.
+A clocked variable latexmath:[\mathbf{v}_k] can acquire a new value and can be queried only when its Clock latexmath:[\mathbf{k}] is active, except during <<InitializationMode>>.
 _[This is common in clock semantics. See, e.g., <<MLS12>>.]_
 During <<InitializationMode>>, if a clocked variable is declared as an <<InitialUnknown>>, then it must be initialized as a discrete variable.
 Declaring a clocked variable as an <<InitialUnknown>> is optional.
 Uninitialized clocked variables must be initialized in the corresponding Clock's first tick.
 
-A <<ClockedState>> is a clocked variable belonging to the state vector latexmath:[x^C_d], whose value depends on its previous value (i.e., the value computed at the last clock tick).
+A <<ClockedState>> is a clocked variable belonging to the state vector latexmath:[\mathbf{x}_k], whose value depends on its previous value (i.e., the value computed at the last Clock tick).
 Clocked states declare the <<valueReference>> of their previous variable using the <<previous>> attribute.
 
 The association between <<clocked-variable,clocked variables>> and their <<Clock,Clocks>> is defined by the attribute <<clocks>>.

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -793,19 +793,39 @@ _An example is provided in <<example-scheduled-execution>>.]_
 
 ===== Model Partitions and Clocked Variables [[clocked-variable]]
 
-An input Clock tick activates its specific <<model-partition>>.
+Each clock latexmath:[C] induces a discrete system, whose state advances at each of latexmath:[C]'s tick.
+Such system, also called the <<model-partition>> of latexmath:[C], is commonly written as:
 
-_[Such a model partition may represent a task or an interrupt service routine of an embedded system, or a discretized part of a plant model.]_
+latexmath:[\begin{align*}
+x^C_d(k) &= f^C(x^C_d(k-1), u^C(k), t(k)) \\
+y^C_d(k) &= g^C(x^C_d(k), u^C(k), t(k))
+\end{align*}]
 
-Discrete-time variables computed in such a model partition are called <<clocked-variable,clocked variables>>.
+where:
 
-The value of a clocked variable can acquire a new value and can be queried only when its Clock is active, except during <<InitializationMode>>.
+. latexmath:[x^C_d] denotes the state vector
+. latexmath:[k] denotes the latexmath:[k]-th tick
+. latexmath:[f^C] denotes the state transition function
+. latexmath:[x^C_d(k-1)] denotes previous state vector
+. latexmath:[u^C] denotes input state vector
+. latexmath:[t] denotes the simulation time
+. latexmath:[y^C_d] denotes output vector
+. latexmath:[g^C] denotes the output function
+
+_[Such a model partition may represent a task or an interrupt service routine of an embedded system, or a discretized part of a plant model.
+The name "model partition" refers to the fact that an model inside an FMU may declare multiple clocks, each with its own partition of the overall model.]_
+
+When latexmath:[C] is active (i.e., ticking) invoking the FMI functions `fmi3Get{VariableType}` on variables in the output vector latexmath:[y^C_d] will trigger the execution of the output function latexmath:[g^C] to compute such variables.
+When FMI function <<fmi3EvaluateDiscreteStates>> is invoked, the state vector latexmath:[x^C_d] is updated according to state transition function latexmath:[f^C].
+The discrete-time variables (latexmath:[x^C_d] and latexmath:[y^C_d]) are called <<clocked-variable,clocked variables>>.
+
+A clocked variable can acquire a new value and can be queried only when its Clock is active, except during <<InitializationMode>>.
 _[This is common in clock semantics. See, e.g., <<MLS12>>.]_
 During <<InitializationMode>>, if a clocked variable is declared as an <<InitialUnknown>>, then it must be initialized as a discrete variable.
 Declaring a clocked variable as an <<InitialUnknown>> is optional.
 Uninitialized clocked variables must be initialized in the corresponding Clock's first tick.
 
-A <<ClockedState>> is a clocked variable whose value depends on its previous value (i.e., the value computed at the last clock tick).
+A <<ClockedState>> is a clocked variable belonging to the state vector latexmath:[x^C_d], whose value depends on its previous value (i.e., the value computed at the last clock tick).
 Clocked states declare the <<valueReference>> of their previous variable using the <<previous>> attribute.
 
 The association between <<clocked-variable,clocked variables>> and their <<Clock,Clocks>> is defined by the attribute <<clocks>>.

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -482,7 +482,7 @@ a|
 a|
 * Activate output clocks and respective model partitions in latexmath:[\mathbf{f}_{\mathit{event}}] +
 * Deactivate respective model partitions for the evaluation of discrete states +
-* latexmath:[(\mathbf{y}_{c+d}, \mathbf{\dot{x}}_c, \mathbf{x}_{c+d}, \mathbf{z}, \mathbf{r}, \mathbf{w}_{c+d}, \mathbf{b}, \mathbf{T}_{\mathit{next}}) := \mathbf{f}_{\mathit{event}}({}^\bullet\mathbf{x}_{c+d}, \mathbf{x}_{d}, \mathbf{u}_{c+d}, \mathbf{p}, {}^\bullet\mathbf{b}, \mathbf{t})]
+* latexmath:[(\mathbf{y}_{c+d}, \mathbf{\dot{x}}_c, \mathbf{x}_{c}, \mathbf{z}, \mathbf{r}, \mathbf{w}_{c+d}, \mathbf{b}, \mathbf{T}_{\mathit{next}}) := \mathbf{f}_{\mathit{event}}({}^\bullet\mathbf{x}_{c+d}, \mathbf{x}_{d}, \mathbf{u}_{c+d}, \mathbf{p}, {}^\bullet\mathbf{b}, \mathbf{t})]
 |<<get-and-set-variable-values,`fmi3Get{VariableType}`>>, +
 <<fmi3GetContinuousStateDerivatives>>, +
 <<fmi3GetContinuousStates>>, +

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -468,20 +468,19 @@ There are multiple kinds of events that require a transition to <<EventMode>>:
 |<<get-and-set-variable-values,`fmi3Set{VariableType}`>>
 
 a|
-* Activate clocks and respective model partitions in latexmath:[\mathbf{f}_{\mathit{event}}]
+* Activate clocks and output equations of the respective model partitions
 * Deactivate clocks and
   - Reset respective clocked variables to their previous values: latexmath:[\mathbf{v}_{\mathit{k}} := {}^\bullet\mathbf{v}_{\mathit{k}}]
   - Deactivate respective model partitions in latexmath:[\mathbf{f}_{\mathit{event}}]
 |<<fmi3SetClockEM>>
 
 a|
-* Activate output clocks and respective model partitions for the evaluation of discrete states in latexmath:[\mathbf{f}_{\mathit{disc}}] +
+* Execute state transition function of the model partitions of the active clocks +
 * latexmath:[(\mathbf{x}_{d}) := \mathbf{f}_{\mathit{disc}}({}^\bullet\mathbf{x}_{c+d}, \mathbf{u}_{c+d}, \mathbf{p}, {}^\bullet\mathbf{b}, \mathbf{t})]
 |<<fmi3EvaluateDiscreteStates>>
 
 a|
-* Activate output clocks and respective model partitions in latexmath:[\mathbf{f}_{\mathit{event}}] +
-* Deactivate respective model partitions for the evaluation of discrete states +
+* Executes output equations of models partitions of active clock. +
 * latexmath:[(\mathbf{y}_{c+d}, \mathbf{\dot{x}}_c, \mathbf{x}_{c}, \mathbf{z}, \mathbf{r}, \mathbf{w}_{c+d}, \mathbf{b}, \mathbf{T}_{\mathit{next}}) := \mathbf{f}_{\mathit{event}}({}^\bullet\mathbf{x}_{c+d}, \mathbf{x}_{d}, \mathbf{u}_{c+d}, \mathbf{p}, {}^\bullet\mathbf{b}, \mathbf{t})]
 |<<get-and-set-variable-values,`fmi3Get{VariableType}`>>, +
 <<fmi3GetContinuousStateDerivatives>>, +
@@ -489,11 +488,12 @@ a|
 <<fmi3GetEventIndicators>> +
 
 a|
-* Evaluate latexmath:[\mathbf{f}_{\mathit{disc}}], if no `fmi3EvaluateDiscreteStates` function was called in this instant of super-dense time
+* Signals end of super-dense time instant.
+* Evaluate latexmath:[\mathbf{f}_{\mathit{disc}}], if no <<fmi3EvaluateDiscreteStates>> function was called in this instant of super-dense time.
 * latexmath:[(\mathbf{T}_\mathit{interval}) := \mathbf{f}_{\mathit{update}}({}^\bullet\mathbf{x}_{c+d}, \mathbf{u}_{c+d}, \mathbf{p}, {}^\bullet\mathbf{b}, \mathbf{t})]
 * Update previous values of discrete states: latexmath:[{}^\bullet\mathbf{x}_d:=\mathbf{x}_d]
 * Update previous values of <<buffers>>: latexmath:[{}^\bullet\mathbf{b}:=\mathbf{b}]
-* Deactivate active clocks and respective model partitions in latexmath:[\mathbf{f}_{\mathit{event}}]
+* Deactivate active clocks and respective model partitions
 * Increment super-dense time: latexmath:[\mathbf{t}:=(\mathbf{t}_\mathit{R}, \mathbf{t}_\mathit{I} + 1)]
 |<<fmi3UpdateDiscreteStates>>
 

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -325,6 +325,7 @@ a|
 * Deactivate initialization equations latexmath:[\mathbf{f}_{\mathit{init}}]
 * Update previous values of <<buffers>>: latexmath:[{}^\bullet\mathbf{b}:=\mathbf{b}]
 * Model Exchange:
+  - Activate discrete state equations latexmath:[\mathbf{f}_{\mathit{disc}}]
   - Activate event equations latexmath:[\mathbf{f}_{\mathit{event}}]
   - latexmath:[\mathbf{t}:=(\mathbf{t}_{\mathit{start}}, 0)]
 
@@ -468,32 +469,35 @@ There are multiple kinds of events that require a transition to <<EventMode>>:
 |<<get-and-set-variable-values,`fmi3Set{VariableType}`>>
 
 a|
-* Activate clocks and respective model partitions in latexmath:[\mathbf{f}_{\mathit{event}}]
-* Deactivate clocks and
+* `fmi3Active`: Activate clocks and respective model partitions in latexmath:[\mathbf{f}_{\mathit{disc}}] and latexmath:[\mathbf{f}_{\mathit{event}}]
+* `fmi3Subctive`: Activate clocks and respective model partitions only in latexmath:[\mathbf{f}_{\mathit{event}}]
+* `fmi3Inactive`: Deactivate clocks and
   - Reset respective clocked variables to their previous values: latexmath:[\mathbf{v}_{\mathit{k}} := {}^\bullet\mathbf{v}_{\mathit{k}}]
-  - Deactivate respective model partitions in latexmath:[\mathbf{f}_{\mathit{event}}]
+  - Deactivate respective model partitions in latexmath:[\mathbf{f}_{\mathit{disc}}] and latexmath:[\mathbf{f}_{\mathit{event}}]
 |<<fmi3SetClockEM>>
 
 a|
-* Activate output clocks and respective model partitions in latexmath:[\mathbf{f}_{\mathit{event}}] +
-* latexmath:[(\mathbf{y}_{c+d}, \mathbf{\dot{x}}_c, \mathbf{x}_{c+d}, \mathbf{z}, \mathbf{r}, \mathbf{w}_{c+d}, \mathbf{b}, \mathbf{T}_{\mathit{next}}) := \mathbf{f}_{\mathit{event}}({}^\bullet\mathbf{x}_{c+d}, \mathbf{u}_{c+d}, \mathbf{p}, {}^\bullet\mathbf{b}, \mathbf{t})]
+* Activate output clocks and respective model partitions in latexmath:[\mathbf{f}_{\mathit{disc}}] and latexmath:[\mathbf{f}_{\mathit{event}}] +
+* latexmath:[(\mathbf{x}_{d}) := \mathbf{f}_{\mathit{disc}}({}^\bullet\mathbf{x}_{c+d}, \mathbf{u}_{c+d}, \mathbf{p}, {}^\bullet\mathbf{b}, \mathbf{t})]
+* latexmath:[(\mathbf{y}_{c+d}, \mathbf{\dot{x}}_c, \mathbf{x}_{c}, \mathbf{z}, \mathbf{r}, \mathbf{w}_{c+d}, \mathbf{b}, \mathbf{T}_{\mathit{next}}) := \mathbf{f}_{\mathit{event}}({}^\bullet\mathbf{x}_{c}, \mathbf{x}_{d}, \mathbf{u}_{c+d}, \mathbf{p}, {}^\bullet\mathbf{b}, \mathbf{t})]
 |<<get-and-set-variable-values,`fmi3Get{VariableType}`>>, +
 <<fmi3GetContinuousStateDerivatives>>, +
 <<fmi3GetContinuousStates>>, +
 <<fmi3GetEventIndicators>> +
 
 a|
-* Evaluate latexmath:[\mathbf{f}_{\mathit{event}}], if no `fmi3GetXXX` function was called in this instant of super-dense time
+* Evaluate latexmath:[\mathbf{f}_{\mathit{disc}}] and latexmath:[\mathbf{f}_{\mathit{event}}], if no `fmi3GetXXX` function was called in this instant of super-dense time
 * latexmath:[(\mathbf{T}_\mathit{interval}) := \mathbf{f}_{\mathit{update}}({}^\bullet\mathbf{x}_{c+d}, \mathbf{u}_{c+d}, \mathbf{p}, {}^\bullet\mathbf{b}, \mathbf{t})]
 * Update previous values of discrete states: latexmath:[{}^\bullet\mathbf{x}_d:=\mathbf{x}_d]
 * Update previous values of <<buffers>>: latexmath:[{}^\bullet\mathbf{b}:=\mathbf{b}]
-* Deactivate active clocks and respective model partitions in latexmath:[\mathbf{f}_{\mathit{event}}]
+* Deactivate active clocks and respective model partitions in latexmath:[\mathbf{f}_{\mathit{disc}}] and latexmath:[\mathbf{f}_{\mathit{event}}]
 * Increment super-dense time: latexmath:[\mathbf{t}:=(\mathbf{t}_\mathit{R}, \mathbf{t}_\mathit{I} + 1)]
 |<<fmi3UpdateDiscreteStates>>
 
 a|
 * [[updateRelations]]Update previous values of <<relations>>: latexmath:[{}^\bullet\mathbf{r}:=\mathbf{r}]
 * Deactivate event equations latexmath:[\mathbf{f}_\mathit{event}]
+* Deactivate discrete state equations latexmath:[\mathbf{f}_{\mathit{disc}}]
 * Model Exchange: Activate continuous-time equations latexmath:[\mathbf{f}_\mathit{cont}]
 
 |<<fmi3EnterContinuousTimeMode>>,
@@ -511,7 +515,7 @@ Getting variables might trigger <<selectiv-computation,computations>>.
 
 [[fmi3SetClockEM,`fmi3SetClock`]]
 Function <<fmi3SetClock>>::
-For <<inputClock,`input Clocks`>>, <<fmi3SetClock>> is called to set the activation status of <<Clock,`Clocks`>> to `fmi3ClockActive` or `fmi3ClockInactive`.
+For <<inputClock,`input Clocks`>>, <<fmi3SetClock>> is called to set the activation status of <<Clock,`Clocks`>> to `fmi3ClockActive`, `fmi3ClockInactive` or `fmi3ClockSubactive`.
 During the solution of algebraic loops, the activation condition of triggered input clocks may change and therefore <<fmi3SetClock>> can be called multiple times per super-dense time instant.
 When a Clock is deactivated, the FMU must reset all clocked states of this Clock to the values computed during the last <<fmi3UpdateDiscreteStates>> when this Clock was active (latexmath:[{}^\bullet\mathbf{v}_{\mathit{k}}]). +
 _[Rationale: a triggered output Clock latexmath:[c] may depend on some variable latexmath:[v] that is involved in an algebraic loop._
@@ -809,7 +813,7 @@ Function <<fmi3GetClock>>::
 The scheduling algorithm uses <<fmi3GetClock>> to determine which clock is active. +
 _[For efficiency, <<fmi3GetClock>> should only be called if <<clocksTicked, `clocksTicked == fmi3True`>>.]_ +
 Depending on the clock activation state, the scheduling algorithm can call <<get-and-set-variable-values,`fmi3Set{VariableType}`>> and <<get-and-set-variable-values,`fmi3Get{VariableType}`>> for variables associated with the corresponding <<Clock>>.
-For an <<outputClock>> only the first call of `fmi3GetClock` for a specific activation of this <<Clock>> signals `fmi3ClockActive`.
+For an <<outputClock>> only the first call of `fmi3GetClock` for a specific activation of this <<Clock>> signals `fmi3ClockActive` or `fmi3ClockSubactive`.
 The FMU sets the reported activation state immediately back to `fmi3ClockInactive` for following `fmi3GetClock` calls for that <<Clock>> until this <<outputClock>> is activated again.
 
 Functions <<fmi3GetIntervalDecimal>> & <<fmi3GetIntervalFraction>>::

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -325,7 +325,6 @@ a|
 * Deactivate initialization equations latexmath:[\mathbf{f}_{\mathit{init}}]
 * Update previous values of <<buffers>>: latexmath:[{}^\bullet\mathbf{b}:=\mathbf{b}]
 * Model Exchange:
-  - Activate discrete state equations latexmath:[\mathbf{f}_{\mathit{disc}}]
   - Activate event equations latexmath:[\mathbf{f}_{\mathit{event}}]
   - latexmath:[\mathbf{t}:=(\mathbf{t}_{\mathit{start}}, 0)]
 
@@ -469,35 +468,38 @@ There are multiple kinds of events that require a transition to <<EventMode>>:
 |<<get-and-set-variable-values,`fmi3Set{VariableType}`>>
 
 a|
-* `fmi3Active`: Activate clocks and respective model partitions in latexmath:[\mathbf{f}_{\mathit{disc}}] and latexmath:[\mathbf{f}_{\mathit{event}}]
-* `fmi3Subctive`: Activate clocks and respective model partitions only in latexmath:[\mathbf{f}_{\mathit{event}}]
-* `fmi3Inactive`: Deactivate clocks and
+* Activate clocks and respective model partitions in latexmath:[\mathbf{f}_{\mathit{event}}]
+* Deactivate clocks and
   - Reset respective clocked variables to their previous values: latexmath:[\mathbf{v}_{\mathit{k}} := {}^\bullet\mathbf{v}_{\mathit{k}}]
-  - Deactivate respective model partitions in latexmath:[\mathbf{f}_{\mathit{disc}}] and latexmath:[\mathbf{f}_{\mathit{event}}]
+  - Deactivate respective model partitions in latexmath:[\mathbf{f}_{\mathit{event}}]
 |<<fmi3SetClockEM>>
 
 a|
-* Activate output clocks and respective model partitions in latexmath:[\mathbf{f}_{\mathit{disc}}] and latexmath:[\mathbf{f}_{\mathit{event}}] +
+* Activate output clocks and respective model partitions for the evaluation of discrete states in latexmath:[\mathbf{f}_{\mathit{disc}}] +
 * latexmath:[(\mathbf{x}_{d}) := \mathbf{f}_{\mathit{disc}}({}^\bullet\mathbf{x}_{c+d}, \mathbf{u}_{c+d}, \mathbf{p}, {}^\bullet\mathbf{b}, \mathbf{t})]
-* latexmath:[(\mathbf{y}_{c+d}, \mathbf{\dot{x}}_c, \mathbf{x}_{c}, \mathbf{z}, \mathbf{r}, \mathbf{w}_{c+d}, \mathbf{b}, \mathbf{T}_{\mathit{next}}) := \mathbf{f}_{\mathit{event}}({}^\bullet\mathbf{x}_{c}, \mathbf{x}_{d}, \mathbf{u}_{c+d}, \mathbf{p}, {}^\bullet\mathbf{b}, \mathbf{t})]
+|<<fmi3EvaluateDiscreteStates>>
+
+a|
+* Activate output clocks and respective model partitions in latexmath:[\mathbf{f}_{\mathit{event}}] +
+* Deactivate respective model partitions for the evaluation of discrete states +
+* latexmath:[(\mathbf{y}_{c+d}, \mathbf{\dot{x}}_c, \mathbf{x}_{c+d}, \mathbf{z}, \mathbf{r}, \mathbf{w}_{c+d}, \mathbf{b}, \mathbf{T}_{\mathit{next}}) := \mathbf{f}_{\mathit{event}}({}^\bullet\mathbf{x}_{c+d}, \mathbf{x}_{d}, \mathbf{u}_{c+d}, \mathbf{p}, {}^\bullet\mathbf{b}, \mathbf{t})]
 |<<get-and-set-variable-values,`fmi3Get{VariableType}`>>, +
 <<fmi3GetContinuousStateDerivatives>>, +
 <<fmi3GetContinuousStates>>, +
 <<fmi3GetEventIndicators>> +
 
 a|
-* Evaluate latexmath:[\mathbf{f}_{\mathit{disc}}] and latexmath:[\mathbf{f}_{\mathit{event}}], if no `fmi3GetXXX` function was called in this instant of super-dense time
+* Evaluate latexmath:[\mathbf{f}_{\mathit{disc}}], if no `fmi3EvaluateDiscreteStates` function was called in this instant of super-dense time
 * latexmath:[(\mathbf{T}_\mathit{interval}) := \mathbf{f}_{\mathit{update}}({}^\bullet\mathbf{x}_{c+d}, \mathbf{u}_{c+d}, \mathbf{p}, {}^\bullet\mathbf{b}, \mathbf{t})]
 * Update previous values of discrete states: latexmath:[{}^\bullet\mathbf{x}_d:=\mathbf{x}_d]
 * Update previous values of <<buffers>>: latexmath:[{}^\bullet\mathbf{b}:=\mathbf{b}]
-* Deactivate active clocks and respective model partitions in latexmath:[\mathbf{f}_{\mathit{disc}}] and latexmath:[\mathbf{f}_{\mathit{event}}]
+* Deactivate active clocks and respective model partitions in latexmath:[\mathbf{f}_{\mathit{event}}]
 * Increment super-dense time: latexmath:[\mathbf{t}:=(\mathbf{t}_\mathit{R}, \mathbf{t}_\mathit{I} + 1)]
 |<<fmi3UpdateDiscreteStates>>
 
 a|
 * [[updateRelations]]Update previous values of <<relations>>: latexmath:[{}^\bullet\mathbf{r}:=\mathbf{r}]
 * Deactivate event equations latexmath:[\mathbf{f}_\mathit{event}]
-* Deactivate discrete state equations latexmath:[\mathbf{f}_{\mathit{disc}}]
 * Model Exchange: Activate continuous-time equations latexmath:[\mathbf{f}_\mathit{cont}]
 
 |<<fmi3EnterContinuousTimeMode>>,
@@ -515,7 +517,7 @@ Getting variables might trigger <<selectiv-computation,computations>>.
 
 [[fmi3SetClockEM,`fmi3SetClock`]]
 Function <<fmi3SetClock>>::
-For <<inputClock,`input Clocks`>>, <<fmi3SetClock>> is called to set the activation status of <<Clock,`Clocks`>> to `fmi3ClockActive`, `fmi3ClockInactive` or `fmi3ClockSubactive`.
+For <<inputClock,`input Clocks`>>, <<fmi3SetClock>> is called to set the activation status of <<Clock,`Clocks`>> to `fmi3ClockActive` or `fmi3ClockInactive`.
 During the solution of algebraic loops, the activation condition of triggered input clocks may change and therefore <<fmi3SetClock>> can be called multiple times per super-dense time instant.
 When a Clock is deactivated, the FMU must reset all clocked states of this Clock to the values computed during the last <<fmi3UpdateDiscreteStates>> when this Clock was active (latexmath:[{}^\bullet\mathbf{v}_{\mathit{k}}]). +
 _[Rationale: a triggered output Clock latexmath:[c] may depend on some variable latexmath:[v] that is involved in an algebraic loop._
@@ -552,6 +554,15 @@ Function <<fmi3GetEventIndicators>>::
 Function <<fmi3GetNumberOfContinuousStates>>::
 Function <<fmi3GetNumberOfEventIndicators>>::
 Can only be called in Model Exchange.
+
+Function <<fmi3EvaluateDiscreteStates>>::
+Evaluate latexmath:[\mathbf{f}_{\mathit{disc}}] to obtain current values of discrete states from previous values.
++
+[[fmi3EvaluateDiscreteStates,`fmi3EvaluateDiscreteStates`]]
+[source, C]
+----
+include::../headers/fmi3FunctionTypes.h[tag=EvaluateDiscreteStates]
+----
 
 Function <<fmi3UpdateDiscreteStates>>::
 When the importer converges on a solution for event handling at the current super-dense time step it calls <<fmi3UpdateDiscreteStates>> to determine if another event iteration is required (introducing a new super-dense time instant) or <<EventMode>> can be exited.
@@ -813,7 +824,7 @@ Function <<fmi3GetClock>>::
 The scheduling algorithm uses <<fmi3GetClock>> to determine which clock is active. +
 _[For efficiency, <<fmi3GetClock>> should only be called if <<clocksTicked, `clocksTicked == fmi3True`>>.]_ +
 Depending on the clock activation state, the scheduling algorithm can call <<get-and-set-variable-values,`fmi3Set{VariableType}`>> and <<get-and-set-variable-values,`fmi3Get{VariableType}`>> for variables associated with the corresponding <<Clock>>.
-For an <<outputClock>> only the first call of `fmi3GetClock` for a specific activation of this <<Clock>> signals `fmi3ClockActive` or `fmi3ClockSubactive`.
+For an <<outputClock>> only the first call of `fmi3GetClock` for a specific activation of this <<Clock>> signals `fmi3ClockActive`.
 The FMU sets the reported activation state immediately back to `fmi3ClockInactive` for following `fmi3GetClock` calls for that <<Clock>> until this <<outputClock>> is activated again.
 
 Functions <<fmi3GetIntervalDecimal>> & <<fmi3GetIntervalFraction>>::

--- a/headers/fmi3FunctionTypes.h
+++ b/headers/fmi3FunctionTypes.h
@@ -514,6 +514,10 @@ typedef fmi3Status fmi3SetIntervalFractionTYPE(fmi3Instance instance,
                                                size_t nIntervals);
 /* end::SetIntervalFraction[] */
 
+/* tag::EvaluateDiscreteStates[] */
+typedef fmi3Status fmi3EvaluateDiscreteStatesTYPE();
+/* end::EvaluateDiscreteStates[] */
+
 /* tag::UpdateDiscreteStates[] */
 typedef fmi3Status fmi3UpdateDiscreteStatesTYPE(fmi3Instance instance,
                                                 fmi3Boolean* discreteStatesNeedUpdate,

--- a/headers/fmi3PlatformTypes.h
+++ b/headers/fmi3PlatformTypes.h
@@ -77,16 +77,17 @@ typedef         uint8_t fmi3Byte;     /* Smallest addressable unit of the machin
                                          (typically one byte) */
 typedef const fmi3Byte* fmi3Binary;   /* Data type for binary data
                                          (out-of-band length terminated) */
-typedef            bool fmi3Clock;    /* Data type to be used with fmi3ClockActive and
-                                         fmi3ClockInactive */
+typedef             int fmi3Clock;    /* Data type to be used with fmi3ClockActive,
+                                         fmi3ClockInactive and fmi3ClockSubactive*/
 
 /* Values for fmi3Boolean */
 #define fmi3True  true
 #define fmi3False false
 
 /* Values for fmi3Clock */
-#define fmi3ClockActive   true
-#define fmi3ClockInactive false
+#define fmi3ClockInactive  0
+#define fmi3ClockActive    1
+#define fmi3ClockSubactive 2
 /* end::VariableTypes[] */
 
 #endif /* fmi3PlatformTypes_h */

--- a/headers/fmi3PlatformTypes.h
+++ b/headers/fmi3PlatformTypes.h
@@ -77,17 +77,16 @@ typedef         uint8_t fmi3Byte;     /* Smallest addressable unit of the machin
                                          (typically one byte) */
 typedef const fmi3Byte* fmi3Binary;   /* Data type for binary data
                                          (out-of-band length terminated) */
-typedef             int fmi3Clock;    /* Data type to be used with fmi3ClockActive,
-                                         fmi3ClockInactive and fmi3ClockSubactive*/
+typedef            bool fmi3Clock;    /* Data type to be used with fmi3ClockActive and
+                                         fmi3ClockInactive */
 
 /* Values for fmi3Boolean */
 #define fmi3True  true
 #define fmi3False false
 
 /* Values for fmi3Clock */
-#define fmi3ClockInactive  0
-#define fmi3ClockActive    1
-#define fmi3ClockSubactive 2
+#define fmi3ClockActive   true
+#define fmi3ClockInactive false
 /* end::VariableTypes[] */
 
 #endif /* fmi3PlatformTypes_h */


### PR DESCRIPTION
This shall resolve issue #1450.
It enables the evaluation of output equations f_event independently
from state equations f_state with the fmi3Clock value fmi3ClockSubactive.
This is particularly needed for model exchange.
