### PR TITLE
Some changes regarding intervalQualifier and getInterval

### DIFF
--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -952,7 +952,7 @@ with the following meanings:
  * `fmi3IntervalChanged` is returned to indicate that the value for the interval has changed for this <<Clock>>.
  Any previously returned intervals (if any) are overwritten with the current value.
  The new <<Clock>> interval is relative to the time of the current <<EventMode>> or <<ClockUpdateMode>> in contrast to the interval of a periodic <<Clock>>, where the interval is defined as the time between consecutive <<Clock>> ticks.
- In Scheduled Execution this means that the corresponding Clock has to be scheduled or re-scheduled (if a previous call to <<fmi3GetInterval>> returned <<fmi3IntervalChanged>>).
+ In Scheduled Execution this means that the corresponding model partition has to be scheduled or re-scheduled (if a previous call to <<fmi3GetInterval>> returned <<fmi3IntervalChanged>>).
 
  [[fmi3IntervalUnchanged,`fmi3IntervalUnchanged`]]
   * `fmi3IntervalUnchanged` is returned if a previous call to <<fmi3GetInterval>> already returned a value qualified with <<fmi3IntervalChanged>> which has not changed since.
@@ -960,7 +960,7 @@ with the following meanings:
 
 [[fmi3IntervalNotYetKnown,`fmi3IntervalNotYetKnown`]]
  * `fmi3IntervalNotYetKnown` is returned for a <<countdown-aperiodic-clock>> for which the next interval is not yet known.
- This qualifier value can only be returned directly after the corresponding Clock was active and previous calls to <<fmi3GetInterval>> never returned <<fmi3IntervalChanged>> (nor <<fmi3IntervalUnchanged>>).
+ This qualifier value can only be returned directly after the Clock was active and previous calls to <<fmi3GetInterval>> never returned <<fmi3IntervalChanged>> (nor <<fmi3IntervalUnchanged>>).
  In Scheduled Execution this return value means that the corresponding model partition cannot be scheduled yet.
 
 The importer must query the next interval at each <<EventMode>> or <<ClockUpdateMode>>, for all <<countdown-aperiodic-clock,countdown aperiodic Clocks>> because the next interval may become available or may change at any <<EventMode>> or <<ClockUpdateMode>>.

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -911,7 +911,7 @@ include::../headers/fmi3FunctionTypes.h[tag=SetIntervalDecimal]
 * `valueReferences` is an array of size `nValueReferences` holding the value references of the Clock variables.
 
 [[intervals,`intervals`]]
-* `intervals` is an array of size `nIntervals` holding the Clock intervals to be set.
+* `intervals` is an array of size `nValueReferences` holding the Clock intervals to be set.
 
 [[fmi3SetIntervalFraction,`fmi3SetIntervalFraction`]]
 [source, C]
@@ -923,7 +923,7 @@ include::../headers/fmi3FunctionTypes.h[tag=SetIntervalFraction]
 
 [[intervalCounters,`intervalCounters`]]
 [[resolutions,`resolutions`]]
-* `intervalCounters` and <<resolutions>> are arrays of size `nIntervals` holding the Clock <<intervalCounters>> and <<resolutions>> to be set.
+* `intervalCounters` and <<resolutions>> are arrays of size `nValueReferences` holding the Clock <<intervalCounters>> and <<resolutions>> to be set.
 
 [[fmi3GetInterval,`fmi3GetInterval`]]
 For other Clock types, the importer calls <<fmi3GetIntervalDecimal>> or <<fmi3GetIntervalFraction>> to query the next Clock interval:
@@ -936,10 +936,10 @@ include::../headers/fmi3FunctionTypes.h[tag=GetIntervalDecimal]
 
 * `valueReferences` is an array of size `nValueReferences` holding the value references of the `Clock` variables.
 
-* `intervals` is an array of size `nIntervals` to retrieve the Clock intervals.
+* `intervals` is an array of size `nValueReferences` to retrieve the Clock intervals.
 
 [[qualifiers,`qualifiers`]]
-* `qualifiers` is an array of size `nIntervals` to retrieve the Clocks <<qualifiers>>.
+* `qualifiers` is an array of size `nValueReferences` to retrieve the Clocks <<qualifiers>>.
 `qualifiers` describes how to treat the <<intervals>> and <<intervalCounters>> arguments and is defined as:
 
 [source, C]
@@ -953,7 +953,7 @@ with the following meanings:
  The importer must query the next interval at each <<EventMode>> or <<ClockUpdateMode>>, for all <<countdown-aperiodic-clock,countdown aperiodic Clocks>> because the next interval may change at any <<EventMode>> or <<ClockUpdateMode>>.
 
 [[fmi3IntervalUnchanged,`fmi3IntervalUnchanged`]]
