### PR TITLE
Relax requirement for including dependencies

### DIFF
--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -25,36 +25,37 @@ Every FMU is distributed with its own ZIP file.
 [[figure-zip-structure]]
 ----
 // Structure of ZIP file of an FMU
-modelDescription.xml          // description of FMU (required file)
-documentation                 // directory containing the documentation (optional)
-   index.html                 // entry point of the documentation
-   diagram.png                // descriptive diagram view of the model (optional)
-   diagram.svg                // if existing the diagram.png is required (optional)
+modelDescription.xml                // description of FMU (required file)
+documentation                       // directory containing the documentation (optional)
+   index.html                       // entry point of the documentation
+   diagram.png                      // descriptive diagram view of the model (optional)
+   diagram.svg                      // if provided, diagram.png is also required (optional)
+   externalDependencies.{txt|html}  // required, if external resources are needed to load or simulate the FMU
    <other documentation files>
-   licenses                   // directory for licenses (optional)
-      license.{txt|html}      // Entry point for license information
-      <license files>         // For example BSD licenses
-icons                         // FMU and terminal icons (optional)
-   terminalsAndIcons.xml      // description of terminals and icons (optional)
-   icon.png                   // image file of icon without terminals (optional)
-   icon.svg                   // if existing the icon.png is required (optional)
-   // all terminal and fmu icons referenced in the graphical representation
-sources                       // directory containing the C sources (optional)
+   licenses                         // directory for licenses (optional)
+      license.{txt|html}            // entry point for license information
+      <license files>               // for example BSD licenses
+icons                               // FMU and terminal icons (optional)
+   terminalsAndIcons.xml            // description of terminals and icons (optional)
+   icon.png                         // image file of icon without terminals (optional)
+   icon.svg                         // if existing the icon.png is required (optional)
+                                    // all terminal and fmu icons referenced in the graphical representation
+sources                             // directory containing the C sources (optional)
    buildDescription.xml
-binaries                      // directory containing the binaries (optional)
-   x86_64-windows             // binaries for Windows on Intel 64-bit
-      <modelIdentifier>.dll   // shared library of the FMI implementation
-      <other DLLs>            // the DLL can include other DLLs
-   x86_64-windows-msvc140mt   // static libraries for 64-bit Windows generated
-      <modelIdentifier>.lib   // with Visual Studio 2015 with /MT flag
-   i686-linux                 // binaries for Linux on Intel 32-bit
-      <modelIdentifier>.so    // shared library of the FMI implementation
-   aarch32-linux              // binaries for Linux on ARM 32-bit
-      <modelIdentifier>.so    // shared library of the FMI implementation
-   x86_64-darwin              // binaries for macOS
-      <modelIdentifier>.dylib // shared library of the FMI implementation
-resources                     // resources used by the FMU (optional)
-extra                         // Additional (meta-)data of the FMU (optional)
+binaries                            // directory containing the binaries (optional)
+   x86_64-windows                   // binaries for Windows on Intel 64-bit
+      <modelIdentifier>.dll         // shared library of the FMI implementation
+      <other DLLs>                  // the DLL can include other DLLs
+   x86_64-windows-msvc140mt         // static libraries for 64-bit Windows generated
+      <modelIdentifier>.lib         // with Visual Studio 2015 with /MT flag
+   i686-linux                       // binaries for Linux on Intel 32-bit
+      <modelIdentifier>.so          // shared library of the FMI implementation
+   aarch32-linux                    // binaries for Linux on ARM 32-bit
+      <modelIdentifier>.so          // shared library of the FMI implementation
+   x86_64-darwin                    // binaries for macOS
+      <modelIdentifier>.dylib       // shared library of the FMI implementation
+resources                           // resources used by the FMU (optional)
+extra                               // Additional (meta-)data of the FMU (optional)
 ----
 
 ===== Directory Documentation [[documentation-directory]]

--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -273,6 +273,7 @@ Further names can be introduced by vendors.
 FMUs should contain all resources that are required to load and execute a shared library, link against a static library, or compile from source.
 Shared libraries should be statically linked against their dependencies _[e.g. the Visual Studio C Runtime on Windows]_.
 `RPATH="$ORIGIN"` should be set when building ELF binaries to allow dynamic loading of dependencies on the target machine.
+All external dependencies must be documented (see <<documentation-directory>>).
 
 The binaries must be placed in the respective <platformTuple> directory with the general format `<arch>-<sys>{-<abi>{<abi_ver>}{<abi_sub>}}`.
 

