### PR TITLE
Clarify countdown clock ticks

### DIFF
--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -633,7 +633,7 @@ The importer calls <<fmi3GetClock>> to inquire the clock activation state.
 |<<fmi3SetClock>> in <<EventMode>>,
 <<fmi3ActivateModelPartition>> in <<ClockActivationMode>>,
 <<fmi3GetInterval>> in <<InitializationMode>>,
-<<fmi3GetInterval>> in both <<EventMode>> and <<ClockActivationMode>>
+<<fmi3GetInterval>> in both <<EventMode>> and <<ClockActivationMode>> if and only if this Clock ticked
 |simulation of the behavior of a control algorithm with variable execution time, generation of pulse sequences
 
 |[[countdown,`countdown`]]`countdown`
@@ -778,7 +778,7 @@ latexmath:[\begin{align*}
 Must be retrieved in <<InitializationMode>>.
 
 |latexmath:[\mathbf{T}_{interval, i} \geq 0, \qquad i = 1,2,3,{...}]
-|The time interval from the call of <<fmi3CallbackIntermediateUpdate>> at which the argument <<qualifier,`qualifier`>> of <<fmi3GetInterval>> returns `fmi3IntervalChanged` to the next Clock tick.
+|The time interval from the event time or the point in time when <<fmi3CallbackIntermediateUpdate>> is called at which the argument <<qualifier,`qualifier`>> of <<fmi3GetInterval>> returns `fmi3IntervalChanged` to the next Clock tick.
 
 |===
 
@@ -847,7 +847,7 @@ The FMU may request to schedule another model partition even while currently a m
 A new interval for a <<countdown>> Clock can be provided at any time during the execution of any model partition.
 The FMU signals that a <<countdown>> Clock is about to tick by calling <<fmi3CallbackIntermediateUpdate>> with argument <<clockHandlingRequested>> == `fmi3True`.
 The importer calls <<fmi3GetInterval>> for all <<countdown>> Clocks.
-If a new interval is provided, i.e. return argument <<qualifier>> == `fmi3IntervalChanged`, the importer initiates the scheduling of the associated model partitions with the returned <<interval>>.
+If a new <<countdown-aperiodic-clock,`interval`>> latexmath:[\mathbf{T}_{interval, i}] is provided, i.e. return argument <<qualifier>> == `fmi3IntervalChanged`, the importer initiates the scheduling of the associated model partitions regarding the delay of the returned interval.
 
 In case more than one Clock ticks at the same time instant, the scheduler needs a priority to define the activation sequence of the associated model partitions.
 This ordering is defined by the <<priority>> attributes of the Clock.
@@ -925,7 +925,8 @@ include::../headers/fmi3FunctionTypes.h[tag=IntervalQualifier]
 ----
 with the following meanings:
 
- * `fmi3IntervalNotYetKnown` is returned for a <<countdown-aperiodic-clock>> for which the next interval is not yet known. The importer must query the next interval at each <<EventMode>> or <<IntermediateUpdateMode>> if <<clockHandlingRequested,`clockHandlingRequested == fmi3True`>> in <<fmi3CallbackIntermediateUpdate>>, respectively, for all <<countdown-aperiodic-clock,countdown aperiodic Clocks>> because the next interval may change at any <<EventMode>> or <<IntermediateUpdateMode>>.
+ * `fmi3IntervalNotYetKnown` is returned for a <<countdown-aperiodic-clock>> for which the next interval is not yet known.
+ The importer must query the next interval at each <<EventMode>> or <<IntermediateUpdateMode>> if <<clockHandlingRequested,`clockHandlingRequested == fmi3True`>> in <<fmi3CallbackIntermediateUpdate>>, respectively, for all <<countdown-aperiodic-clock,countdown aperiodic Clocks>> because the next interval may change at any <<EventMode>> or <<IntermediateUpdateMode>>.
  * `fmi3IntervalUnchanged` is returned if a previous call to <<fmi3GetInterval>> already returned a value which has not changed since.
  * `fmi3IntervalChanged` is returned to indicate that the value for the interval has changed for this <<Clock>>.
  The new <<Clock>> interval is relative to the time of the current <<EventMode>> or <<IntermediateUpdateMode>> in contrast to the interval of a periodic <<Clock>>, where the interval is defined as the time between consecutive <<Clock>> ticks.

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -633,27 +633,26 @@ The importer calls <<fmi3GetClock>> to inquire the clock activation state.
 |<<fmi3SetClock>> in <<EventMode>>,
 <<fmi3ActivateModelPartition>> in <<ClockActivationMode>>,
 <<fmi3GetInterval>> in <<InitializationMode>>,
-<<fmi3GetInterval>> in both <<EventMode>> and <<ClockActivationMode>> if and only if this Clock ticked using <<clocksTicked,`clocksTicked == fmi3True`>>
+<<fmi3GetInterval>> in both <<EventMode>> and <<ClockActivationMode>>
 |simulation of the behavior of a control algorithm with variable execution time, generation of pulse sequences
 
 |[[countdown,`countdown`]]`countdown`
 |<<fmi3SetClock>> in <<EventMode>>,
 <<fmi3ActivateModelPartition>> in <<ClockActivationMode>>,
-<<fmi3GetInterval>> in <<InitializationMode>>, in every <<EventMode>>, and in <<IntermediateUpdateMode>>.
-In Scheduled Execution the FMU has to inform the importer by calling <<fmi3CallbackIntermediateUpdate>> that the Clock is about to tick using <<clocksTicked,`clocksTicked == fmi3True`>>
+<<fmi3GetInterval>> in <<InitializationMode>>, in every <<EventMode>> and in <<IntermediateUpdateMode>>.
+In Scheduled Execution the FMU has to inform the importer by calling <<fmi3CallbackIntermediateUpdate>> that the Clock is about to tick using <<clockHandlingRequested,`clockHandlingRequested == fmi3True`>>
 |time-delayed actions after an event, for example, ignition signal some time after specific crank shaft angle
 
 2.2+|[[triggered,`triggered`]]triggered
 |<<input>>
 |<<triggered>>
 |<<fmi3SetClock>> in <<EventMode>>,
-<<fmi3ActivateModelPartition>> in <<ClockActivationMode>>,
-argument <<clocksTicked>> of <<fmi3CallbackIntermediateUpdate>>
+<<fmi3ActivateModelPartition>> in <<ClockActivationMode>>
 |triggered by a hardware interrupt of an embedded system, e.g. a control algorithm, triggered by a crankshaft angle
 
 |<<output>>
 |<<triggered>>
-|<<fmi3GetClock>> in both <<EventMode>> and <<IntermediateUpdateMode>>, and argument <<clocksTicked>> of <<fmi3CallbackIntermediateUpdate>>
+|<<fmi3GetClock>> in both <<EventMode>> and <<IntermediateUpdateMode>>, argument <<clockHandlingRequested>> of <<fmi3CallbackIntermediateUpdate>>
 |crankshaft angle sensor ticking several times per revolution
 |====
 
@@ -759,7 +758,7 @@ Must be retrieved in <<EventMode>> or <<ClockActivationMode>> if and only if the
 
 [[countdown-aperiodic-clock,countdown aperiodic Clock]]
 Countdown aperiodic Clock::
-is a time-based Clock whose next interval is not yet known right after the Clock just ticked, forcing the importer to call <<fmi3GetInterval>> in every <<EventMode>> and in <<IntermediateUpdateMode>> if <<clocksTicked>> == `fmi3True` in <<fmi3CallbackIntermediateUpdate>>.
+is a time-based Clock whose next interval is not yet known right after the Clock just ticked, forcing the importer to call <<fmi3GetInterval>> in every <<EventMode>> and in <<IntermediateUpdateMode>> if <<clockHandlingRequested>> == `fmi3True` in <<fmi3CallbackIntermediateUpdate>>.
 The return argument <<qualifier>> of <<fmi3GetInterval>> is used to indicate if the next interval is already known.
 +
 The next Clock tick at time instant latexmath:[t_i] is defined as: +
@@ -779,7 +778,7 @@ latexmath:[\begin{align*}
 Must be retrieved in <<InitializationMode>>.
 
 |latexmath:[\mathbf{T}_{interval, i} \geq 0, \qquad i = 1,2,3,{...}]
-|The time interval from the event time at which the argument <<qualifier,`qualifier == fmi3IntervalChanged`>> of <<fmi3GetInterval>> to the next Clock tick.
+|The time interval from the call of <<fmi3CallbackIntermediateUpdate>> at which the argument <<qualifier,`qualifier`>> of <<fmi3GetInterval>> returns `fmi3IntervalChanged` to the next Clock tick.
 
 |===
 
@@ -845,11 +844,10 @@ During <<ClockActivationMode>> after <<fmi3ActivateModelPartition>> has been cal
 To retrieve this information the importer calls <<fmi3GetInterval>> on the Clock.
 
 The FMU may request to schedule another model partition even while currently a model partition is being executed.
-<<countdown>> Clocks can tick at any time during the execution of any model partition.
-The FMU signals their ticking by calling <<fmi3CallbackIntermediateUpdate>> with argument <<clocksTicked>> == `fmi3True`.
-The importer calls <<fmi3GetInterval>> for all countdown Clocks.
-If a new interval is provided, the importer initiates the scheduling of the associated model partitions with the returned <<interval>>.
-<<qualifier>> == `fmi3IntervalChanged` indicates that the corresponding Clock has to be scheduled.
+A new interval for a <<countdown>> Clock can be provided at any time during the execution of any model partition.
+The FMU signals that a <<countdown>> Clock is about to tick by calling <<fmi3CallbackIntermediateUpdate>> with argument <<clockHandlingRequested>> == `fmi3True`.
+The importer calls <<fmi3GetInterval>> for all <<countdown>> Clocks.
+If a new interval is provided, i.e. return argument <<qualifier>> == `fmi3IntervalChanged`, the importer initiates the scheduling of the associated model partitions with the returned <<interval>>.
 
 In case more than one Clock ticks at the same time instant, the scheduler needs a priority to define the activation sequence of the associated model partitions.
 This ordering is defined by the <<priority>> attributes of the Clock.
@@ -927,10 +925,10 @@ include::../headers/fmi3FunctionTypes.h[tag=IntervalQualifier]
 ----
 with the following meanings:
 
- * `fmi3IntervalNotYetKnown` is returned for <<countdown-aperiodic-clock>> for which the next interval is not yet known. The importer must query the next interval at each <<EventMode>> for all <<countdown-aperiodic-clock>> because the next interval may change at any <<EventMode>>.
+ * `fmi3IntervalNotYetKnown` is returned for a <<countdown-aperiodic-clock>> for which the next interval is not yet known. The importer must query the next interval at each <<EventMode>> or <<IntermediateUpdateMode>> if <<clockHandlingRequested,`clockHandlingRequested == fmi3True`>> in <<fmi3CallbackIntermediateUpdate>>, respectively, for all <<countdown-aperiodic-clock,countdown aperiodic Clocks>> because the next interval may change at any <<EventMode>> or <<IntermediateUpdateMode>>.
  * `fmi3IntervalUnchanged` is returned if a previous call to <<fmi3GetInterval>> already returned a value which has not changed since.
  * `fmi3IntervalChanged` is returned to indicate that the value for the interval has changed for this <<Clock>>.
- The new <<Clock>> interval is relative to the time of the current <<EventMode>>.
+ The new <<Clock>> interval is relative to the time of the current <<EventMode>> or <<IntermediateUpdateMode>> in contrast to the interval of a periodic <<Clock>>, where the interval is defined as the time between consecutive <<Clock>> ticks.
 
 [[fmi3GetIntervalFraction,`fmi3GetIntervalFraction`]]
 [source, C]

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -778,7 +778,7 @@ latexmath:[\begin{align*}
 Must be retrieved in <<InitializationMode>>.
 
 |latexmath:[\mathbf{T}_{interval, i} \geq 0, \qquad i = 1,2,3,{...}]
-|The time interval from the event time or the point in time when <<fmi3CallbackIntermediateUpdate>> is called at which the argument <<qualifier,`qualifier`>> of <<fmi3GetInterval>> returns `fmi3IntervalChanged` to the next Clock tick.
+|The time interval from the event time or the point in time when <<fmi3CallbackIntermediateUpdate>> is called (see <<intermediateUpdateTime>>) at which the argument <<qualifier,`qualifier`>> of <<fmi3GetInterval>> returns `fmi3IntervalChanged` to the next Clock tick.
 
 |===
 
@@ -912,6 +912,7 @@ include::../headers/fmi3FunctionTypes.h[tag=GetIntervalDecimal]
 
 * `valueReferences` is an array of size `nValueReferences` holding the value references of the `Clock` variables.
 
+[[intervals,`intervals`]]
 * `intervals` is an array of size `nIntervals` to retrieve the Clock intervals.
 
 * `qualifiers` is an array of size `nIntervals` to retrieve the Clock <<qualifier>>.

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -773,7 +773,7 @@ If an event happens or an <<outputClock>> ticks, <<intermediateUpdateTime>> is t
 In Co-Simulation, <<intermediateUpdateTime>> is restricted by the arguments to <<fmi3DoStep>> as follows: +
 <<currentCommunicationPoint>> latexmath:[\leq] <<intermediateUpdateTime>> latexmath:[\leq] (<<currentCommunicationPoint>> + <<communicationStepSize>>). +
 The FMU must not call the callback function <<fmi3CallbackIntermediateUpdate>> with an <<intermediateUpdateTime>> that is smaller than the <<intermediateUpdateTime>> given in a previous call of <<fmi3CallbackIntermediateUpdate>> with `intermediateStepFinished == fmi3True`. +
-In Scheduled Execution the <<intermediateUpdateTime>> is ignored since in this case the simulation algorithm controls the time and not the FMU.
+In Scheduled Execution the <<intermediateUpdateTime>> is used as base for the argument <<intervals>> of <<fmi3GetInterval>> if <<clockHandlingRequested,`clockHandlingRequested == fmi3True`>>.
 
 [[clockHandlingRequested,`clockHandlingRequested`]]
 * The <<clockHandlingRequested>> parameter is only used in Scheduled Execution and is ignored in Co-Simulation.

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -9,7 +9,7 @@ State-machine states specific to a single interface type will be described in th
 [[each-state-description]]
 Each state description lists the governing equations and actions and the corresponding API functions influencing these equations in a table (not defining the calling order), and also lists the allowed function calls and usage restrictions.
 
-.Common calling sequence for C functions of common states for all three FMI types.
+.Common calling sequence for C functions of common states for at least two of the interface types.
 [#figure-common-state-machine]
 image::images/state-machines-common-states.svg[width=80%, align="center"]
 
@@ -772,8 +772,8 @@ include::../headers/fmi3FunctionTypes.h[tag=CallbackIntermediateUpdate]
 If an event happens or an <<outputClock>> ticks, <<intermediateUpdateTime>> is the time of event or <<outputClock>> tick.
 In Co-Simulation, <<intermediateUpdateTime>> is restricted by the arguments to <<fmi3DoStep>> as follows: +
 <<currentCommunicationPoint>> latexmath:[\leq] <<intermediateUpdateTime>> latexmath:[\leq] (<<currentCommunicationPoint>> + <<communicationStepSize>>). +
-The FMU must not call the callback function <<fmi3CallbackIntermediateUpdate>> with an <<intermediateUpdateTime>> that is smaller than the <<intermediateUpdateTime>> given in a previous call of <<fmi3CallbackIntermediateUpdate>> with `intermediateStepFinished == fmi3True`.
-In Scheduled Execution the <<intermediateUpdateTime>> should be ignored since in this case the simulation algorithm controls the time and not the FMU.
+The FMU must not call the callback function <<fmi3CallbackIntermediateUpdate>> with an <<intermediateUpdateTime>> that is smaller than the <<intermediateUpdateTime>> given in a previous call of <<fmi3CallbackIntermediateUpdate>> with `intermediateStepFinished == fmi3True`. +
+In Scheduled Execution the <<intermediateUpdateTime>> is ignored since in this case the simulation algorithm controls the time and not the FMU.
 
 [[clockHandlingRequested,`clockHandlingRequested`]]
 * The <<clockHandlingRequested>> parameter is only used in Scheduled Execution and is ignored in Co-Simulation.

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -724,9 +724,8 @@ _[The following use cases are enabled:_
 
 * _Access to intermediate variables enables advanced Co-Simulation with interpolation/extrapolation techniques (such as polynomial extrapolation, <<transmission-line-modeling>> (<<tlm>>) co-simulation, anti-alias filtering, smoothing of input among others)._
 * _<<IntermediateUpdateMode>> enables the same input approximation that was possible in FMI 2.0 with `fmi2SetInputDerivatives`, by evaluation of the approximation polynomial by the importer and not within the FMU as in FMI 2.0_
-* _FMUs can inform the importer about an event, which occurs during an <<fmi3DoStep>> in case of CS (see <<fmi-for-co-simulation>>)._
 * _The Co-Simulation algorithm can request an <<early-return,early return>> from <<fmi3DoStep>>, because of an event between communication points (see <<early-return>>)._
-* _A model partition of a Scheduled Execution FMU calls <<fmi3CallbackIntermediateUpdate>> to signal clock activations with `clocksTicked == fmi3True`._
+* _A model partition of a Scheduled Execution FMU calls <<fmi3CallbackIntermediateUpdate>> to signal that a <<triggered, `triggered output`>> <<Clock>> ticked or a new interval for a <<countdown>> <<Clock>> is provided with <<clockHandlingRequested, `clockHandlingRequested == fmi3True`>>._
 
 _Note that the call to <<fmi3CallbackIntermediateUpdate>> and thus entering the <<IntermediateUpdateMode>> can only be triggered by the FMU itself._
 _The importer cannot actively trigger this and hence for some use cases (e.g. cooperative multitasking and setting of intermediate input values) it relies on the callbacks from the FMUs to be able to realize these use cases properly.]_
@@ -776,9 +775,9 @@ In Co-Simulation, <<intermediateUpdateTime>> is restricted by the arguments to <
 The FMU must not call the callback function <<fmi3CallbackIntermediateUpdate>> with an <<intermediateUpdateTime>> that is smaller than the <<intermediateUpdateTime>> given in a previous call of <<fmi3CallbackIntermediateUpdate>> with `intermediateStepFinished == fmi3True`.
 In Scheduled Execution the <<intermediateUpdateTime>> should be ignored since in this case the simulation algorithm controls the time and not the FMU.
 
-[[clocksTicked,`clocksTicked`]]
-* The <<clocksTicked>> parameter is only used in Scheduled Execution and is ignored in Co-Simulation.
-When <<clocksTicked,`clocksTicked == fmi3True`>>, it means that <<fmi3GetClock>> function must be called for gathering all <<Clock>> related information about ticking <<outputClock,`output clocks`>>, <<fmi3GetInterval>> must be called for all <<countdown>> <<Clock,Clocks>> and then activate the respective model partitions accordingly.
+[[clockHandlingRequested,`clockHandlingRequested`]]
+* The <<clockHandlingRequested>> parameter is only used in Scheduled Execution and is ignored in Co-Simulation.
+When <<clockHandlingRequested,`clockHandlingRequested == fmi3True`>>, it means that <<fmi3GetClock>> must be called for gathering all <<Clock>> related information about ticking <<outputClock,`output`>> <<Clock,Clocks>> and <<fmi3GetInterval>> must be called for all <<countdown>> <<Clock,Clocks>> whose associated model partitions have to be scheduled afterwards if a new interval is provided.
 
 [[intermediateVariableSetRequested,`intermediateVariableSetRequested`]]
 * If <<intermediateVariableSetRequested,`intermediateVariableSetRequested == fmi3True`>>, the co-simulation algorithm may provide intermediate values for continuous <<input>> variables with <<intermediateUpdate,`intermediateUpdate = true`>> by calling <<get-and-set-variable-values,`fmi3Set{VariableType}`>>.
@@ -848,7 +847,7 @@ Additionally to the functions listed above, Scheduled Execution allows calling t
 
 Function <<fmi3GetClock>>::
 The scheduling algorithm uses <<fmi3GetClock>> to determine which clock is active. +
-_[For efficiency, <<fmi3GetClock>> should only be called if <<clocksTicked, `clocksTicked == fmi3True`>>.]_ +
+_[For efficiency, <<fmi3GetClock>> should only be called if <<clockHandlingRequested, `clockHandlingRequested == fmi3True`>>.]_ +
 Depending on the clock activation state, the scheduling algorithm can call <<get-and-set-variable-values,`fmi3Set{VariableType}`>> and <<get-and-set-variable-values,`fmi3Get{VariableType}`>> for variables associated with the corresponding <<Clock>>.
 For an <<outputClock>> only the first call of `fmi3GetClock` for a specific activation of this <<Clock>> signals `fmi3ClockActive`.
 The FMU sets the reported activation state immediately back to `fmi3ClockInactive` for following `fmi3GetClock` calls for that <<Clock>> until this <<outputClock>> is activated again.

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -774,6 +774,7 @@ In Co-Simulation, <<intermediateUpdateTime>> is restricted by the arguments to <
 <<currentCommunicationPoint>> latexmath:[\leq] <<intermediateUpdateTime>> latexmath:[\leq] (<<currentCommunicationPoint>> + <<communicationStepSize>>). +
 The FMU must not call the callback function <<fmi3CallbackIntermediateUpdate>> with an <<intermediateUpdateTime>> that is smaller than the <<intermediateUpdateTime>> given in a previous call of <<fmi3CallbackIntermediateUpdate>> with `intermediateStepFinished == fmi3True`. +
 In Scheduled Execution the <<intermediateUpdateTime>> is used as base for the argument <<intervals>> of <<fmi3GetInterval>> if <<clockHandlingRequested,`clockHandlingRequested == fmi3True`>>.
+_[It is up to the FMU if the <<intermediateUpdateTime>> is based on wall-clock time (e.g. in real-time mode) or if this is just returning the last <<activationTime>> of <<fmi3ActivateModelPartition>> because it can adjust the <<intervals>> returned by <<fmi3GetInterval>> to properly declare the next clock activation.]_
 
 [[clockHandlingRequested,`clockHandlingRequested`]]
 * The <<clockHandlingRequested>> parameter is only used in Scheduled Execution and is ignored in Co-Simulation.

--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -1039,7 +1039,7 @@ Model Exchange: No restrictions on value changes (see <<smoothness>>).
 
 The default is <<continuous>> for variables of type `<Float32>` and `<Float64>`, and <<discrete>> for all other types.
 
-For variables of type `Clock` and <<clocked-variable,`clocked variables`>> the <<variability>> is always <<discrete>>.
+For variables of type `Clock` and <<clocked-variable,`clocked variables`>> the <<variability>> is always <<discrete>> or <<tunable>>.
 
 _[Note that the information about continuous <<state,`states`>> is defined with elements <<ContinuousStateDerivative>> in `<ModelStructure>`.]_
 

--- a/docs/5_1_scheduled_execution_math.adoc
+++ b/docs/5_1_scheduled_execution_math.adoc
@@ -26,7 +26,7 @@ The FMU's code has to be prepared for being able to correctly handle preemptive 
 In general for Scheduled Execution this requires a secured internal and external access to global states and variable values to ensure the correct handling of the preemption of model partition computations.
 _[For <<get-and-set-variable-values,`fmi3Get{VariableType}`>>, <<get-and-set-variable-values,`fmi3Set{VariableType}`>> in particular a unique assignment of the respective variables to model partitions via its associated <<Clock>> is strongly recommended.]_
 It is also required that the FMU reports the active state of an <<outputClock>> only with the first call of <<fmi3GetClock>> for a specific activation of this <<Clock>> and sets the reported activation state immediately back to `false` for the following <<fmi3GetClock>> calls for that <<Clock>> until this <<outputClock>> is internally activated again.
-Similarly for <<countdown, `countdown Clocks`>> a call to <<fmi3GetIntervalDecimal>> has to ensure that the Clock's interval qualifier is reset to <<fmi3GetIntervalDecimal, `fmi3IntervalUnchanged`>>.
+Similarly for <<countdown, `countdown Clocks`>> a call to <<fmi3GetIntervalDecimal>> has to ensure that the interval qualifier of the <<Clock>> is reset to <<fmi3GetIntervalDecimal, `fmi3IntervalUnchanged`>>.
 
 If a preemptive multitasking regime is intended, an individual task (or thread -- task and thread are used synonymously here) for each model partition (associated to an <<inputClock>>) has to be created.
 The task for computing each <<fmi3ActivateModelPartition>> is created and controlled by the simulation algorithm, not by the FMU.

--- a/docs/examples/snippets.c
+++ b/docs/examples/snippets.c
@@ -122,14 +122,14 @@ void CallbackIntermediateUpdate(fmi3InstanceEnvironment instanceEnvironment,
 
 /* tag::SE_fmu_activateMP10ms[] */
 void activateModelPartition10ms(ModelInstance* instance, fmi3Float64 activationTime) {
-
+	fmi3Float64 intermediateUpdateTime = 0.0; // ignored for SE
 	fmi3Boolean conditionForCountdownClockMet = (AIn1 > AIn2);
 	if (conditionForCountdownClockMet) {
 		CountdownClockQualifier = fmi3IntervalChanged;
 		CountdownClockInterval = 0.0;
 		// inform the simulation algorithm that the countdown clock is about to tick
 		fmi3Boolean clockHandlingRequested = fmi3True;
-		instance->callbackIntermediateUpdate(instance->instanceEnvironment, activationTime, clockHandlingRequested,
+		instance->callbackIntermediateUpdate(instance->instanceEnvironment, intermediateUpdateTime, clockHandlingRequested,
 			fmi3False, fmi3False, fmi3False, fmi3False, NULL, NULL);
 	}
 	fmi3Boolean conditionForOutputClockMet = (AIn2 > 42.0);
@@ -138,7 +138,7 @@ void activateModelPartition10ms(ModelInstance* instance, fmi3Float64 activationT
 		OutputClockTicked = fmi3ClockActive;
 		// inform the simulation algorithm that the output clock has ticked
 		fmi3Boolean clockHandlingRequested = fmi3True;
-		instance->callbackIntermediateUpdate(instance->instanceEnvironment, activationTime, clockHandlingRequested,
+		instance->callbackIntermediateUpdate(instance->instanceEnvironment, intermediateUpdateTime, clockHandlingRequested,
 			fmi3False, fmi3False, fmi3False, fmi3False, NULL, NULL);
 	}
 	AOut = AIn1 + AIn2;

--- a/headers/fmi3FunctionTypes.h
+++ b/headers/fmi3FunctionTypes.h
@@ -90,7 +90,7 @@ typedef void  (*fmi3CallbackLogMessage) (fmi3InstanceEnvironment instanceEnviron
 typedef void (*fmi3CallbackIntermediateUpdate) (
     fmi3InstanceEnvironment instanceEnvironment,
     fmi3Float64  intermediateUpdateTime,
-    fmi3Boolean  clocksTicked,
+    fmi3Boolean  clockHandlingRequested,
     fmi3Boolean  intermediateVariableSetRequested,
     fmi3Boolean  intermediateVariableGetAllowed,
     fmi3Boolean  intermediateStepFinished,


### PR DESCRIPTION
The specification is unclear about the concrete time of a countdown clock tick.
Across the spec there are described two contradictory point of views:

1. A countdown clock ticks while a model partition is being executed, i.e. the clock already has ticked when intermediate update is invoked.
2. A model partition can only signal that a countdown clock is about to tick. The actual ticking takes place after the provided interval is run out.

Here are some quotes that state the first variant:

- Section 2.2.9.4:
  >The FMU may request to schedule another model partition even while currently a model partition is being executed. countdown Clocks can tick at any time during the execution of any model partition. The FMU signals their ticking by calling fmi3CallbackIntermediateUpdate with argument clocksTicked == fmi3True. The importer calls fmi3GetInterval for all countdown Clocks. If a new interval is provided, the importer initiates the scheduling of the associated model partitions with the returned interval. qualifier == fmi3IntervalChanged indicates that the corresponding Clock has to be scheduled.

- The parameter name `clocksTicked` of the fmi3CallbackIntermediateUpdate function implies that the countdown clock already has ticked.

Here are some quotes that state the second variant:

- Table 5. Overview of Clock types. - countdown clock:
  >In Scheduled Execution the FMU has to inform the importer by calling fmi3CallbackIntermediateUpdate that the Clock is about to tick using clocksTicked == fmi3True.

- Section 2.2.9 - countdown clocks - interval description:
  >The time interval from the event time at which the argument qualifier == fmi3IntervalChanged of fmi3GetInterval to the next Clock tick.

- Section 5.1.1:
  >During the computation of a model partition of an input Clock the FMU may inform the importer that an output Clock ticked or a countdown Clock has to be ticked.

- Comment in the SE code example:
  `// ask FMU if countdown clock is about to tick`

As the ticking of a countdown clock is not clearly defined this could lead to misunderstandings. To fix this, one of the variants must be chosen. The second variant is to prefer for the following reasons:
- If the clock already had ticked before fmi3CallbackIntermediateUpdate is called by the FMU this would be a behavior of an output clock

- An input clock is defined as follows (2.2.9.2):
  >In Scheduled Execution, when input Clocks tick, the importer will activate the associated model partitions (but not the input Clocks) using fmi3ActivateModelPartition. While the importer is the source of the actual Clock activations, the timing of the Clocks is defined by the FMU, either through the modelDescription.xml or calling fmi3GetInterval, or by another Clock connected to a triggered input Clock.

  Since the model partition is activated after the interval is run out, there must be a clock tick. If it already had ticked "inside the FMU" and the interval is >0 there would be no model partition activation for that clock tick, which is contradictory to the definition of input clocks.

So, I propose to use the second variant to unify the description of countdown clocks and to rename the fmi3CallbackIntermediateUpdate parameter `clocksTicked` to `clockHandlingRequested` according to other parameters like `intermediateVariableSetRequested`.

@andreas-junghanns @MBlesken Please review