- * `fmi3IntervalUnchanged` is returned if a previous call to <<fmi3GetInterval>> already returned a value which has not changed since.
+ * `fmi3IntervalUnchanged` is returned if a previous call to <<fmi3GetInterval>> already returned a value which has not changed since. In Scheduled Execution this means the corresponding model partition is already scheduled.
 
 [[fmi3IntervalChanged,`fmi3IntervalChanged`]]
  * `fmi3IntervalChanged` is returned to indicate that the value for the interval has changed for this <<Clock>>.
@@ -968,9 +968,9 @@ include::../headers/fmi3FunctionTypes.h[tag=GetIntervalFraction]
 * `valueReferences` is an array of size `nValueReferences` holding the value references of the `Clock` variables.
 
 [[intervalCounters,`intervalCounters`]]
-* `intervalCounters` and <<resolutions>> are arrays of size `nIntervals` to retrieve the Clock <<intervalCounters>> and <<resolutions>>.
+* `intervalCounters` and <<resolutions>> are arrays of size `nValueReferences` to retrieve the Clock <<intervalCounters>> and <<resolutions>>.
 
-* `qualifiers` is an array of size `nIntervals` to retrieve the Clock <<qualifiers>>.
+* `qualifiers` is an array of size `nValueReferences` to retrieve the Clock <<qualifiers>>.
 
 [[shifts, `shifts`]]
 For <<table-overview-clocks,some Clocks>>, the importer has to query the delay to the first Clock tick from the FMU using the following functions[[fmi3GetShift,`fmi3GetShift`]]:
@@ -983,7 +983,7 @@ include::../headers/fmi3FunctionTypes.h[tag=GetShiftDecimal]
 
 * `valueReferences` is an array of size `nValueReferences` holding the value references of the Clock variables.
 
-* <<shifts>> is an array of length `nShifts` that defines the time of the first Clock tick (see <<shiftCounter>>).
+* <<shifts>> is an array of length `nValueReferences` that defines the time of the first Clock tick (see <<shiftCounter>>).
 
 [[fmi3GetShiftFraction,`fmi3GetShiftFraction`]]
 [source, C]
@@ -996,7 +996,7 @@ include::../headers/fmi3FunctionTypes.h[tag=GetShiftFraction]
 * <<shifts>> and
 
 [[shiftCounters,`shiftCounters`]]
-* <<shiftCounters>> are arrays of length `nShifts` that define the time of the first Clock tick (see <<shiftCounter>>).
+* <<shiftCounters>> are arrays of length `nValueReferences` that define the time of the first Clock tick (see <<shiftCounter>>).
 
 ==== Dependencies of Variables [[model-dependencies]]
 

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -948,19 +948,22 @@ include::../headers/fmi3FunctionTypes.h[tag=IntervalQualifier]
 ----
 with the following meanings:
 
-[[fmi3IntervalNotYetKnown,`fmi3IntervalNotYetKnown`]]
- * `fmi3IntervalNotYetKnown` is returned for a <<countdown-aperiodic-clock>> for which the next interval is not yet known.
- The importer must query the next interval at each <<EventMode>> or <<ClockUpdateMode>>, for all <<countdown-aperiodic-clock,countdown aperiodic Clocks>> because the next interval may change at any <<EventMode>> or <<ClockUpdateMode>>.
- When the corresponding model partitions are activated the interval qualifiers must be reset to `fmi3IntervalNotYetKnown`.
-
-[[fmi3IntervalUnchanged,`fmi3IntervalUnchanged`]]
- * `fmi3IntervalUnchanged` is returned if a previous call to <<fmi3GetInterval>> already returned a value which has not changed since.
- Therefore, the FMU has to reset the qualifier to `fmi3IntervalUnchanged` directly after returning a new interval.
- In Scheduled Execution this means the corresponding model partition is already scheduled.
-
 [[fmi3IntervalChanged,`fmi3IntervalChanged`]]
  * `fmi3IntervalChanged` is returned to indicate that the value for the interval has changed for this <<Clock>>.
+ Any previously returned intervals (if any) are overwritten with the current value.
  The new <<Clock>> interval is relative to the time of the current <<EventMode>> or <<ClockUpdateMode>> in contrast to the interval of a periodic <<Clock>>, where the interval is defined as the time between consecutive <<Clock>> ticks.