--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -268,8 +268,9 @@ If an FMU is run through one of its binaries all items in that binary folder mus
 
 The names of the binary directories are standardized by the "platform tuple".
 Further names can be introduced by vendors.
-Dynamic link libraries must include all referenced resources that are not available on a standard target machine _[for example, DLLs on Windows that are built with Visual Studio should be compiled with the `/MT` option to include the required symbols from the Visual C runtime in the DLL, and not use the option `/MD` where this is not the case]_.
-When compiling a shared object on Linux, `RPATH="$ORIGIN"` has to be set when generating the shared object in order that shared objects used from it, can be dynamically loaded.
+FMUs should contain all resources that are required to load and execute a shared library, link against a static library, or compile from source.
+Shared libraries should be statically linked against their dependencies _[e.g. the Visual Studio C Runtime on Windows]_.
+`RPATH="$ORIGIN"` should be set when building ELF binaries to allow dynamic loading of dependencies on the target machine.
 
 The binaries must be placed in the respective <platformTuple> directory with the general format `<arch>-<sys>{-<abi>{<abi_ver>}{<abi_sub>}}`.
 

--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -61,8 +61,7 @@ extra                               // Additional (meta-)data of the FMU (option
 ===== Directory Documentation [[documentation-directory]]
 
 <<figure-zip-structure>> defines the files expected in the `documentation` directory.
-If the FMU depends on external resources to be loaded or simulated `documentation/externalDependencies.{txt|html}` must be present to document these dependencies and how to provide them.
-_[E.g. shared libraries the platform binary depends on that are not contained in the FMU.]_
+If the FMU depends on external resources _[e.g. shared libraries, files, or servers]_ to be loaded or simulated `documentation/externalDependencies.{txt|html}` must be present to document these dependencies and how to provide them.
 
 ====== Directory Licenses [[license-information]]
 This optional subdirectory can be used to bundle all license texts for the code, binaries or other material (documentation, content of resources folder) contained in the FMU.

--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -30,7 +30,7 @@ documentation                       // directory containing the documentation (o
    index.html                       // entry point of the documentation
    diagram.png                      // descriptive diagram view of the model (optional)
    diagram.svg                      // if provided, diagram.png is also required (optional)
-   externalDependencies.{txt|html}  // required, if external resources are needed to load or simulate the FMU
+   externalDependencies.{txt|html}  // documentation of external resources required to load or simulate the FMU
    <other documentation files>
    licenses                         // directory for licenses (optional)
       license.{txt|html}            // entry point for license information
@@ -61,6 +61,8 @@ extra                               // Additional (meta-)data of the FMU (option
 ===== Directory Documentation [[documentation-directory]]
 
 <<figure-zip-structure>> defines the files expected in the `documentation` directory.
+If the FMU depends on external resources to be loaded or simulated `documentation/externalDependencies.{txt|html}` must be present to document these dependencies and how to provide them.
+_[E.g. shared libraries the platform binary depends on that are not contained in the FMU.]_
 
 ====== Directory Licenses [[license-information]]
 This optional subdirectory can be used to bundle all license texts for the code, binaries or other material (documentation, content of resources folder) contained in the FMU.


### PR DESCRIPTION
fixes #1477

Update 1 after my discussion with @andreas-junghanns:

This proposal is by no means an invitation to link dynamically, but to legalize the large number of FMUs that are doing it already (for various reasons) and will continue to do it. Not allowing  it (even though it is clearly discouraged) will e.g. lead to the exclusion of a large number of FMUs from the Cross-Check, because they are clearly illegal according to the current specification (see also https://github.com/modelica/fmi-cross-check/issues/57).

Update 2: 

At least on Windows we have to distinguish between two types of dependencies on external DLLs:

1. Load time dependencies that are declared in the `<modelIdentifier>.dll`. These can be determined before calling `LoadLibrary()` and an error message can be displayed to the user.

2. Runtime dependencies where the external DLLs are loaded _after_ `LoadLibrary()` has been called. In this case the FMU can generate an error message that can (and must) be displayed to the user if `fmi*Instantiate*()` returns `NULL`. Also this approach does not lead to DLL-hell, as the paths to the DLLs are specifically chosen by the FMU.

As I understand @andreas-junhanns, he wants to avoid being blamed as an importer for bugs in the FMU rather than forbidding dynamic loading of DLLs in general.