### PR TITLE
fixed sentence about list attribute name

### DIFF
--- a/docs/1___overview.adoc
+++ b/docs/1___overview.adoc
@@ -284,7 +284,7 @@ All strings passed as arguments or returned are read-only and must not be modifi
 Reason: This eases the reuse of strings.
 
 Named list elements::
-All lists defined in the `fmi3ModelDescription.xsd` XML schema file have a string attribute `name` to a list element.
+All lists defined in the `fmi3ModelDescription.xsd` XML schema file have a string attribute `name`.
 This attribute must be unique with respect to all other `name` attributes of the same list.
 
 Use C::

--- a/docs/1___overview.adoc
+++ b/docs/1___overview.adoc
@@ -284,7 +284,7 @@ All strings passed as arguments or returned are read-only and must not be modifi
 Reason: This eases the reuse of strings.
 
 Named list elements::
-All lists defined in the `fmi3ModelDescription.xsd` XML schema file have a string attribute called `name`.
+Each element of lists defined in the `fmi3ModelDescription.xsd` have a string attribute called `name`.
 This attribute must be unique with respect to all other `name` attributes of the same list.
 
 Use C::

--- a/docs/1___overview.adoc
+++ b/docs/1___overview.adoc
@@ -284,7 +284,7 @@ All strings passed as arguments or returned are read-only and must not be modifi
 Reason: This eases the reuse of strings.
 
 Named list elements::
-All lists defined in the `fmi3ModelDescription.xsd` XML schema file have a string attribute `name`.
+All lists defined in the `fmi3ModelDescription.xsd` XML schema file have a string attribute called `name`.
 This attribute must be unique with respect to all other `name` attributes of the same list.
 
 Use C::


### PR DESCRIPTION
Checklist

* [x] Used a [personal fork](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo) of the repository to propose changes.
* [x] [Built the specification](https://github.com/modelica/fmi-standard/blob/master/CONTRIBUTING.adoc#building-the-specification-document).
* [x] [Linted the documents](https://github.com/modelica/fmi-standard/blob/master/CONTRIBUTING.adoc#building-the-specification-document).

N/A [Re-generated schema figures](https://github.com/modelica/fmi-standard/blob/master/CONTRIBUTING.adoc#changing-the-xsd-schemas).


The sentence prior to the change did not make sense:
> All lists defined in the fmi3ModelDescription.xsd XML schema file have a string attribute name **to a list element**.

I think the `to a list element` comes from an earlier version of the senctence which is not required anymore. I suggest this version of the sentence:
> All lists defined in the fmi3ModelDescription.xsd XML schema file have a string attribute called name.