### PR TITLE
Remove the term task

### DIFF
--- a/docs/1___overview.adoc
+++ b/docs/1___overview.adoc
@@ -112,7 +112,7 @@ The Scheduled Execution interface exposes individual <<model-partition, model pa
 A scheduler provided by the <<importer>> can thus control the execution of each model partition separately.
 In some ways the Scheduled Execution interface has similarities to the Model Exchange interface: the first externalizes a scheduling algorithm usually found in a controller algorithm (see <<fmi-for-scheduled-execution>>) and the second interface externalizes the ODE solver.
 
-.Schematic view of data flow between user, the scheduler of the importer and tasks of the FMU for Scheduled Execution
+.Schematic view of data flow between user, the scheduler of the importer and model partitions of the FMU for Scheduled Execution
 [#figure-scheduled-execution-data-flow]
 image::images/scheduled-execution-data-flow.svg[width=40%, align="center"]
 

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -116,7 +116,7 @@ A simulation environment will then dynamically load this library and will explic
 The name of the library is `MyModel.dll` on Windows or `MyModel.so` on Linux; in other words the <<modelIdentifier>> attribute is used as library name.
 
 _[An FMU can be optionally shipped so that it basically contains only the communication to another simulation tool (`needsExecutionTool = true`, see <<fmi-for-co-simulation>>)._
-_This is particularly common for co-simulation tasks._
+_This is particularly common for co-simulation use cases._
 _In this tool coupling case one DLL/Shared Object can be used for all models due to no function prefixing.]_
 
 Since <<modelIdentifier>> is used as prefix of a C-function name it must fulfill the restrictions on C-function
@@ -851,7 +851,7 @@ Clocked states declare the <<valueReference>> of their previous variable using t
 
 The association between <<clocked-variable,clocked variables>> and their <<Clock,Clocks>> is defined by the attribute <<clocks>>.
 <<clocked-variable,Clocked variables>> can depend on multiple Clocks.
-_[For example, a global counter could be incremented by multiple tasks, each controlled by a different Clock.]_
+_[For example, a global counter could be incremented by multiple model partitions, each controlled by a different Clock.]_
 
 Clocks may depend on input Clocks.
 This dependency is also defined by the <<clocks>> attribute.
@@ -873,13 +873,14 @@ In case more than one Clock ticks at the same time instant, the scheduler needs 
 This ordering is defined by the <<priority>> attributes of the Clock.
 For Scheduled Execution this attribute is mandatory for every Clock.
 
-_[For real-time computation use cases, the priority information is used also for task preemption configurations._
+_[A clock's <<priority>> information is required to support the scheduled execution of several model partitions._
+_In particular the <<preemption-support, preemption support>> is based these priorities._
 _It is therefore important to restrict the number of distinct priority levels for an FMU to available priority levels on the target platform and/or to avoid unnecessary computational overhead._
 _A common number of different priority levels is, e.g., 100 (0 to 99), as defined in Linux based operating systems.]_
 
 _[The Clock priorities are local to an FMU._
 _It is not possible for an FMU exporting tool to know in advance the priorities of other FMUs that will be connected to an FMU in a simulation setup._
-_It is the task of the importer to derive a computational order for the computation of two or more distinct FMUs based on the local FMU Clock priorities and input-output relationships of connected FMUs.]_
+_It is the responsibility of the importer to derive a computational order for the computation of two or more distinct FMUs based on the local FMU Clock priorities and input-output relationships of connected FMUs.]_
 
 _[For <<periodic-clock, `periodic Clocks`>> it is recommended to derive the priorities based on a rate monotonic scheduling scheme (smallest period leads to highest priority, that is, has the smallest priority value.]_
 

--- a/docs/5_4_scheduled_execution_schema.adoc
+++ b/docs/5_4_scheduled_execution_schema.adoc
@@ -29,7 +29,7 @@ See also <<header-files-and-naming-of-functions>>.
 ==== Example XML Description File
 
 The simulation algorithm collects the information about the number and properties of <<Clock,`Clocks`>> supported by the FMU via analyzing the <<modelDescription.xml>> as defined in <<fmi-description-schema>>.
-For every <<inputClock>> the simulation algorithm defines a task.
+For every <<inputClock>> the simulation algorithm identifies a model partition of the FMU.
 The properties <<intervalDecimal>> (or <<intervalCounter>>) and <<priority>> are defined based on the <<inputClock,input clocks'>> <<intervalDecimal>> (or <<intervalCounter>>) and <<priority>> defined in the <<modelDescription.xml>>.
 The simulation algorithm can read from the <<modelDescription.xml>> that <<outputClock>> `OutClock` may tick triggered by <<inputClock>> `10msClock` and that <<inputClock>> `AperiodicClock` is triggered by `OutClock`.
 


### PR DESCRIPTION
Since the term _task_ is usually raising questions and discussions I replaced the term in a couple more spots. Everyone is welcome to review.