### PR TITLE
Build configuration compiler

### DIFF
--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -108,6 +108,9 @@ If a <<BuildConfiguration>> without a <<platform>> attribute is provided this is
 
 |`description`
 |Description of the build configuration
+
+|`compiler`
+|The compiler to compile the sources (e.g. `VisualC`, `gcc`, `clang++`)
 |====
 
 ====== SourceFileSet
@@ -128,9 +131,6 @@ An importer of the FMU has to regard every `<SourceFileSet>` of the matching <<B
 
 |`language`
 |Language of the source files (e.g. `C99`, `C++11`)
-
-|`compiler`
-|The compiler to compile the sources (e.g. `VisualC`, `gcc`, `clang++`)
 
 |`compilerOptions`
 |The compiler flags that have to be used when compiling the sources (e.g. `-fno-rtti`, `/Od`)

--- a/docs/examples/build_description_complex.xml
+++ b/docs/examples/build_description_complex.xml
@@ -21,11 +21,11 @@
     <Library name="hdf5" version="&gt;=1.8,!=1.8.17,&lt;1.10" external="true" description="HDF5"/>
   </BuildConfiguration>
 
-  <BuildConfiguration modelIdentifier="PlantModel" platform="aarch64-linux">
+  <BuildConfiguration modelIdentifier="PlantModel" platform="aarch64-linux" compiler="clang++">
     <SourceFileSet language="C99">
       <SourceFile name="fmi3Functions.c"/>
     </SourceFileSet>
-    <SourceFileSet language="C++11" compiler="clang++" compilerOptions="-fno-rtti">
+    <SourceFileSet language="C++11" compilerOptions="-fno-rtti">
       <SourceFile name="model.c"/>
       <PreprocessorDefinition name="NO_FILE_SYSTEM"/>
     </SourceFileSet>

--- a/schema/fmi3BuildDescription.xsd
+++ b/schema/fmi3BuildDescription.xsd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
-	<xs:include schemaLocation="fmi3Annotation.xsd"/>
-	<xs:annotation>
-		<xs:documentation>
+    <xs:include schemaLocation="fmi3Annotation.xsd"/>
+    <xs:annotation>
+        <xs:documentation>
 Copyright(c) 2008-2011 MODELISAR consortium,
              2012-2021 Modelica Association Project "FMI".
              All rights reserved.
@@ -34,84 +34,84 @@ OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------------
 		</xs:documentation>