+ In Scheduled Execution this means that the corresponding Clock has to be scheduled or re-scheduled (if a previous call to <<fmi3GetInterval>> returned <<fmi3IntervalChanged>>).
+
+ [[fmi3IntervalUnchanged,`fmi3IntervalUnchanged`]]
+  * `fmi3IntervalUnchanged` is returned if a previous call to <<fmi3GetInterval>> already returned a value qualified with <<fmi3IntervalChanged>> which has not changed since.
+  In Scheduled Execution this means the corresponding model partition has already been scheduled.
+
+[[fmi3IntervalNotYetKnown,`fmi3IntervalNotYetKnown`]]
+ * `fmi3IntervalNotYetKnown` is returned for a <<countdown-aperiodic-clock>> for which the next interval is not yet known.
+ This qualifier value can only be returned directly after the corresponding Clock was active and previous calls to <<fmi3GetInterval>> never returned <<fmi3IntervalChanged>> (nor <<fmi3IntervalUnchanged>>).
+ In Scheduled Execution this return value means that the corresponding model partition cannot be scheduled yet.
+
+The importer must query the next interval at each <<EventMode>> or <<ClockUpdateMode>>, for all <<countdown-aperiodic-clock,countdown aperiodic Clocks>> because the next interval may become available or may change at any <<EventMode>> or <<ClockUpdateMode>>.
 
 [[fmi3GetIntervalFraction,`fmi3GetIntervalFraction`]]
 [source, C]

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -951,9 +951,11 @@ with the following meanings:
 [[fmi3IntervalNotYetKnown,`fmi3IntervalNotYetKnown`]]
  * `fmi3IntervalNotYetKnown` is returned for a <<countdown-aperiodic-clock>> for which the next interval is not yet known.
  The importer must query the next interval at each <<EventMode>> or <<ClockUpdateMode>>, for all <<countdown-aperiodic-clock,countdown aperiodic Clocks>> because the next interval may change at any <<EventMode>> or <<ClockUpdateMode>>.
+ When the corresponding model partitions are activated the interval qualifiers must be reset to `fmi3IntervalNotYetKnown`.
 
 [[fmi3IntervalUnchanged,`fmi3IntervalUnchanged`]]
  * `fmi3IntervalUnchanged` is returned if a previous call to <<fmi3GetInterval>> already returned a value which has not changed since.
+ Therefore, the FMU has to reset the qualifier to `fmi3IntervalUnchanged` directly after returning a new interval.
  In Scheduled Execution this means the corresponding model partition is already scheduled.
 
 [[fmi3IntervalChanged,`fmi3IntervalChanged`]]

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -953,7 +953,8 @@ with the following meanings:
  The importer must query the next interval at each <<EventMode>> or <<ClockUpdateMode>>, for all <<countdown-aperiodic-clock,countdown aperiodic Clocks>> because the next interval may change at any <<EventMode>> or <<ClockUpdateMode>>.
 
 [[fmi3IntervalUnchanged,`fmi3IntervalUnchanged`]]
- * `fmi3IntervalUnchanged` is returned if a previous call to <<fmi3GetInterval>> already returned a value which has not changed since. In Scheduled Execution this means the corresponding model partition is already scheduled.
+ * `fmi3IntervalUnchanged` is returned if a previous call to <<fmi3GetInterval>> already returned a value which has not changed since.
+ In Scheduled Execution this means the corresponding model partition is already scheduled.
 
 [[fmi3IntervalChanged,`fmi3IntervalChanged`]]
  * `fmi3IntervalChanged` is returned to indicate that the value for the interval has changed for this <<Clock>>.

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -396,22 +396,13 @@ See <<fmi3GetAdjointDerivative>>.
 Function <<fmi3GetEventIndicators>>::
 See <<fmi3GetEventIndicators>>.
 
-Function <<fmi3GetShiftDecimal>>::
+Functions <<fmi3GetShiftDecimal>> & <<fmi3GetShiftFraction>>::
 See <<fmi3GetShift>>.
 
-Function <<fmi3GetShiftFraction>>::
-See <<fmi3GetShift>>.
-
-Function <<fmi3GetIntervalDecimal>>::
+Functions <<fmi3GetIntervalDecimal>> & <<fmi3GetIntervalFraction>>::
 See <<fmi3GetInterval>>.
 
-Function <<fmi3GetIntervalFraction>>::
-See <<fmi3GetInterval>>.
-
-Function <<fmi3SetIntervalDecimal>>::
-One of these functions must be called for all <<fixed-periodic-clock,Fixed periodic Clocks>>.
-
-Function <<fmi3SetIntervalFraction>>::
+Functions <<fmi3SetIntervalDecimal>> & <<fmi3SetIntervalFraction>>::
 One of these functions must be called for all <<fixed-periodic-clock,Fixed periodic Clocks>>.
 
 [[fmi3ExitInitializationMode,`fmi3ExitInitializationMode`]]
@@ -563,8 +554,7 @@ _If the semantics of some Clocks require any specific treatment, e.g. activation
 Function <<fmi3GetClock>>::
 is used to inquire the status of <<Clock,Clocks>>.
 
