### PR TITLE
Forbid use of GetOutputDerivatives in SE

### DIFF
--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -30,8 +30,8 @@ If some resource is required by the FMU but is not available, the FMU must log w
 
 ==== Header Files and Naming of Functions [[header-files-and-naming-of-functions]]
 
-Three header files are provided that define the interface of an FMU.
-In all header files the convention is used that all C function and type definitions start with the prefix `fmi3`:
+The interface of an FMU is defined by three C99 header files.
+By convention all function declarations and type definitions in these header files have the prefix `fmi3`.
 
 `fmi3PlatformTypes.h`::
 contains the type definitions of the input and output arguments of the functions as well as some C preprocessor macro definitions for constants.

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -30,8 +30,8 @@ If some resource is required by the FMU but is not available, the FMU must log w
 
 ==== Header Files and Naming of Functions [[header-files-and-naming-of-functions]]
 
-The interface of an FMU is defined by three C99 header files.
-By convention all function declarations and type definitions in these header files have the prefix `fmi3`.
+Three header files are provided that define the interface of an FMU.
+In all header files the convention is used that all C function and type definitions start with the prefix `fmi3`:
 
 `fmi3PlatformTypes.h`::
 contains the type definitions of the input and output arguments of the functions as well as some C preprocessor macro definitions for constants.
@@ -1329,6 +1329,9 @@ The inner level does not exist for scalar variables.
 * `nValues` is the size of the argument `values`.
 `nValues` only equals `nValueReferences` if all corresponding output variables are scalar variables.
 --