-	</xs:annotation>
-	<xs:element name="fmiBuildDescription">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="BuildConfiguration" maxOccurs="unbounded">
-					<xs:complexType>
-						<xs:sequence>
-							<xs:element name="SourceFileSet" minOccurs="0" maxOccurs="unbounded">
-								<xs:complexType>
-									<xs:sequence>
-										<xs:element name="SourceFile" maxOccurs="unbounded">
-											<xs:complexType>
-												<xs:sequence>
-													<xs:element ref="Annotations" minOccurs="0"/>
-												</xs:sequence>
-												<xs:attribute name="name" type="xs:normalizedString" use="required"/>
-											</xs:complexType>
-										</xs:element>
-										<xs:element name="PreprocessorDefinition" minOccurs="0" maxOccurs="unbounded">
-											<xs:complexType>
-												<xs:sequence>
-													<xs:element name="Option" minOccurs="0" maxOccurs="unbounded">
-														<xs:complexType>
-															<xs:attribute name="value" type="xs:normalizedString"/>
-															<xs:attribute name="description" type="xs:string"/>
-														</xs:complexType>
-													</xs:element>
-													<xs:element ref="Annotations" minOccurs="0"/>
-												</xs:sequence>
-												<xs:attribute name="name" type="xs:normalizedString" use="required"/>
-												<xs:attribute name="optional" type="xs:boolean" default="false"/>
-												<xs:attribute name="value" type="xs:normalizedString"/>
-												<xs:attribute name="description" type="xs:string"/>
-											</xs:complexType>
-										</xs:element>
-										<xs:element name="IncludeDirectory" minOccurs="0" maxOccurs="unbounded">
-											<xs:complexType>
-												<xs:sequence>
-													<xs:element ref="Annotations" minOccurs="0"/>
-												</xs:sequence>
-												<xs:attribute name="name" type="xs:normalizedString" use="required"/>
-											</xs:complexType>
-										</xs:element>
-										<xs:element ref="Annotations" minOccurs="0"/>
-									</xs:sequence>
-									<xs:attribute name="name" type="xs:normalizedString"/>
-									<xs:attribute name="language" type="xs:normalizedString"/>
-									<xs:attribute name="compiler" type="xs:normalizedString"/>
-									<xs:attribute name="compilerOptions" type="xs:string"/>
-								</xs:complexType>
-							</xs:element>
-							<xs:element name="Library" minOccurs="0" maxOccurs="unbounded">
-								<xs:complexType>
-									<xs:sequence>
-										<xs:element ref="Annotations" minOccurs="0"/>
-									</xs:sequence>
-									<xs:attribute name="name" type="xs:normalizedString" use="required"/>
-									<xs:attribute name="version" type="xs:normalizedString"/>
-									<xs:attribute name="external" type="xs:boolean" default="false"/>
-									<xs:attribute name="description" type="xs:string"/>
-								</xs:complexType>
-							</xs:element>
-							<xs:element ref="Annotations" minOccurs="0"/>
-						</xs:sequence>
-						<xs:attribute name="modelIdentifier" type="xs:normalizedString" use="required"/>
-						<xs:attribute name="platform" type="xs:normalizedString"/>
-						<xs:attribute name="description" type="xs:string"/>
-					</xs:complexType>
-				</xs:element>
-				<xs:element ref="Annotations" minOccurs="0"/>
-			</xs:sequence>
-			<xs:attribute name="fmiVersion" use="required">
-				<xs:simpleType>
-					<xs:restriction base="xs:normalizedString">
-						<xs:pattern value="3[.](0-.*)"/>
-					</xs:restriction>
-				</xs:simpleType>
-			</xs:attribute>
-		</xs:complexType>
-	</xs:element>
+    </xs:annotation>
+    <xs:element name="fmiBuildDescription">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="BuildConfiguration" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="SourceFileSet" minOccurs="0" maxOccurs="unbounded">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="SourceFile" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                                <xs:sequence>
+                                                    <xs:element ref="Annotations" minOccurs="0"/>
+                                                </xs:sequence>
+                                                <xs:attribute name="name" type="xs:normalizedString" use="required"/>
+                                            </xs:complexType>
+                                        </xs:element>
+                                        <xs:element name="PreprocessorDefinition" minOccurs="0" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                                <xs:sequence>
+                                                    <xs:element name="Option" minOccurs="0" maxOccurs="unbounded">
+                                                        <xs:complexType>
+                                                            <xs:attribute name="value" type="xs:normalizedString"/>
+                                                            <xs:attribute name="description" type="xs:string"/>
+                                                        </xs:complexType>
+                                                    </xs:element>
+                                                    <xs:element ref="Annotations" minOccurs="0"/>
+                                                </xs:sequence>
+                                                <xs:attribute name="name" type="xs:normalizedString" use="required"/>
+                                                <xs:attribute name="optional" type="xs:boolean" default="false"/>
+                                                <xs:attribute name="value" type="xs:normalizedString"/>
+                                                <xs:attribute name="description" type="xs:string"/>
+                                            </xs:complexType>
+                                        </xs:element>
+                                        <xs:element name="IncludeDirectory" minOccurs="0" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                                <xs:sequence>
+                                                    <xs:element ref="Annotations" minOccurs="0"/>
+                                                </xs:sequence>
+                                                <xs:attribute name="name" type="xs:normalizedString" use="required"/>
+                                            </xs:complexType>
+                                        </xs:element>
+                                        <xs:element ref="Annotations" minOccurs="0"/>
+                                    </xs:sequence>
+                                    <xs:attribute name="name" type="xs:normalizedString"/>
+                                    <xs:attribute name="language" type="xs:normalizedString"/>
+                                    <xs:attribute name="compilerOptions" type="xs:string"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="Library" minOccurs="0" maxOccurs="unbounded">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element ref="Annotations" minOccurs="0"/>
+                                    </xs:sequence>
+                                    <xs:attribute name="name" type="xs:normalizedString" use="required"/>
+                                    <xs:attribute name="version" type="xs:normalizedString"/>
+                                    <xs:attribute name="external" type="xs:boolean" default="false"/>
+                                    <xs:attribute name="description" type="xs:string"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element ref="Annotations" minOccurs="0"/>
+                        </xs:sequence>
+                        <xs:attribute name="modelIdentifier" type="xs:normalizedString" use="required"/>
+                        <xs:attribute name="platform" type="xs:normalizedString"/>
+                        <xs:attribute name="description" type="xs:string"/>
+                        <xs:attribute name="compiler" type="xs:normalizedString"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element ref="Annotations" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="fmiVersion" use="required">
+                <xs:simpleType>
+                    <xs:restriction base="xs:normalizedString">
+                        <xs:pattern value="3[.](0-.*)"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
 </xs:schema>

