### PR TITLE
Align definitions for FMI types 

### DIFF
--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -86,15 +86,15 @@ In analogy to the term digital mock-up (see _mock-up_), functional mock-up descr
 |_FMI functions_
 |The function of the FMI C-API.
 
-|_FMI for co-simulation_
+|_FMI for Co-Simulation_
 |Functional Mock-up Interface for Co-Simulation: +
-One of the MODELISAR _Functional Mock-up Interface types._ It connects the _importer_ with one or more _FMU_.
+It connects the _importer_ with one or more _FMUs_ using co-simulation algorithms.
 
-|_FMI for model exchange_
+|_FMI for Model Exchange_
 |Functional Mock-up Interface for Model Exchange: +
-One of the MODELISAR _Functional Mock-up Interface types._ +
+FMU type that externalizes the ODE/DAE solver to allow tightly coupling multiple FMUs and avoid co-simulation delays.
 
-|_FMI for scheduled execution_
+|_FMI for Scheduled Execution_
 |Functional Mock-up Interface for Scheduled Execution: +
 FMI type that externalizes the scheduler to run _model partitions_, potentially synchronized between more than one FMU and exchanging input and output variables accordingly.
 

--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -92,7 +92,11 @@ One of the MODELISAR _Functional Mock-up Interface types._ It connects the _impo
 
 |_FMI for model exchange_
 |Functional Mock-up Interface for Model Exchange: +
-One of the MODELISAR _Functional Mock-up Interface types._ It consists of the _model description_ and the _C API_. +
+One of the MODELISAR _Functional Mock-up Interface types._ +
+
+|_FMI for scheduled execution_
+|Functional Mock-up Interface for Scheduled Execution: +
+FMI type that externalizes the scheduler to run _model partitions_, potentially synchronized between more than one FMU and exchanging input and output variables accordingly.
 
 |_FMU_
 |Functional Mock-up Unit: +
@@ -184,9 +188,6 @@ These parameters are different from <<calculatedParameter,calculated parameters>
 
 |_runtime environment_
 |See co-simulation environment
-
-|_scheduled execution_
-|FMI type that externalizes the scheduler to run _model partitions_, potentially synchronized between more than one FMU and exchanging input and output variables accordingly.
 
 |_simulation_
 |Compute the behavior of one or several _models_ under specified conditions. +


### PR DESCRIPTION
@andreas-junghanns maybe you can adjust this attempt when reviewing. My questions are:
* Why was the definition for schedule execution not named _FMI for_ scheduled execution?
* Why was " It consists of the model description and the C API." only stated for ME?
* Is SE "One of the MODELISAR Functional Mock-up Interface types.", too? (Please add if applicable.)