+
+In Scheduled Execution, all variables are time-discrete.
+Therefore, calling <<fmi3GetOutputDerivatives>> is not allowed in Scheduled Execution.
 
 _[ Example:_ +
 _Assuming an FMU has outputs latexmath:[y_1][2*3] with value reference 1, latexmath:[y_2] with value reference 2, latexmath:[ y_3][2] value reference 3, latexmath:[y_4] with value reference 4 and `maxOutputDerivativeOrder`=2._ +

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -577,8 +577,8 @@ The second point solves the issue that computing exactly when an event happens i
 ===== Clock Types
 
 Clocks are <<discrete>> <<fmu-variables,variables>> with a special semantic.
-
-The following Clock types are described in detail after the table.
+[[clockType,`clockType`]]
+The variable's XML attribute <<clockType>> declares the type of Clock, described in detail after the table.
 
 Input Clock::
 [[inputClock, `input Clock`]]
@@ -590,7 +590,7 @@ While the importer is the source of the actual Clock activations, the timing of 
 Output Clock::
 [[outputClock, `output Clock`]]
 is a variable of type Clock with <<causality>> == <<output>>.
-The attribute <<interval>> must be <<triggered>> for output Clocks.
+The attribute <<clockType>> must be <<triggered>> for output Clocks.
 The importer calls <<fmi3GetClock>> to inquire the clock activation state.
 
 .Overview of Clock types.
@@ -599,14 +599,14 @@ The importer calls <<fmi3GetClock>> to inquire the clock activation state.
 |====
 2+|Clock type
 |<<causality>>
-|<<interval>>
+|<<clockType>>
 |Related API calls and arguments
 |Example
 
 .6+|time-based
 .4+|[[periodic]]periodic
 .4+|<<input>>
-|[[constant-interval,`constant`]]`constant`
+|[[constant-clockType,`constant`]]`constant`
 |<<fmi3SetClock>> in <<EventMode>>,
 <<fmi3ActivateModelPartition>> in <<ClockActivationMode>>,
 <<fmi3GetInterval>> and <<fmi3GetShift>> in <<InitializationMode>>
@@ -682,11 +682,11 @@ The mathematical descriptions of <<time-based-clock>> will use the following not
 |The previous time instant, where the Clock ticked.
 
 |latexmath:[\mathbf{T}_{\mathit{shift}}]
-|The delay for the first Clock tick relative to latexmath:[\mathbf{t}_{\mathit{start}}]. latexmath:[\mathbf{T}_{\mathit{shift}}] is defined differently for the different Clock types, and can be retrieved from the FMU with <<fmi3GetShiftDecimal>> as floating point value, or with <<fmi3GetShiftFraction>> as rational number `shiftCounter / resolution` (see <<resolution>>).
+|The delay for the first Clock tick relative to latexmath:[\mathbf{t}_{\mathit{start}}]. latexmath:[\mathbf{T}_{\mathit{shift}}] is defined differently for the different Clock types, and can be retrieved from the FMU with <<fmi3GetShiftDecimal>> as floating point value, or with <<fmi3GetShiftFraction>> as rational number <<shiftCounters>> / <<resolutions>>.
 
 |latexmath:[\mathbf{T}_{interval, i}]
 |The time interval until the next Clock tick, defined differently for the different Clock types.
-latexmath:[\mathbf{T}_{interval, i}] can be set with <<fmi3SetIntervalDecimal>> or retrieved with <<fmi3GetIntervalDecimal>> as floating point value, or as rational number using <<fmi3SetIntervalFraction>> or <<fmi3GetIntervalFraction>> `intervalCounter / resolution` (see <<resolution>>).
+latexmath:[\mathbf{T}_{interval, i}] can be set with <<fmi3SetIntervalDecimal>> or retrieved with <<fmi3GetIntervalDecimal>> as floating point value, or as rational number using <<fmi3SetIntervalFraction>> or <<fmi3GetIntervalFraction>> <<intervalCounters>> / <<resolutions>>.
 
 |latexmath:[\mathbf{t}_\mathit{event}]
 |The current event time in <<EventMode>>, or the current time in Scheduled Execution.
@@ -694,8 +694,8 @@ latexmath:[\mathbf{T}_{interval, i}] can be set with <<fmi3SetIntervalDecimal>> 
 |===
 
 [[periodic-clock]]Periodic Clock::
-is a time-based Clock with a constant interval, except when <<interval>> == <<tunable>>, which indicates that the interval can change when tunable <<parameter, parameters>> change.
-The time instant of the first Clock tick is defined by a <<shift>>.
+is a time-based Clock with a constant interval, except when <<clockType>> == <<tunable>>, which indicates that the interval can change when tunable <<parameter, parameters>> change.
+The time instant of the first Clock tick is defined by a <<shiftCounter>> or <<shiftDecimal>>.
 +
 The next Clock tick at time instant latexmath:[t_i] is defined as: +
 latexmath:[\begin{align*}
@@ -714,21 +714,21 @@ latexmath:[\begin{align*}
 |===
 
 Constant periodic Clock::
-is a time-based periodic clock that defines its <<interval>> and <<shift>> in the <<modelDescription.xml>>.
+is a time-based periodic clock that defines its <<intervalDecimal>> or <<intervalCounter>> and <<shiftCounter>> or <<shiftDecimal>> in the <<modelDescription.xml>>.
 
 [[fixed-periodic-clock,fixed periodic Clock]]Fixed periodic Clock::
-is a time-based periodic Clock which ticks with an arbitrary, but constant interval starting after an arbitrary <<shift>> defined by the importer.
-The importer informs the FMU about the interval using <<fmi3SetInterval>>.
+is a time-based periodic Clock which ticks with an arbitrary, but constant interval starting after an arbitrary <<shiftCounter>> or <<shiftDecimal>>.
+The importer informs the FMU about the Clock interval using <<fmi3SetInterval>>.
 
 Calculated periodic Clock::
-is a time-based periodic Clock whose <<interval>> and <<shift>> depend on <<fixed>> <<parameter, parameters>>.
-The importer must use <<fmi3GetInterval>> and <<fmi3GetShift>> to retrieve the Clock interval and <<shift>> in <<InitializationMode>>.
+is a time-based periodic Clock whose interval and shift depend on <<fixed>> <<parameter, parameters>>.
+The importer must use <<fmi3GetInterval>> and <<fmi3GetShift>> to retrieve the Clock interval and shift in <<InitializationMode>>.
 
 Tunable periodic Clock::
-is a time-based periodic Clock whose <<interval>> depends on <<tunable>> <<parameter, parameters>>.
+is a time-based periodic Clock whose interval depends on <<tunable>> <<parameter, parameters>>.
 The importer must use <<fmi3GetInterval>> to retrieve the Clock interval in <<EventMode>> or <<ClockActivationMode>>, if any of the <<tunable>> <<parameter, parameters>> it depends on was changed.
-<<shift>> may only depend on <<fixed>> <<parameter, parameters>>.
-The importer must use <<fmi3GetShift>> to retrieve the Clock <<shift>> in <<InitializationMode>>.
+The shift may only depend on <<fixed>> <<parameter, parameters>>.
+The importer must use <<fmi3GetShift>> to retrieve the Clock shift in <<InitializationMode>>.
 
 Aperiodic Clock::
 is a time-based Clock with an interval that can change during runtime by FMU-internal mechanisms.
@@ -764,7 +764,7 @@ Must be retrieved in <<EventMode>> or <<ClockActivationMode>> if and only if the
 [[countdown-aperiodic-clock,countdown aperiodic Clock]]
 Countdown aperiodic Clock::
 is a time-based Clock whose next interval is not yet known right after the Clock just ticked, forcing the importer to call <<fmi3GetInterval>> in every <<EventMode>> and in <<IntermediateUpdateMode>> if <<clocksTicked>> == `fmi3True` in <<fmi3CallbackIntermediateUpdate>>.
-The return argument <<qualifier>> of <<fmi3GetInterval>> is used to indicate if the next interval is already known.
+The return argument <<qualifiers>> of <<fmi3GetInterval>> is used to indicate if the next interval is already known.
 +
 The next Clock tick at time instant latexmath:[t_i] is defined as: +
 latexmath:[\begin{align*}
@@ -783,7 +783,7 @@ latexmath:[\begin{align*}
 Must be retrieved in <<InitializationMode>>.
 
 |latexmath:[\mathbf{T}_{interval, i} \geq 0, \qquad i = 1,2,3,{...}]
-|The time interval from the event time at which the argument <<qualifier,`qualifier == fmi3IntervalChanged`>> of <<fmi3GetInterval>> to the next Clock tick.
+|The time interval from the event time at which the argument <<qualifiers,`qualifiers == fmi3IntervalChanged`>> of <<fmi3GetInterval>> to the next Clock tick.
 
 |===
 
@@ -797,7 +797,7 @@ Triggered output Clock::
 is activated within the FMU and the importer must call <<fmi3GetClock>> in <<EventMode>> or in <<IntermediateUpdateMode>>.
 
 _[Output Clocks are intended to enable an FMU to provide a trigger to the outside world, e.g. to a <<triggered, `triggered input Clock`>> of another FMU._
-_Note, that if intended to activate model partitions or a Clock of the same FMU calling <<fmi3GetInterval>> for a <<countdown, `countdown Clock`>> and evaluating the <<qualifier>> is recommended._
+_Note, that if intended to activate model partitions or a Clock of the same FMU calling <<fmi3GetInterval>> for a <<countdown, `countdown Clock`>> and evaluating the <<qualifiers>> is recommended._
 _An example is provided in <<example-scheduled-execution>>.]_
 
 ===== Model Partitions and Clocked Variables [[clocked-variable]]
@@ -852,8 +852,8 @@ The FMU may request to schedule another model partition even while currently a m
 <<countdown>> Clocks can tick at any time during the execution of any model partition.
 The FMU signals their ticking by calling <<fmi3CallbackIntermediateUpdate>> with argument <<clocksTicked>> == `fmi3True`.
 The importer calls <<fmi3GetInterval>> for all countdown Clocks.
-If a new interval is provided, the importer initiates the scheduling of the associated model partitions with the returned <<interval>>.
-<<qualifier>> == `fmi3IntervalChanged` indicates that the corresponding Clock has to be scheduled.
+If a new interval is provided, the importer initiates the scheduling of the associated model partitions with the returned interval.
+<<qualifiers>> == <<fmi3IntervalChanged>> indicates that the corresponding Clock has to be scheduled.
 
 In case more than one Clock ticks at the same time instant, the scheduler needs a priority to define the activation sequence of the associated model partitions.
 This ordering is defined by the <<priority>> attributes of the Clock.
@@ -883,9 +883,9 @@ include::../headers/fmi3FunctionTypes.h[tags=SetClock]
 <<fmi3SetClock>> is never called in Scheduled Execution.
 
 For some Clock types, the interval [[fmi3SetInterval,`fmi3SetInterval`]] is set by the environment for the current time instant by the function <<fmi3SetIntervalDecimal>> or <<fmi3SetIntervalFraction>>.
-The values of the arguments `interval`, `intervalCounter`, `resolution`, `shift` and `shiftCounter` refer to the unit of the <<independent>> variable.
+The values of the arguments <<intervals>>, <<intervalCounters>>, <<resolutions>>, <<shifts>> and <<shiftCounters>> refer to the unit of the <<independent>> variable.
 
-The attribute <<supportsFraction>> of a Clock declares, if the `fmi3SetIntervalFraction` and/or `fmi3GetXXXFraction` functions are allowed to be called.
+The attribute <<supportsFraction>> of a Clock declares, if the <<fmi3SetIntervalFraction>> and/or `fmi3GetXXXFraction` functions are allowed to be called.
 
 [[fmi3SetIntervalDecimal,`fmi3SetIntervalDecimal`]]
 [source, C]
@@ -895,6 +895,7 @@ include::../headers/fmi3FunctionTypes.h[tag=SetIntervalDecimal]
 
 * `valueReferences` is an array of size `nValueReferences` holding the value references of the Clock variables.
 
+[[intervals,`intervals`]]
 * `intervals` is an array of size `nIntervals` holding the Clock intervals to be set.
 
 [[fmi3SetIntervalFraction,`fmi3SetIntervalFraction`]]
@@ -905,7 +906,9 @@ include::../headers/fmi3FunctionTypes.h[tag=SetIntervalFraction]
 
 * `valueReferences` is an array of size `nValueReferences` holding the value references of the `Clock` variables.
 
-* `intervalCounters` and `resolutions` are arrays of size `nIntervals` holding the Clock <<intervalCounter>> and <<resolution>> to be set.
+[[intervalCounters,`intervalCounters`]]
+[[resolutions,`resolutions`]]
+* `intervalCounters` and <<resolutions>> are arrays of size `nIntervals` holding the Clock <<intervalCounters>> and <<resolutions>> to be set.
 
 [[fmi3GetInterval,`fmi3GetInterval`]]
 For other Clock types, the importer calls <<fmi3GetIntervalDecimal>> or <<fmi3GetIntervalFraction>> to query the next Clock interval:
@@ -920,10 +923,9 @@ include::../headers/fmi3FunctionTypes.h[tag=GetIntervalDecimal]
 
 * `intervals` is an array of size `nIntervals` to retrieve the Clock intervals.
 
-* `qualifiers` is an array of size `nIntervals` to retrieve the Clock <<qualifier>>.
-
-[[qualifier,`qualifier`]]
-`qualifier` describes how to treat the `interval` and `intervalCounter` arguments and is defined as:
+[[qualifiers,`qualifiers`]]
+* `qualifiers` is an array of size `nIntervals` to retrieve the Clocks <<qualifiers>>.
+`qualifiers` describes how to treat the <<intervals>> and <<intervalCounters>> arguments and is defined as:
 
 [source, C]
 ----
@@ -931,8 +933,13 @@ include::../headers/fmi3FunctionTypes.h[tag=IntervalQualifier]
 ----
 with the following meanings:
 
+[[fmi3IntervalNotYetKnown,`fmi3IntervalNotYetKnown`]]
  * `fmi3IntervalNotYetKnown` is returned for <<countdown-aperiodic-clock>> for which the next interval is not yet known. The importer must query the next interval at each <<EventMode>> for all <<countdown-aperiodic-clock>> because the next interval may change at any <<EventMode>>.
+
+[[fmi3IntervalUnchanged,`fmi3IntervalUnchanged`]]
  * `fmi3IntervalUnchanged` is returned if a previous call to <<fmi3GetInterval>> already returned a value which has not changed since.
+
+[[fmi3IntervalChanged,`fmi3IntervalChanged`]]
  * `fmi3IntervalChanged` is returned to indicate that the value for the interval has changed for this <<Clock>>.
  The new <<Clock>> interval is relative to the time of the current <<EventMode>>.
 
@@ -944,11 +951,12 @@ include::../headers/fmi3FunctionTypes.h[tag=GetIntervalFraction]
 
 * `valueReferences` is an array of size `nValueReferences` holding the value references of the `Clock` variables.
 
-* `intervalCounters` and `resolutions` are arrays of size `nIntervals` to retrieve the Clock <<intervalCounter>> and <<resolution>>.
+[[intervalCounters,`intervalCounters`]]
+* `intervalCounters` and <<resolutions>> are arrays of size `nIntervals` to retrieve the Clock <<intervalCounters>> and <<resolutions>>.
 
-* `qualifiers` is an array of size `nIntervals` to retrieve the Clock <<qualifier>>.
+* `qualifiers` is an array of size `nIntervals` to retrieve the Clock <<qualifiers>>.
 
-[[shift, `shift`]]
+[[shifts, `shifts`]]
 For <<table-overview-clocks,some Clocks>>, the importer has to query the delay to the first Clock tick from the FMU using the following functions[[fmi3GetShift,`fmi3GetShift`]]:
 
 [[fmi3GetShiftDecimal,`fmi3GetShiftDecimal`]]
@@ -959,7 +967,7 @@ include::../headers/fmi3FunctionTypes.h[tag=GetShiftDecimal]
 
 * `valueReferences` is an array of size `nValueReferences` holding the value references of the Clock variables.
 
-* `shifts` is an array of length `nShifts` that defines the time of the first Clock tick (see <<shiftCounter>>).
+* <<shifts>> is an array of length `nShifts` that defines the time of the first Clock tick (see <<shiftCounter>>).
 
 [[fmi3GetShiftFraction,`fmi3GetShiftFraction`]]
 [source, C]
@@ -969,7 +977,10 @@ include::../headers/fmi3FunctionTypes.h[tag=GetShiftFraction]
 
 * `valueReferences` is an array of size `nValueReferences` holding the value references of the Clock variables.
 
-* `shifts` and `shiftCounters` are arrays of length `nShifts` that define the time of the first Clock tick (see <<shiftCounter>>).
+* <<shifts>> and
+
+[[shiftCounters,`shiftCounters`]]
+* <<shiftCounters>> are arrays of length `nShifts` that define the time of the first Clock tick (see <<shiftCounter>>).
 
 ==== Dependencies of Variables [[model-dependencies]]
 

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -567,8 +567,8 @@ This allows different use cases to be implemented with different semantics.
 
 Clock variables synchronize events between importer and across FMUs, by
 
-. communicating exactly which specific event happens and
-. exactly at which time instant, independent from continuous time specified by the arguments of `fmi3SetTime` or `fmi3DoStep`.
+. communicating exactly which specific event happens (using <<fmi3SetClock>> in ME and CS or <<fmi3ActivateModelPartition>> in SE) and
+. exactly at which time instant, independent from continuous time specified by the arguments of <<fmi3SetTime>> or <<fmi3DoStep>>.
 
 The first point solves the issue that an FMU must know exactly which event happens during an <<EventMode>> if several events are very close to one another.
 

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -369,6 +369,10 @@ Exceptions:
 
 All strings passed as arguments to `fmi3SetString`, as well as all binary values passed as arguments to `fmi3SetBinary`, must be copied during these function calls, because there is no guarantee of the lifetime of strings or binary values, when these functions return.
 
+_[Note: In Scheduled Execution, Clocks are neither activated nor deactivated by the importer._
+_Instead: The activation of a clock requires the importer to call <<fmi3ActivateModelPartition>>._
+_For triggered output Clocks, the importer must still call <<fmi3GetClock>> during <<IntermediateUpdateMode>>.]_
+
 ===== Handling min/max Range Violations [[min-max-violations]]
 
 Attributes <<min>> and <<max>> can be defined for variables of float, integer or enumeration types.

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -369,7 +369,7 @@ Exceptions:
 
 All strings passed as arguments to `fmi3SetString`, as well as all binary values passed as arguments to `fmi3SetBinary`, must be copied during these function calls, because there is no guarantee of the lifetime of strings or binary values, when these functions return.
 
-_[Note: In Scheduled Execution, Clocks are neither activated nor deactivated by the importer._
+_[Note: In Scheduled Execution, Clocks are neither activated nor deactivated by the importer using <<fmi3SetClock>>._
 _Instead: The activation of a clock requires the importer to call <<fmi3ActivateModelPartition>>._
 _For triggered output Clocks, the importer must still call <<fmi3GetClock>> during <<IntermediateUpdateMode>>.]_
 

--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -717,7 +717,7 @@ This attribute must only be used for <<periodic-clock,periodic Clocks>>.
 This attribute defines, if the functions `fmi3GetXXXFraction` and `fmi3SetIntervalFraction` are allowed to be called for all <<time-based-clock,time-based Clocks>>.
 
 |[[resolution, `resolution`]]`resolution`
-|Instead of defining clock timing using floating point numbers, FMI allows the definition of rational numbers using <<intervalCounter,`intervalCounters`>> and <<shiftCounter,`shiftCounters`>>.
+|Instead of defining clock timing using floating point numbers, FMI allows the definition of rational numbers using <<intervalCounter>> and <<shiftCounter>>.
 The `resolution` defines the minimal quanta clock timing can be resolved by.
 
 This attribute is required for <<periodic-clock,time-based periodic clocks>> if <<supportsFraction,`supportsFraction = true`>> and either <<intervalCounter>> or <<shiftCounter>> is present.
@@ -729,11 +729,11 @@ This attribute must only be used for <<periodic-clock,periodic Clocks>>.
 
 latexmath:[\mathbf{T}_{interval} = ] `intervalCounter / resolution`.
 
-`intervalCounter` and `resolution` have no default value.
+<<intervalCounter>> and <<resolution>> have no default value.
 
 This value must be greater than 0.
 
-This attribute is allowed if <<supportsFraction,`supportsFraction = true`>> and is required if <<interval,interval == `constant`>> or <<interval,interval == `fixed`>>.
+This attribute is allowed if <<supportsFraction,`supportsFraction = true`>> and is required if <<clockType,clockType == `constant`>> or <<clockType,clockType == `fixed`>>.
 
 This attribute must only be used for <<periodic-clock,periodic Clocks>>.
 
@@ -744,7 +744,7 @@ latexmath:[\mathbf{T}_{shift} = ] `shiftCounter / resolution`.
 
 This value must be greater than 0.
 
-This attribute is allowed if <<supportsFraction,`supportsFraction = true`>> and is required if <<interval,interval == `constant`>> or <<interval,interval == `fixed`>>.
+This attribute is allowed if <<supportsFraction,`supportsFraction = true`>> and is required if <<clockType,clockType == `constant`>> or <<clockType,clockType == `fixed`>>.
 
 This attribute must only be used for <<periodic-clock,periodic Clocks>>.
 

--- a/docs/5_1_scheduled_execution_math.adoc
+++ b/docs/5_1_scheduled_execution_math.adoc
@@ -26,7 +26,7 @@ The FMU's code has to be prepared for being able to correctly handle preemptive 
 In general for Scheduled Execution this requires a secured internal and external access to global states and variable values to ensure the correct handling of the preemption of model partition computations.
 _[For <<get-and-set-variable-values,`fmi3Get{VariableType}`>>, <<get-and-set-variable-values,`fmi3Set{VariableType}`>> in particular a unique assignment of the respective variables to model partitions via its associated <<Clock>> is strongly recommended.]_
 It is also required that the FMU reports the active state of an <<outputClock>> only with the first call of <<fmi3GetClock>> for a specific activation of this <<Clock>> and sets the reported activation state immediately back to `false` for the following <<fmi3GetClock>> calls for that <<Clock>> until this <<outputClock>> is internally activated again.
-Similarly for <<countdown, `countdown Clocks`>> a call to <<fmi3GetIntervalDecimal>> has to ensure that the Clock's interval qualifier is reset to <<fmi3GetIntervalDecimal, `fmi3IntervalUnchanged`>>.
+Similarly for <<countdown, `countdown Clocks`>> a call to <<fmi3GetIntervalDecimal>> has to ensure that the Clock's interval qualifier is reset to <<fmi3IntervalUnchanged>>.
 
 If a preemptive multitasking regime is intended, an individual task (or thread -- task and thread are used synonymously here) for each model partition (associated to an <<inputClock>>) has to be created.
 The task for computing each <<fmi3ActivateModelPartition>> is created and controlled by the simulation algorithm, not by the FMU.

--- a/docs/5_3_scheduled_execution_example.adoc
+++ b/docs/5_3_scheduled_execution_example.adoc
@@ -34,7 +34,7 @@ include::examples/snippets.c[tags=SE_sa_task10ms]
 
 The FMU requests to schedule the model partition of `AperiodicClock`.
 It calls <<fmi3CallbackIntermediateUpdate>> to enable the importer to check whether the FMU has defined a new interval for `AperiodicClock`.
-Evaluating the return values <<qualifier>> and <<interval>> of <<fmi3GetInterval>> the simulation algorithms determines if the respective task has to be scheduled and which delay has to be applied.
+Evaluating the return values <<qualifiers>> and <<intervals>> of <<fmi3GetInterval>> the simulation algorithms determines if the respective task has to be scheduled and which delay has to be applied.
 
 [source, C]
 ----
@@ -57,7 +57,7 @@ In the context of the task being executed every 10 ms, the FMU initiates the sch
 include::examples/snippets.c[tags=SE_fmu_activateMP10ms]
 ----
 
-In <<fmi3GetIntervalDecimal>> the Clock's interval qualifier is reset to <<fmi3GetIntervalDecimal, `fmi3IntervalUnchanged`>>.
+In <<fmi3GetIntervalDecimal>> the Clock's interval qualifier is reset to <<fmi3IntervalUnchanged>>.
 To ensure consistency the FMU may need to prevent preemption.
 In this example it is actually not needed since CallbackIntermediateUpdate is only called from one model partition.
 

--- a/schema/fmi3AttributeGroups.xsd
+++ b/schema/fmi3AttributeGroups.xsd
@@ -97,7 +97,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <xs:attributeGroup name="fmi3ClockAttributes">
         <xs:attribute name="canBeDeactivated" type="xs:boolean" default="false"/>
         <xs:attribute name="priority" type="xs:unsignedInt" use="optional"/>
-        <xs:attribute name="interval" use="required">
+        <xs:attribute name="clockType" use="required">
             <xs:simpleType>
                 <xs:restriction base="xs:normalizedString">
                     <xs:enumeration value="constant"/>


### PR DESCRIPTION
What about all other derivative functions in SE?