--- a/schema/fmi3BuildDescription.xsd
+++ b/schema/fmi3BuildDescription.xsd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
-    <xs:include schemaLocation="fmi3Annotation.xsd"/>
-    <xs:annotation>
-        <xs:documentation>
+	<xs:include schemaLocation="fmi3Annotation.xsd"/>
+	<xs:annotation>
+		<xs:documentation>
 Copyright(c) 2008-2011 MODELISAR consortium,
              2012-2021 Modelica Association Project "FMI".
              All rights reserved.
@@ -34,84 +34,84 @@ OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------------
 		</xs:documentation>
-    </xs:annotation>
-    <xs:element name="fmiBuildDescription">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="BuildConfiguration" maxOccurs="unbounded">
-                    <xs:complexType>
-                        <xs:sequence>
-                            <xs:element name="SourceFileSet" minOccurs="0" maxOccurs="unbounded">
-                                <xs:complexType>
-                                    <xs:sequence>
-                                        <xs:element name="SourceFile" maxOccurs="unbounded">
-                                            <xs:complexType>
-                                                <xs:sequence>
-                                                    <xs:element ref="Annotations" minOccurs="0"/>
-                                                </xs:sequence>
-                                                <xs:attribute name="name" type="xs:normalizedString" use="required"/>
-                                            </xs:complexType>
-                                        </xs:element>
-                                        <xs:element name="PreprocessorDefinition" minOccurs="0" maxOccurs="unbounded">
-                                            <xs:complexType>
-                                                <xs:sequence>
-                                                    <xs:element name="Option" minOccurs="0" maxOccurs="unbounded">
-                                                        <xs:complexType>
-                                                            <xs:attribute name="value" type="xs:normalizedString"/>
-                                                            <xs:attribute name="description" type="xs:string"/>
-                                                        </xs:complexType>
-                                                    </xs:element>
-                                                    <xs:element ref="Annotations" minOccurs="0"/>
-                                                </xs:sequence>
-                                                <xs:attribute name="name" type="xs:normalizedString" use="required"/>
-                                                <xs:attribute name="optional" type="xs:boolean" default="false"/>
-                                                <xs:attribute name="value" type="xs:normalizedString"/>
-                                                <xs:attribute name="description" type="xs:string"/>
-                                            </xs:complexType>
-                                        </xs:element>
-                                        <xs:element name="IncludeDirectory" minOccurs="0" maxOccurs="unbounded">
-                                            <xs:complexType>
-                                                <xs:sequence>
-                                                    <xs:element ref="Annotations" minOccurs="0"/>
-                                                </xs:sequence>
-                                                <xs:attribute name="name" type="xs:normalizedString" use="required"/>
-                                            </xs:complexType>
-                                        </xs:element>
-                                        <xs:element ref="Annotations" minOccurs="0"/>
-                                    </xs:sequence>
-                                    <xs:attribute name="name" type="xs:normalizedString"/>
-                                    <xs:attribute name="language" type="xs:normalizedString"/>
-                                    <xs:attribute name="compilerOptions" type="xs:string"/>
-                                </xs:complexType>
-                            </xs:element>
-                            <xs:element name="Library" minOccurs="0" maxOccurs="unbounded">
-                                <xs:complexType>
-                                    <xs:sequence>
-                                        <xs:element ref="Annotations" minOccurs="0"/>
-                                    </xs:sequence>
-                                    <xs:attribute name="name" type="xs:normalizedString" use="required"/>
-                                    <xs:attribute name="version" type="xs:normalizedString"/>
-                                    <xs:attribute name="external" type="xs:boolean" default="false"/>
-                                    <xs:attribute name="description" type="xs:string"/>
-                                </xs:complexType>
-                            </xs:element>
-                            <xs:element ref="Annotations" minOccurs="0"/>
-                        </xs:sequence>
-                        <xs:attribute name="modelIdentifier" type="xs:normalizedString" use="required"/>
-                        <xs:attribute name="platform" type="xs:normalizedString"/>
-                        <xs:attribute name="description" type="xs:string"/>
-                        <xs:attribute name="compiler" type="xs:normalizedString"/>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element ref="Annotations" minOccurs="0"/>
-            </xs:sequence>
-            <xs:attribute name="fmiVersion" use="required">
-                <xs:simpleType>
-                    <xs:restriction base="xs:normalizedString">
-                        <xs:pattern value="3[.](0-.*)"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:attribute>
-        </xs:complexType>
-    </xs:element>
+	</xs:annotation>
+	<xs:element name="fmiBuildDescription">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="BuildConfiguration" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="SourceFileSet" minOccurs="0" maxOccurs="unbounded">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="SourceFile" maxOccurs="unbounded">
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element ref="Annotations" minOccurs="0"/>
+												</xs:sequence>
+												<xs:attribute name="name" type="xs:normalizedString" use="required"/>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="PreprocessorDefinition" minOccurs="0" maxOccurs="unbounded">
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="Option" minOccurs="0" maxOccurs="unbounded">
+														<xs:complexType>
+															<xs:attribute name="value" type="xs:normalizedString"/>
+															<xs:attribute name="description" type="xs:string"/>
+														</xs:complexType>
+													</xs:element>
+													<xs:element ref="Annotations" minOccurs="0"/>
+												</xs:sequence>
+												<xs:attribute name="name" type="xs:normalizedString" use="required"/>
+												<xs:attribute name="optional" type="xs:boolean" default="false"/>
+												<xs:attribute name="value" type="xs:normalizedString"/>
+												<xs:attribute name="description" type="xs:string"/>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="IncludeDirectory" minOccurs="0" maxOccurs="unbounded">
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element ref="Annotations" minOccurs="0"/>
+												</xs:sequence>
+												<xs:attribute name="name" type="xs:normalizedString" use="required"/>
+											</xs:complexType>
+										</xs:element>
+										<xs:element ref="Annotations" minOccurs="0"/>
+									</xs:sequence>
+									<xs:attribute name="name" type="xs:normalizedString"/>
+									<xs:attribute name="language" type="xs:normalizedString"/>
+									<xs:attribute name="compilerOptions" type="xs:string"/>
+									<xs:attribute name="compiler" type="xs:normalizedString"/>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="Library" minOccurs="0" maxOccurs="unbounded">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element ref="Annotations" minOccurs="0"/>
+									</xs:sequence>
+									<xs:attribute name="name" type="xs:normalizedString" use="required"/>
+									<xs:attribute name="version" type="xs:normalizedString"/>
+									<xs:attribute name="external" type="xs:boolean" default="false"/>
+									<xs:attribute name="description" type="xs:string"/>
+								</xs:complexType>
+							</xs:element>
+							<xs:element ref="Annotations" minOccurs="0"/>
+						</xs:sequence>
+						<xs:attribute name="modelIdentifier" type="xs:normalizedString" use="required"/>
+						<xs:attribute name="platform" type="xs:normalizedString"/>
+						<xs:attribute name="description" type="xs:string"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="Annotations" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attribute name="fmiVersion" use="required">
+				<xs:simpleType>
+					<xs:restriction base="xs:normalizedString">
+						<xs:pattern value="3[.](0-.*)"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
 </xs:schema>