-Function <<fmi3GetIntervalDecimal>>::
-Function <<fmi3GetIntervalFraction>>::
+Functions <<fmi3GetIntervalDecimal>> & <<fmi3GetIntervalFraction>>::
 For <<inputClock,`input Clocks`>> it is allowed to call these functions to query the next activation interval. +
 For <<changing-aperiodic-clock>>, these functions must be called in every <<EventMode>> where this clock was activated. +
 For <<countdown-aperiodic-clock>>, these functions must be called in every <<EventMode>>. +

--- a/docs/5_1_scheduled_execution_math.adoc
+++ b/docs/5_1_scheduled_execution_math.adoc
@@ -9,7 +9,8 @@ The FMU's code has to be prepared for being able to correctly handle preemptive 
 In general for Scheduled Execution this requires a secured internal and external access to global states and variable values to ensure the correct handling of the preemption of model partition computations.
 _[For <<get-and-set-variable-values,`fmi3Get{VariableType}`>>, <<get-and-set-variable-values,`fmi3Set{VariableType}`>> in particular a unique assignment of the respective variables to model partitions via its associated <<Clock>> is strongly recommended.]_
 It is also required that the FMU reports the active state of an <<outputClock>> only with the first call of <<fmi3GetClock>> for a specific activation of this <<Clock>> and sets the reported activation state immediately back to `false` for the following <<fmi3GetClock>> calls for that <<Clock>> until this <<outputClock>> is internally activated again.
-Similarly for <<countdown, `countdown Clocks`>> a call to <<fmi3GetIntervalDecimal>> has to ensure that the Clock's interval qualifier is reset to <<fmi3IntervalUnchanged>>. When the corresponding model partition is activated the interval qualifier must be reset to <<fmi3IntervalNotYetKnown>>.
+Similarly for <<countdown, `countdown Clocks`>> a call to <<fmi3GetIntervalDecimal>> has to ensure that the Clock's interval qualifier is reset to <<fmi3IntervalUnchanged>>.
+When the corresponding model partition is activated the interval qualifier must be reset to <<fmi3IntervalNotYetKnown>>.
 
 If a preemptive multitasking regime is intended, an individual task (or thread -- task and thread are used synonymously here) for each model partition (associated to an <<inputClock>>) has to be created.
 The task for computing each <<fmi3ActivateModelPartition>> is created and controlled by the simulation algorithm, not by the FMU.

--- a/docs/5_1_scheduled_execution_math.adoc
+++ b/docs/5_1_scheduled_execution_math.adoc
@@ -9,7 +9,7 @@ The FMU's code has to be prepared for being able to correctly handle preemptive 
 In general for Scheduled Execution this requires a secured internal and external access to global states and variable values to ensure the correct handling of the preemption of model partition computations.
 _[For <<get-and-set-variable-values,`fmi3Get{VariableType}`>>, <<get-and-set-variable-values,`fmi3Set{VariableType}`>> in particular a unique assignment of the respective variables to model partitions via its associated <<Clock>> is strongly recommended.]_
 It is also required that the FMU reports the active state of an <<outputClock>> only with the first call of <<fmi3GetClock>> for a specific activation of this <<Clock>> and sets the reported activation state immediately back to `false` for the following <<fmi3GetClock>> calls for that <<Clock>> until this <<outputClock>> is internally activated again.
-Similarly for <<countdown, `countdown Clocks`>> a call to <<fmi3GetIntervalDecimal>> has to ensure that the Clock's interval qualifier is reset to <<fmi3IntervalUnchanged>>.
+Similarly for <<countdown, `countdown Clocks`>> a call to <<fmi3GetIntervalDecimal>> has to ensure that the Clock's interval qualifier is reset to <<fmi3IntervalUnchanged>>. When the corresponding model partition is activated the interval qualifier must be reset to <<fmi3IntervalNotYetKnown>>.
 
 If a preemptive multitasking regime is intended, an individual task (or thread -- task and thread are used synonymously here) for each model partition (associated to an <<inputClock>>) has to be created.
 The task for computing each <<fmi3ActivateModelPartition>> is created and controlled by the simulation algorithm, not by the FMU.

--- a/docs/5_1_scheduled_execution_math.adoc
+++ b/docs/5_1_scheduled_execution_math.adoc
@@ -9,8 +9,7 @@ The FMU's code has to be prepared for being able to correctly handle preemptive 
 In general for Scheduled Execution this requires a secured internal and external access to global states and variable values to ensure the correct handling of the preemption of model partition computations.
 _[For <<get-and-set-variable-values,`fmi3Get{VariableType}`>>, <<get-and-set-variable-values,`fmi3Set{VariableType}`>> in particular a unique assignment of the respective variables to model partitions via its associated <<Clock>> is strongly recommended.]_
 It is also required that the FMU reports the active state of an <<outputClock>> only with the first call of <<fmi3GetClock>> for a specific activation of this <<Clock>> and sets the reported activation state immediately back to `false` for the following <<fmi3GetClock>> calls for that <<Clock>> until this <<outputClock>> is internally activated again.
