### PR TITLE
VDMCheck3 on SE xml

### DIFF
--- a/docs/examples/scheduled_execution.xml
+++ b/docs/examples/scheduled_execution.xml
@@ -31,5 +31,6 @@
 	<ModelStructure>
 		<Output valueReference="2" dependencies="0 1"/>
 		<Output valueReference="4" dependencies="3"/>
+		<Output valueReference="7" dependencies="5"/>
 	</ModelStructure>
 </fmiModelDescription>


### PR DESCRIPTION
Reacting to VDMCheck3 check 
_fmi-standard/docs/examples> VDMCheck3.sh scheduled_execution.xml  
Checking XML 
1023: 2.2.9 Outputs section does not match output variables at XML:31 
1028: 2.2.9 InitialUnknowns must include refs: {2, 4} 
Errors found._

>1023: 2.2.9 Outputs section does not match output variables at XML:31 

I adjusted the ModelStructure.

> 1028: 2.2.9 InitialUnknowns must include refs: {2, 4} 

The question arises whether the _clocks_ attribute of the out clock should be removed. The standard does not forbid to leave it. Note that depending on whether the clock attribute is defined or is not defined the output clock is a clocked or not a clocked variable. If it is a clocked variable it would have to be listed as InitialUnknown ("are not clocked variables and have causality = output") - Does it make sense to list an output clock in the initial unknowns? Is it okay to allow to define a clocks attribute? (This is another example like #1600 where it would make sense to be more restrictive in the standard about when to allow or at least recommend to use the clocks attribute.) 