--- a/schema/fmi3BuildDescription.xsd
+++ b/schema/fmi3BuildDescription.xsd
@@ -82,7 +82,6 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 									<xs:attribute name="name" type="xs:normalizedString"/>
 									<xs:attribute name="language" type="xs:normalizedString"/>
 									<xs:attribute name="compilerOptions" type="xs:string"/>
-									<xs:attribute name="compiler" type="xs:normalizedString"/>
 								</xs:complexType>
 							</xs:element>
 							<xs:element name="Library" minOccurs="0" maxOccurs="unbounded">
@@ -101,6 +100,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 						<xs:attribute name="modelIdentifier" type="xs:normalizedString" use="required"/>
 						<xs:attribute name="platform" type="xs:normalizedString"/>
 						<xs:attribute name="description" type="xs:string"/>
+						<xs:attribute name="compiler" type="xs:normalizedString"/>
 					</xs:complexType>
 				</xs:element>
 				<xs:element ref="Annotations" minOccurs="0"/>


### PR DESCRIPTION
@andreas-junghanns  @t-sommer Why is compiler an attribute of SourceFileSet? I propose to move it one level up: I cannot imagine a BuildConfiguration should be able to contain sources to be built with several different compilers. Also a static library needs to provide information on the compiler that was used. 

This PR is somehow related to #1305 
FYI: @IZacharias 