-Similarly for <<countdown, `countdown Clocks`>> a call to <<fmi3GetIntervalDecimal>> has to ensure that the Clock's interval qualifier is reset to <<fmi3IntervalUnchanged>>.
-When the corresponding model partition is activated the interval qualifier must be reset to <<fmi3IntervalNotYetKnown>>.
+Similarly for <<countdown>> Clocks a call to <<fmi3GetIntervalDecimal>> has to ensure that the Clock's interval qualifier is reset to <<fmi3IntervalUnchanged>>.
 
 If a preemptive multitasking regime is intended, an individual task (or thread -- task and thread are used synonymously here) for each model partition (associated to an <<inputClock>>) has to be created.
 The task for computing each <<fmi3ActivateModelPartition>> is created and controlled by the simulation algorithm, not by the FMU.

--- a/docs/5_2_scheduled_execution_api.adoc
+++ b/docs/5_2_scheduled_execution_api.adoc
@@ -125,7 +125,7 @@ _[If required, the FMU can internally derive the <<Clock>> interval_ latexmath:[
 Consecutive calls to <<fmi3ActivateModelPartition>> for a <<clockReference>> (i.e. <<valueReference>> of <<Clock>> variable) must have strictly monotonically increasing <<activationTime>> latexmath:[\mathbf{t}_i].
 
 Functions <<fmi3GetIntervalDecimal>> & <<fmi3GetIntervalFraction>>::
-These function calls are allowed for <<tunableClock>> and <<changing, `changing Clocks`>>.
+These function calls are allowed for <<tunableClock>> and <<changing>> Clocks.
 
 [[fmi3CallbackClockUpdate,`fmi3CallbackClockUpdate`]]
 Function `fmi3CallbackClockUpdate`::
@@ -158,7 +158,7 @@ For an <<outputClock>> only the first call of <<fmi3GetClock>> for a specific ac
 The FMU sets the reported activation state immediately back to fmi3ClockInactive` for following <<fmi3GetClock>> calls for that <<Clock>> until this <<outputClock>> is activated again.
 
 Functions <<fmi3GetIntervalDecimal>> & <<fmi3GetIntervalFraction>>::
-These function calls are allowed for <<countdown,`countdown Clocks`>>.
+These function calls are allowed for <<countdown>> Clocks.
 
 _[In Scheduled Execution it cannot be determined which model partition has called <<fmi3CallbackClockUpdate>>, because multiple model partitions can be active at the same time._
 _Since all information about which model partition to activate is coded into its corresponding Clock, there is no need to know which potentially other model partition activated this Clock.]_

--- a/docs/5_2_scheduled_execution_api.adoc
+++ b/docs/5_2_scheduled_execution_api.adoc
@@ -124,6 +124,9 @@ _[If required, the FMU can internally derive the <<Clock>> interval_ latexmath:[
 +
 Consecutive calls to <<fmi3ActivateModelPartition>> for a <<clockReference>> (i.e. <<valueReference>> of <<Clock>> variable) must have strictly monotonically increasing <<activationTime>> latexmath:[\mathbf{t}_i].
 
+Functions <<fmi3GetIntervalDecimal>> & <<fmi3GetIntervalFraction>>::
+These function calls are allowed for <<tunableClock>> and <<changing, `changing Clocks`>>.
+
 [[fmi3CallbackClockUpdate,`fmi3CallbackClockUpdate`]]
 Function `fmi3CallbackClockUpdate`::
 
@@ -155,7 +158,7 @@ For an <<outputClock>> only the first call of <<fmi3GetClock>> for a specific ac
 The FMU sets the reported activation state immediately back to fmi3ClockInactive` for following <<fmi3GetClock>> calls for that <<Clock>> until this <<outputClock>> is activated again.
 
 Functions <<fmi3GetIntervalDecimal>> & <<fmi3GetIntervalFraction>>::
-These function calls are allowed for <<countdown,countdown Clocks>>.
+These function calls are allowed for <<countdown,`countdown Clocks`>>.
 
 _[In Scheduled Execution it cannot be determined which model partition has called <<fmi3CallbackClockUpdate>>, because multiple model partitions can be active at the same time._
 _Since all information about which model partition to activate is coded into its corresponding Clock, there is no need to know which potentially other model partition activated this Clock.]_

--- a/docs/5_3_scheduled_execution_example.adoc
+++ b/docs/5_3_scheduled_execution_example.adoc
@@ -8,7 +8,7 @@ During the execution of the model partition of <<Clock>> `10msClock`, the FMU ch
 The importer retrieves this interval and activates the corresponding model partition.
 
 In this example, the calls to <<fmi3ActivateModelPartition>> (as well as related <<get-and-set-variable-values,`fmi3Get{VariableType}`>> and `fmi3Set{VariableType}`) for each associated Clock are placed into a task.
-A task can be thought of as a simple interface of the scheduler that allows to connect the FMU interface by implementing a void/void function and set up the task's priorities as derived from the respective <<Clock>> configurations of the FMU.
+A task can be thought of as a simple interface of the scheduler that allows to connect the FMU interface by implementing a void/void function and set up the priorities of the tasks as derived from the respective <<Clock>> configurations of the FMU.
 
 As a result of the FMU's configuration and implementation the following can be observed:
 The task of <<countdown,countdown clock>> `AperiodicClock` is waiting for the task of <<Clock>> `10msClock` to finish.
@@ -65,6 +65,13 @@ In this example it is actually not needed since CallbackClockUpdate is only call
 [source, C]
 ----
 include::examples/snippets.c[tags=SE_fmu_getIntervalDecimal]
+----
+
+In the aperiodic model partition the interval qualifier is reset to <<fmi3IntervalNotYetKnown>>.
+
+[source, C]
+----
+include::examples/snippets.c[tags=SE_fmu_activateMPAperiodic]
 ----
 
 If <<fmi3GetClock>> is called for a certain <<outputClock>> the <<outputClock>> is reset.

--- a/docs/examples/snippets.c
+++ b/docs/examples/snippets.c
@@ -88,7 +88,6 @@ void activateModelPartition50ms(fmi3Instance* instance, fmi3Float64 activationTi
     ModelInstance * inst = (ModelInstance *) instance;
     inst->BOut = 2.2 * inst->BIn;
 }
-void activateModelPartitionAperiodic(fmi3Instance* instance, fmi3Float64 activationTime) {}
 
 /*tag::SE_sa_task10ms[] */
 void ExecuteModelPartition10ms() {
@@ -100,21 +99,21 @@ void ExecuteModelPartition10ms() {
 
 /* tag::SE_sa_clockUpdate[] */
 void CallbackClockUpdate(fmi3InstanceEnvironment instanceEnvironment) {
-
     fmi3Float64 interval[] = { 0.0 };
     fmi3IntervalQualifier intervalQualifier[] = { fmi3IntervalNotYetKnown };
-    // ask FMU if countdown clock is about to tick
+
+    // ask FMU if countdown clock AperiodicClock is about to tick
     const fmi3ValueReference aperiodicClockReferences[] = { 6 };
-    fmi3GetIntervalDecimal(fmu, aperiodicClockReferences, 1, interval, intervalQualifier, 1);
+    fmi3GetIntervalDecimal(fmu, aperiodicClockReferences, 1, interval, intervalQualifier);
     if (intervalQualifier[0] == fmi3IntervalChanged) {
         // schedule task for AperiodicClock with a delay
         ScheduleAperiodicTask(interval[0]);
     }
-    // ask FMU if output clock has ticked
+    // ask FMU if OutputClock has ticked
     fmi3ValueReference outputClockReferences[] = { 7 };
-    fmi3Boolean clocksActivationState[] = { fmi3ClockInactive };
-    fmi3GetClock(fmu, outputClockReferences, 1, clocksActivationState, 1);
-    if (clocksActivationState[0]) {
+    fmi3Boolean clockActivationStates[] = { fmi3ClockInactive };
+    fmi3GetClock(fmu, outputClockReferences, 1, clockActivationStates);
+    if (clockActivationStates[0]) {
         // schedule some external task
         ScheduleExternalTask();
     }
@@ -129,24 +128,33 @@ void activateModelPartition10ms(fmi3Instance instance, fmi3Float64 activationTim
     if (conditionForCountdownClockMet) {
         inst->CountdownClockQualifier = fmi3IntervalChanged;
         inst->CountdownClockInterval = 0.0;
-        // inform simulation algorithm that the countdown clock has ticked
+        // inform the simulation algorithm that countdown clock AperiodicClock is about to tick
         inst->callbackClockUpdate(inst->instanceEnvironment);
     }
+
     fmi3Boolean conditionForOutputClockMet = (inst->AIn2 > 42.0);
     if (conditionForOutputClockMet) {
-        // outputClock ticks
+        // OutputClock ticks
         inst->OutputClockTicked = fmi3ClockActive;
-        // inform simulation algorithm that output clock has ticked
+        // inform the simulation algorithm that OutputClock has ticked
         inst->callbackClockUpdate(inst->instanceEnvironment);
     }
     inst->AOut = inst->AIn1 + inst->AIn2;
 }
 /* end::SE_fmu_activateMP10ms[] */
 
-/* tag::SE_fmu_activateMP[] */
-fmi3Status fmi3ActivateModelPartition(fmi3Instance instance, fmi3ValueReference clockReference,
-    fmi3Float64 activationTime) {
+/* tag::SE_fmu_activateMPAperiodic[] */
+void activateModelPartitionAperiodic(fmi3Instance instance, fmi3Float64 activationTime) {
+    ModelInstance* inst = (ModelInstance*)instance;
+    inst->CountdownClockQualifier = fmi3IntervalNotYetKnown;
+    // ...
+}
+/* end::SE_fmu_activateMPAperiodic[] */
 
+/* tag::SE_fmu_activateMP[] */
+fmi3Status fmi3ActivateModelPartition(fmi3Instance instance,
+                                      fmi3ValueReference clockReference,
+                                      fmi3Float64 activationTime) {
     switch (clockReference) {
     case 5:    // Input clock 10msClock
         activateModelPartition10ms(instance, activationTime);
@@ -164,20 +172,30 @@ fmi3Status fmi3ActivateModelPartition(fmi3Instance instance, fmi3ValueReference 
 /* end::SE_fmu_activateMP[] */
 
 /* tag::SE_fmu_getIntervalDecimal[] */
-fmi3Status fmi3GetIntervalDecimal(fmi3Instance instance, const fmi3ValueReference valueReferences[],
-    size_t nValueReferences, fmi3Float64 interval[], fmi3IntervalQualifier qualifier[], size_t nValues) {
+fmi3Status fmi3GetIntervalDecimal(fmi3Instance instance,
+                                  const fmi3ValueReference valueReferences[],
+                                  size_t nValueReferences,
+                                  fmi3Float64 interval[],
+                                  fmi3IntervalQualifier qualifier[]) {
     ModelInstance * inst = (ModelInstance *) instance;
 
-    for (int i = 0; i < nValues; i++) {
-        if (valueReferences[i] == 6) {
+    for (int i = 0; i < nValueReferences; i++) {
+        switch (valueReferences[i]) {
+        case 5:    // Input clock 10msClock
+            interval[i] = 0.01;
+            qualifier[i] = fmi3IntervalUnchanged;
+            break;
+        case 6:    // Input clock AperiodicClock
             env->lockPreemption(); // Optional: Preventing preemption is actually not needed here.
             interval[i] = inst->CountdownClockInterval;
             qualifier[i] = inst->CountdownClockQualifier;
             inst->CountdownClockQualifier = fmi3IntervalUnchanged;
             env->unlockPreemption();
-        }
-        else {
-            qualifier[i] = fmi3IntervalNotYetKnown;
+            break;
+        case 8:    // Input clock 50msClock
+            interval[i] = 0.05;
+            qualifier[i] = fmi3IntervalUnchanged;
+        // ...
         }
     }
     return fmi3OK;
@@ -185,19 +203,21 @@ fmi3Status fmi3GetIntervalDecimal(fmi3Instance instance, const fmi3ValueReferenc
 /* end::SE_fmu_getIntervalDecimal[] */
 
 /* tag::SE_fmu_getClock[] */
-fmi3Status fmi3GetClock(fmi3Instance instance, const fmi3ValueReference valueReferences[],
-    size_t nValueReferences, fmi3Clock values[], size_t nValues) {
+fmi3Status fmi3GetClock(fmi3Instance instance,
+                        const fmi3ValueReference valueReferences[],
+                        size_t nValueReferences,
+                        fmi3Clock values[]) {
     ModelInstance * inst = (ModelInstance *) instance;
 
-    for (int i = 0; i < nValues; i++) {
-        if (valueReferences[i] == 7) {
+    for (int i = 0; i < nValueReferences; i++) {
+        switch (valueReferences[i]) {
+        case 7:    // OutputClock
             env->lockPreemption(); // Optional: Preventing preemption is actually not needed here.
             values[i] = inst->OutputClockTicked;
             inst->OutputClockTicked = fmi3ClockInactive;
             env->unlockPreemption();
-        }
-        else {
-            values[i] = fmi3ClockInactive;
+            break;
+        // ...
         }
     }
     return fmi3OK;

--- a/docs/examples/snippets.c
+++ b/docs/examples/snippets.c
@@ -189,7 +189,9 @@ fmi3Status fmi3GetIntervalDecimal(fmi3Instance instance,
             env->lockPreemption(); // Optional: Preventing preemption is actually not needed here.
             interval[i] = inst->CountdownClockInterval;
             qualifier[i] = inst->CountdownClockQualifier;
-            inst->CountdownClockQualifier = fmi3IntervalUnchanged;
+            if (inst->CountdownClockQualifier == fmi3IntervalChanged) {
+                inst->CountdownClockQualifier = fmi3IntervalUnchanged;
+            }
             env->unlockPreemption();
             break;
         case 8:    // Input clock 50msClock

--- a/headers/fmi3FunctionTypes.h
+++ b/headers/fmi3FunctionTypes.h
@@ -284,8 +284,7 @@ typedef fmi3Status fmi3GetBinaryTYPE (fmi3Instance instance,
 typedef fmi3Status fmi3GetClockTYPE  (fmi3Instance instance,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
-                                      fmi3Clock values[],
-                                      size_t nValues);
+                                      fmi3Clock values[]);
 /* end::GetClock[] */
 
 /* tag::Setters[] */
@@ -372,8 +371,7 @@ typedef fmi3Status fmi3SetBinaryTYPE (fmi3Instance instance,
 typedef fmi3Status fmi3SetClockTYPE  (fmi3Instance instance,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
-                                      const fmi3Clock values[],
-                                      size_t nValues);
+                                      const fmi3Clock values[]);
 /* end::SetClock[] */
 
 /* Getting Variable Dependency Information */
@@ -467,8 +465,7 @@ typedef fmi3Status fmi3GetIntervalDecimalTYPE(fmi3Instance instance,
                                               const fmi3ValueReference valueReferences[],
                                               size_t nValueReferences,
                                               fmi3Float64 intervals[],
-                                              fmi3IntervalQualifier qualifiers[],
-                                              size_t nIntervals);
+                                              fmi3IntervalQualifier qualifiers[]);
 /* end::GetIntervalDecimal[] */
 
 /* tag::GetIntervalFraction[] */
@@ -477,16 +474,14 @@ typedef fmi3Status fmi3GetIntervalFractionTYPE(fmi3Instance instance,
                                                size_t nValueReferences,
                                                fmi3UInt64 intervalCounters[],
                                                fmi3UInt64 resolutions[],
-                                               fmi3IntervalQualifier qualifiers[],
-                                               size_t nIntervals);
+                                               fmi3IntervalQualifier qualifiers[]);
 /* end::GetIntervalFraction[] */
 
 /* tag::GetShiftDecimal[] */
 typedef fmi3Status fmi3GetShiftDecimalTYPE(fmi3Instance instance,
                                            const fmi3ValueReference valueReferences[],
                                            size_t nValueReferences,
-                                           fmi3Float64 shifts[],
-                                           size_t nShifts);
+                                           fmi3Float64 shifts[]);
 /* end::GetShiftDecimal[] */
 
 /* tag::GetShiftFraction[] */
@@ -494,16 +489,14 @@ typedef fmi3Status fmi3GetShiftFractionTYPE(fmi3Instance instance,
                                             const fmi3ValueReference valueReferences[],
                                             size_t nValueReferences,
                                             fmi3UInt64 shiftCounters[],
-                                            fmi3UInt64 resolutions[],
-                                            size_t nShifts);
+                                            fmi3UInt64 resolutions[]);
 /* end::GetShiftFraction[] */
 
 /* tag::SetIntervalDecimal[] */
 typedef fmi3Status fmi3SetIntervalDecimalTYPE(fmi3Instance instance,
                                               const fmi3ValueReference valueReferences[],
                                               size_t nValueReferences,
-                                              const fmi3Float64 intervals[],
-                                              size_t nIntervals);
+                                              const fmi3Float64 intervals[]);
 /* end::SetIntervalDecimal[] */
 
 /* tag::SetIntervalFraction[] */
@@ -511,8 +504,7 @@ typedef fmi3Status fmi3SetIntervalFractionTYPE(fmi3Instance instance,
                                                const fmi3ValueReference valueReferences[],
                                                size_t nValueReferences,
                                                const fmi3UInt64 intervalCounters[],
-                                               const fmi3UInt64 resolutions[],
-                                               size_t nIntervals);
+                                               const fmi3UInt64 resolutions[]);
 /* end::SetIntervalFraction[] */
 
 /* tag::EvaluateDiscreteStates[] */


### PR DESCRIPTION
This pull request includes following changes:

1. Some clarifications on the handling of intervalUnchanged and intervalNotYetKnown
2. Some restructuring of the SE code example
3. Adding getInterval to allowed functions of Clock Activation Mode
4. Removing of redundant parameters of clock specific getter and setter functions that are relicts of when clocks were not restricted to be scalars (e.g. nIntervals in getInterval). 
I'm not sure if the redundant parameter maybe was kept intentionally for some reasons. However, it is probably confusing for the reader to have two parameters for the same value. An alternative would be to state explicitly that nValueReferences and nIntervals always have the same value. Not very nice, though.