### PR TITLE
Change == to = in text and insert spaces around =

### DIFF
--- a/docs/2_1_common_math.adoc
+++ b/docs/2_1_common_math.adoc
@@ -81,7 +81,7 @@ The following variable subscripts are used to describe the timing behavior of th
 
 .Conventions and notation used for variable subscripts.
 [#table-subscripts]
-[cols="1,10",options="header"]
+[cols="5,20",options="header"]
 |====
 |Subscript
 |Description
@@ -110,7 +110,7 @@ These variables are continuous-time variables.
 |`start`
 |A variable at the start time of the simulation as defined by the argument <<startTime>> of <<fmi3EnterInitializationMode>>.
 
-|`attribute=value`
+|`attribute = value`
 |A set of variables which have an XML attribute-value combination as defined.
 _[Example:_ latexmath:[\mathbf{v}_{\mathit{initial=exact}}] _are variables defined with attribute <<initial>> = <<exact>> (see <<ModelVariables>>).]_
 

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -224,7 +224,7 @@ If a function returns <<fmi3Error>>, it is possible to restore a previously retr
 Otherwise <<fmi3FreeInstance>> or <<fmi3Reset>> must be called.
 When detecting illegal arguments or a function call not allowed in the current state according to the respective state machine, the FMU must return <<fmi3Error>>.
 Other instances of this FMU are not affected by the error. +
-_[For example, when setting a constant with a call to <<get-and-set-variable-values,`fmi3Set{VariableType}`>>, then the function must return with an error (<<fmi3Error,`fmi3Status == fmi3Error`>>.]_
+_[For example, when setting a constant with a call to <<get-and-set-variable-values,`fmi3Set{VariableType}`>>, then the function must return with an error (<<fmi3Error,`fmi3Status = fmi3Error`>>.]_
 
 [[fmi3Fatal,`fmi3Fatal`]]
 `fmi3Fatal`::
@@ -444,7 +444,7 @@ include::../headers/fmi3FunctionTypes.h[tags=GetFMUState]
 
 [[FMUState,`FMUState`]]This function copies the internal FMU state and returns a pointer to this copy in <<FMUState>>.
 <<FMUState>> must contain all information required to allow continuing the simulation from the current FMU state without additional FMI C-API calls.
-If on entry `*FMUState == NULL`, a new allocation is required.
+If on entry `*FMUState = NULL`, a new allocation is required.
 If `*FMUState != NULL`, then `*FMUState` points to a previously returned <<FMUState>> that is no longer needed and can be overwritten.
 In particular, <<fmi3FreeFMUState>> had not been called with this <<FMUState>> as an argument.
 _[Function <<fmi3GetFMUState>> typically reuses the memory of this <<FMUState>> in this case and returns the same pointer to it, but with the current <<FMUState>>.]_
@@ -531,14 +531,14 @@ After <<table-overview-clocks>> Clock types are explained in more detail.
 
 Input Clock::
 [[inputClock, `input Clock`]]
-is a variable of type Clock with <<causality>> == <<input>>.
+is a variable of type Clock with <<causality>> = <<input>>.
 In Model Exchange and Co-Simulation, when input Clocks tick, the importer will activate the input Clocks using <<fmi3SetClock>>.
 In Scheduled Execution, when input Clocks tick, the importer will activate the associated model partitions (but not the input Clocks) using <<fmi3ActivateModelPartition>>.
 While the importer is the source of the actual Clock activations, the timing of the Clocks is defined by the FMU, either through the <<modelDescription.xml>> or calling <<fmi3GetInterval>>, or by another Clock connected to a <<triggered>> input Clock.
 
 Output Clock::
 [[outputClock, `output Clock`]]
-is a variable of type Clock with <<causality>> == <<output>>.
+is a variable of type Clock with <<causality>> = <<output>>.
 
 The attribute <<intervalVariability>> must be <<triggered>> for <<outputClock,output Clocks>>.
 The importer calls <<fmi3GetClock>> to inquire the Clock's activation state.
@@ -646,7 +646,7 @@ latexmath:[\mathbf{T}_{interval, i}] can be set with <<fmi3SetIntervalDecimal>> 
 |===
 
 [[periodic-clock]]Periodic Clock::
-is a time-based Clock with a constant interval, except when <<intervalVariability>> == <<tunable>>, which indicates that the interval can change when tunable <<parameter, parameters>> change.
+is a time-based Clock with a constant interval, except when <<intervalVariability>> = <<tunable>>, which indicates that the interval can change when tunable <<parameter, parameters>> change.
 The time instant of the first Clock tick is defined by a <<shiftCounter>> or <<shiftDecimal>>.
 +
 The next Clock tick at time instant latexmath:[t_i] is defined as: +

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -337,8 +337,8 @@ continuous-time <<state,states>> latexmath:[\mathbf{x}_{c,\mathit{initial=exact}
 a|
 * Evaluate latexmath:[\mathbf{f}_{\mathit{init}}], if no `fmi3GetXXX` function was called
 * Deactivate initialization equations latexmath:[\mathbf{f}_{\mathit{init}}]
-* Update previous values of <<buffers>>: latexmath:[{}^\bullet\mathbf{b}:=\mathbf{b}]
-* latexmath:[\mathbf{t}:=(\mathbf{t}_{\mathit{start}}, 0)]
+* Update previous values of <<buffers>>: latexmath:[{}^\bullet\mathbf{b} := \mathbf{b}]
+* latexmath:[\mathbf{t} := (\mathbf{t}_{\mathit{start}}, 0)]
 * Model Exchange:
   - activate event equations latexmath:[\mathbf{f}_{\mathit{event}}]
 * Co-Simulation:
@@ -528,14 +528,14 @@ a|
   - latexmath:[\mathbf{f}_{\mathit{disc}}] if <<providesEvaluateDiscreteStates>> is `true` and latexmath:[\mathbf{f}_{\mathit{disc}}] (<<fmi3EvaluateDiscreteStates>>) was not called within this super-dense time, or
   - latexmath:[\mathbf{f}_{\mathit{event}}] if <<providesEvaluateDiscreteStates>> is `false` and latexmath:[\mathbf{f}_{\mathit{event}}] was not called within this super-dense time.
 * latexmath:[(\mathbf{T}_\mathit{interval}) := \mathbf{f}_{\mathit{update}}({}^\bullet\mathbf{x}_{c+d}, \mathbf{u}_{c+d}, \mathbf{p}, {}^\bullet\mathbf{b}, \mathbf{t})]
-* Update previous values of discrete states: latexmath:[{}^\bullet\mathbf{x}_d:=\mathbf{x}_d].
-* Update previous values of <<buffers>>: latexmath:[{}^\bullet\mathbf{b}:=\mathbf{b}].
+* Update previous values of discrete states: latexmath:[{}^\bullet\mathbf{x}_d := \mathbf{x}_d].
+* Update previous values of <<buffers>>: latexmath:[{}^\bullet\mathbf{b} := \mathbf{b}].
 * Deactivate active clocks and respective model partitions.
-* Increment super-dense time: latexmath:[\mathbf{t}:=(\mathbf{t}_\mathit{R}, \mathbf{t}_\mathit{I} + 1)].
+* Increment super-dense time: latexmath:[\mathbf{t} := (\mathbf{t}_\mathit{R}, \mathbf{t}_\mathit{I} + 1)].
 |<<fmi3UpdateDiscreteStates>>
 
 a|
-* [[updateRelations]]Update previous values of <<relations>>: latexmath:[{}^\bullet\mathbf{r}:=\mathbf{r}].
+* [[updateRelations]]Update previous values of <<relations>>: latexmath:[{}^\bullet\mathbf{r} := \mathbf{r}].
 * Deactivate event equations latexmath:[\mathbf{f}_\mathit{event}].
 * Model Exchange: Activate continuous-time equations latexmath:[\mathbf{f}_\mathit{cont}].
 

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -73,27 +73,27 @@ _[Example: An FMU is extracted to the directory `C:\temp\MyFMU`, then <<resource
 ** the environment is not able to provide the file path to the resources folder _[e.g., if the environment does not have a file system._
 _If the FMU in such a case cannot be simulated, as it depends on the resources folder, it shall terminate with an error.]_
 
-* `visible == fmi3False` defines that the interaction with the user should be reduced to a minimum (no application window, no plotting, no animation, etc.).
+* `visible = fmi3False` defines that the interaction with the user should be reduced to a minimum (no application window, no plotting, no animation, etc.).
 In other words, the FMU is executed in batch mode.
-If `visible == fmi3True`, the FMU is executed in interactive mode, and the FMU might require to explicitly acknowledge start of simulation / instantiation / initialization (acknowledgment is non-blocking).
+If `visible = fmi3True`, the FMU is executed in interactive mode, and the FMU might require to explicitly acknowledge start of simulation / instantiation / initialization (acknowledgment is non-blocking).
 
-* [[loggingOn,`loggingOn`]] If `loggingOn == fmi3False`, then any logging is disabled and the <<logMessage>> callback function must not be called by the FMU.
-If `loggingOn == fmi3True`, then all `<LogCategories>` are enabled.
+* [[loggingOn,`loggingOn`]] If `loggingOn = fmi3False`, then any logging is disabled and the <<logMessage>> callback function must not be called by the FMU.
+If `loggingOn = fmi3True`, then all `<LogCategories>` are enabled.
 The function <<fmi3SetDebugLogging>> gives more detailed control about enabling specific `<LogCategories>` (see <<definition-of-log-categories>>).
 
 
 +
-* [[eventModeUsed,`eventModeUsed`]]If `eventModeUsed == fmi3True` the importer can handle events.
-The flag may only be `fmi3True`, if <<hasEventMode,`hasEventMode == true`>>, otherwise the FMU must raise an error.
-For FMUs that have clocks, `eventModeUsed == fmi3True` is required.
+* [[eventModeUsed,`eventModeUsed`]]If `eventModeUsed = fmi3True` the importer can handle events.
+The flag may only be `fmi3True`, if <<hasEventMode,`hasEventMode = true`>>, otherwise the FMU must raise an error.
+For FMUs that have clocks, `eventModeUsed = fmi3True` is required.
 
-* [[earlyReturnAllowed,`earlyReturnAllowed`]]If `earlyReturnAllowed == fmi3True` the importer can handle <<early-return,early return>>.
-Only in this case, <<fmi3DoStep>> may return with <<earlyReturn,`earlyReturn == fmi3True`>>.
+* [[earlyReturnAllowed,`earlyReturnAllowed`]]If `earlyReturnAllowed = fmi3True` the importer can handle <<early-return,early return>>.
+Only in this case, <<fmi3DoStep>> may return with <<earlyReturn,`earlyReturn = fmi3True`>>.
 
 * `instanceEnvironment` is a pointer that must be passed to <<fmi3IntermediateUpdateCallback>>, <<fmi3ClockUpdateCallback>>, and <<logMessage,`fmi3LogMessageCallback`>> to allow the simulation environment an efficient way to identify the calling FMU.
 
 * [[requiredIntermediateVariables,`requiredIntermediateVariables`]] `requiredIntermediateVariables` is an array of the value references of all <<input>> variables that the simulation algorithm intends to set and all <<output>> variables it intends to get during intermediate updates.
-This set may be empty (<<nRequiredIntermediateVariables>> == 0) when the simulation algorithm does not intend to use intermediate update.
+This set may be empty (<<nRequiredIntermediateVariables>> = 0) when the simulation algorithm does not intend to use intermediate update.
 Only the variables in <<requiredIntermediateVariables>> may be accessed by the simulation algorithm using <<get-and-set-variable-values,`fmi3Set{VariableType}`>> and <<get-and-set-variable-values,`fmi3Get{VariableType}`>> during <<IntermediateUpdateMode>>.
 All variables referenced in this set must be marked with the attribute <<intermediateUpdate,`intermediateUpdate = "true"`>> in <<modelDescription.xml>>.
 For Co-Simulation, these intermediate variables must be continuous-time variables.
@@ -111,11 +111,11 @@ include::../headers/fmi3FunctionTypes.h[tags=CallbackLogMessage]
 Pointer to a function that is called by the FMU to provide information about its internal status in human readable form.
 
 ** `status` contains the severity of the message, see `fmi3Status`.
-If <<fmi3OK,`status == fmi3OK`>>, the message is a pure information message.
+If <<fmi3OK,`status = fmi3OK`>>, the message is a pure information message.
 If a function does not return <<fmi3OK>>, it must provide the reason by calling <<logMessage>> at least once with this `status`.
 ** `category` is the category of the message.
 The allowed values for `category` are defined in the <<modelDescription.xml>> file via the element <<definition-of-log-categories,`<LogCategories>`>>.
-<<logMessage>> must only be called for log categories that were enabled by calls to <<fmi3SetDebugLogging>> or via <<loggingOn,`loggingOn == fmi3True`>> in <<fmi3Instantiate>>.
+<<logMessage>> must only be called for log categories that were enabled by calls to <<fmi3SetDebugLogging>> or via <<loggingOn,`loggingOn = fmi3True`>> in <<fmi3Instantiate>>.
 If the FMU does not define any log categories, `category` must be `NULL`.
 ** `message` is a string that contains the message to log. It may contain line-breaks (`\n`), but should not have a trailing line break.
 
@@ -139,8 +139,8 @@ See <<preemption-support>> for details.
 The arguments <<logMessage>>, <<fmi3IntermediateUpdateCallback,`intermediateUpdate`>>, <<fmi3ClockUpdateCallback,`clockUpdate`>>, <<preemption-support,`lockPreemption`>>, and <<preemption-support,`unlockPreemption`>>, are function pointers provided by the simulation environment to be used by the FMU.
 Each of these pointers can be NULL to indicate missing support for the respective functionality.
 If such functionality is used anyway, undefined behavior results.
-_[For example, if <<logMessage,`logMessage == NULL`>>, calls to <<fmi3SetDebugLogging>> result in undefined behavior of the FMU._
-_If <<intermediateUpdate,`intermediateUpdate == NULL`>> and arguments <<requiredIntermediateVariables,`requiredIntermediateVariables != NULL`>> and/or <<nRequiredIntermediateVariables,`nRequiredIntermediateVariables != 0`>> the behavior of the FMU is undefined.]_
+_[For example, if <<logMessage,`logMessage = NULL`>>, calls to <<fmi3SetDebugLogging>> result in undefined behavior of the FMU._
+_If <<intermediateUpdate,`intermediateUpdate = NULL`>> and arguments <<requiredIntermediateVariables,`requiredIntermediateVariables != NULL`>> and/or <<nRequiredIntermediateVariables,`nRequiredIntermediateVariables != 0`>> the behavior of the FMU is undefined.]_
 Additionally, a pointer to the environment is provided (`instanceEnvironment`) that needs to be passed to the callback functions <<logMessage>>, <<fmi3IntermediateUpdateCallback,`intermediateUpdate`>>, <<fmi3ClockUpdateCallback,`clockUpdate`>>, in order that those functions can utilize data from the environment, such as mapping a <<valueReference>> to a string, or assigning memory to a certain FMU instance.
 
 Allowed Function Calls::
@@ -156,18 +156,18 @@ The function controls the debug logging that is output by the FMU via the callba
 The FMU must call the <<logMessage>> callback function only for `categories` which are turned on by this function.
 If this function is never called, logging for all log categories is allowed.
 
-** If <<loggingOn,`loggingOn == fmi3True`>>, debug logging is enabled for the log categories specified in `categories`.
-If <<loggingOn,`loggingOn == fmi3False`>>, debug logging is disabled for the log categories specified in `categories`.
+** If <<loggingOn,`loggingOn = fmi3True`>>, debug logging is enabled for the log categories specified in `categories`.
+If <<loggingOn,`loggingOn = fmi3False`>>, debug logging is disabled for the log categories specified in `categories`.
 
 ** `nCategories` defines the length of the array of argument `categories`.
-If `nCategories == 0`, <<loggingOn>> applies to all log categories and the value of `categories` is undefined.
+If `nCategories = 0`, <<loggingOn>> applies to all log categories and the value of `categories` is undefined.
 
 ** `categories` is an array of `nCategories` elements.
 The importer must only use values specified in the <<modelDescription.xml>> via element <<definition-of-log-categories,`<LogCategories>`>> as elements of argument `categories`.
 
 _[For example: If <<logMessage>> shall be called only for log category `logStatusFatal`, two calls are required:_
-* _first, all log categories are turned off using <<loggingOn,`loggingOn == fmi3False`>> with `nCategories == 0`, and_
-* _second, only `logStatusFatal` is placed in `categories` with <<loggingOn,`loggingOn == fmi3True`>>.]_
+* _first, all log categories are turned off using <<loggingOn,`loggingOn = fmi3False`>> with `nCategories = 0`, and_
+* _second, only `logStatusFatal` is placed in `categories` with <<loggingOn,`loggingOn = fmi3True`>>.]_
 
 [[fmi3Reset,`fmi3Reset`]]
 Function `fmi3Reset`::
@@ -290,10 +290,10 @@ Changes state to <<InitializationMode>>.
 * [[toleranceDefined,`toleranceDefined`]]`toleranceDefined` and
 * [[tolerance,`tolerance`]]`tolerance` depend on the interface type:
 
-** Model Exchange: If <<toleranceDefined,`toleranceDefined == fmi3True`>>, then the model is called with a numerical integration scheme where the step size is controlled by using <<tolerance>> for error estimation (usually as relative tolerance).
+** Model Exchange: If <<toleranceDefined,`toleranceDefined = fmi3True`>>, then the model is called with a numerical integration scheme where the step size is controlled by using <<tolerance>> for error estimation (usually as relative tolerance).
 In such a case all numerical algorithms used inside the model (for example, to solve nonlinear algebraic equations) should also operate with an error estimation of an appropriate smaller relative tolerance.
 
-** Co-Simulation: If <<toleranceDefined,`toleranceDefined == fmi3True`>>, then the communication step size of the FMU is controlled by error estimation.
+** Co-Simulation: If <<toleranceDefined,`toleranceDefined = fmi3True`>>, then the communication step size of the FMU is controlled by error estimation.
 In case the FMU utilizes a numerical integrator with variable step size and error estimation, it is suggested to use <<tolerance>> for the error estimation of the integrator (usually as relative tolerance). +
 An FMU for Co-Simulation might ignore this argument.
 
@@ -305,9 +305,9 @@ An FMU for Co-Simulation might ignore this argument.
 _[It is defined with <<causality>> = <<independent>> in the <<modelDescription.xml>>._
 _If the <<independent>> variable is `time`, <<startTime>> is the starting time of initialization.]_
 
-* [[stopTimeDefined,`stopTimeDefined`]] If `stopTimeDefined == fmi3True`, then <<stopTime>> is the final value of the <<independent>> variable and inherits its unit.
-If the environment tries to compute past <<stopTime>>, the FMU has to return <<fmi3Error,`fmi3Status == fmi3Error`>>.
-If <<stopTimeDefined,`stopTimeDefined == fmi3False`>>, then no final value of the <<independent>> variable is defined and argument <<stopTime>> is meaningless.
+* [[stopTimeDefined,`stopTimeDefined`]] If `stopTimeDefined = fmi3True`, then <<stopTime>> is the final value of the <<independent>> variable and inherits its unit.
+If the environment tries to compute past <<stopTime>>, the FMU has to return <<fmi3Error,`fmi3Status = fmi3Error`>>.
+If <<stopTimeDefined,`stopTimeDefined = fmi3False`>>, then no final value of the <<independent>> variable is defined and argument <<stopTime>> is meaningless.
 
 ==== State: Initialization Mode [[InitializationMode,*Initialization Mode*]]
 
@@ -389,13 +389,13 @@ Return the nominal values of the continuous <<state,states>>.
 This function can only be called in Model Exchange.
 
 * Return argument `nominals` contains the nominal values for each <<state,continuous state>> with the same convention for the order as defined for <<fmi3SetContinuousStates>>.
-If the FMU does not have information about the nominal value of a continuous <<state>> `i`, a nominal value `nominals[i] == 1.0` should be returned.
+If the FMU does not have information about the nominal value of a continuous <<state>> `i`, a nominal value `nominals[i] = 1.0` should be returned.
 It is required that `nominals[i] > 0.0`.
 
 * Argument `nContinuousStates` is the size of the `nominals` vector.
 
 +
-This function should always be called after calling function <<fmi3UpdateDiscreteStates>>, if `nominalsOfContinuousStatesChanged == fmi3True`, since then the nominal values of the continuous <<state,states>> have changed _[for example, because the mapping of the continuous <<state,states>> to variables has changed because of internal <<dynamic-state-selection>>]_.
+This function should always be called after calling function <<fmi3UpdateDiscreteStates>>, if `nominalsOfContinuousStatesChanged = fmi3True`, since then the nominal values of the continuous <<state,states>> have changed _[for example, because the mapping of the continuous <<state,states>> to variables has changed because of internal <<dynamic-state-selection>>]_.
 
 Function <<fmi3GetDirectionalDerivative>>::
 See <<fmi3GetDirectionalDerivative>>.
@@ -428,8 +428,8 @@ Changes the state to
 
  * Model Exchange: <<EventMode>>
  * Co-Simulation:
-  ** <<eventModeUsed,`eventModeUsed == fmi3True`>>: <<EventMode>>
-  ** <<eventModeUsed,`eventModeUsed == fmi3False`>>: <<StepMode>>
+  ** <<eventModeUsed,`eventModeUsed = fmi3True`>>: <<EventMode>>
+  ** <<eventModeUsed,`eventModeUsed = fmi3False`>>: <<StepMode>>
  * Scheduled Execution: <<ClockActivationMode>>.
 
 ==== Super State: Initialized [[Initialized,*Initialized*]]
@@ -478,7 +478,7 @@ There are multiple kinds of events that require a transition to <<EventMode>>:
   - the argument <<nextEventTime>> of <<fmi3UpdateDiscreteStates>>, or
   - the arguments of <<fmi3GetShift>> and <<fmi3GetInterval>>.
 * <<state-event,State events>> are signaled to the importer by <<eventIndicators>> in Model Exchange (see <<localizationStateEvents>>).
-  In Co-Simulation, the FMU returns from <<fmi3DoStep>> with <<eventHandlingNeeded,`eventHandlingNeeded == fmi3True`>>.
+  In Co-Simulation, the FMU returns from <<fmi3DoStep>> with <<eventHandlingNeeded,`eventHandlingNeeded = fmi3True`>>.
   The exact event localization is hidden from the importer.
 * <<step-event,Step events>> are initiated by the FMU at the end of an integrator step (see argument <<enterEventMode>> of <<fmi3CompletedIntegratorStep>>) in Model Exchange.
 
@@ -489,7 +489,7 @@ There are multiple kinds of events that require a transition to <<EventMode>>:
 |<<each-state-description,Equations and Actions>>
 |Functions Influencing Equations
 
-|Set <<tunable>> <<parameter,`parameters`>> latexmath:[\mathbf{p}_{\mathit{variability == tunable}}]
+|Set <<tunable>> <<parameter,`parameters`>> latexmath:[\mathbf{p}_{\mathit{variability = tunable}}]
 |<<get-and-set-variable-values,`fmi3Set{VariableType}`>>
 
 |Set continuous-time and discrete-time <<input,`inputs`>> latexmath:[\mathbf{u}_{c+d}]
@@ -547,7 +547,7 @@ a|
 Allowed Function Calls::
 
 Function <<get-and-set-variable-values,`fmi3Set{VariableType}`>>::
-This function can be called for variables with <<causality,`causality == input`>> and for variables with <<causality,`causality == parameter`>> and <<variability, `variability == tunable`>>.
+This function can be called for variables with <<causality,`causality = input`>> and for variables with <<causality,`causality = parameter`>> and <<variability, `variability = tunable`>>.
 
 Functions <<get-and-set-variable-values,`fmi3Get{VariableType}`>>::
 Getting variables might trigger <<selectiv-computation,computations>>.
@@ -565,7 +565,7 @@ When a Clock latexmath:[\mathbf{k}] is deactivated, the FMU must
 _[Rationale: a triggered <<outputClock,output Clock>> latexmath:[c] may depend on some variable latexmath:[v] that is involved in an algebraic loop._
 _As part of the iterations to solve the algebraic loop, latexmath:[v] acquires a value that activates the Clock._
 _If the final (or some intermediate) value of latexmath:[v] no longer activates the Clock, then this Clock must be deactivated by the Importer during the same super-dense time instant.]_ +
-The importer can set a Clock to `fmi3ClockInactive` only if the Clock has the attribute <<canBeDeactivated,`canBeDeactivated == true`>>.
+The importer can set a Clock to `fmi3ClockInactive` only if the Clock has the attribute <<canBeDeactivated,`canBeDeactivated = true`>>.
 Any Clock active during <<fmi3UpdateDiscreteStates>> must be deactivated by the FMU itself. +
 Only <<time-based-clock,time-based Clocks>> must not be active for more than one call of <<fmi3UpdateDiscreteStates>> per <<EventMode>>. +
 _[The event iteration for handling discontinuities of the continuous part of the FMU should precede handling of time-based Clocks._
@@ -588,7 +588,7 @@ Function <<fmi3GetAdjointDerivative>>::
 See <<fmi3GetAdjointDerivative>>.
 
 Function <<fmi3GetContinuousStates>>::
-This function must be called if <<fmi3UpdateDiscreteStates>> returned with <<valuesOfContinuousStatesChanged, `valuesOfContinuousStatesChanged == fmi3True`>>.
+This function must be called if <<fmi3UpdateDiscreteStates>> returned with <<valuesOfContinuousStatesChanged, `valuesOfContinuousStatesChanged = fmi3True`>>.
 Not allowed in Co-Simulation and Scheduled Execution.
 
 Function <<fmi3GetContinuousStateDerivatives>>::
@@ -624,29 +624,29 @@ include::../headers/fmi3FunctionTypes.h[tag=UpdateDiscreteStates]
 ----
 
 [[discreteStatesNeedUpdate,`discreteStatesNeedUpdate`]]
-* When `discreteStatesNeedUpdate == fmi3True`, the importer must stay in <<EventMode>> for another event iteration, starting a new super-dense time instant.
+* When `discreteStatesNeedUpdate = fmi3True`, the importer must stay in <<EventMode>> for another event iteration, starting a new super-dense time instant.
 
 [[terminateSimulationUDS,`terminateSimulation`]]
-* When <<terminateSimulationUDS,`terminateSimulation == fmi3True`>>, the FMU requests to stop the simulation and the importer must call <<fmi3Terminate>>.
+* When <<terminateSimulationUDS,`terminateSimulation = fmi3True`>>, the FMU requests to stop the simulation and the importer must call <<fmi3Terminate>>.
 
 [[nominalsOfContinuousStatesChanged,`nominalsOfContinuousStatesChanged`]]
-* If argument `nominalsOfContinuousStatesChanged == fmi3True`, then at least one nominal value of the <<state,states>> has changed and can be inquired with <<fmi3GetNominalsOfContinuousStates>>. +
+* If argument `nominalsOfContinuousStatesChanged = fmi3True`, then at least one nominal value of the <<state,states>> has changed and can be inquired with <<fmi3GetNominalsOfContinuousStates>>. +
 This argument is only valid in Model Exchange.
 
 [[valuesOfContinuousStatesChanged,`valuesOfContinuousStatesChanged`]]
-* If argument `valuesOfContinuousStatesChanged == fmi3True`, then at least one continuous state has changed its value because it was re-initialized (see <<reinit>>). +
+* If argument `valuesOfContinuousStatesChanged = fmi3True`, then at least one continuous state has changed its value because it was re-initialized (see <<reinit>>). +
 
 +
 The new values of the <<state,states>> can be inquired with <<fmi3GetContinuousStates>> or individually for each state for which <<reinit, `reinit = true`>> by calling `fmi3GetFloat64`. +
 This argument is only valid in Model Exchange.
 
 [[nextEventTimeDefined,`nextEventTimeDefined`]]
-* When <<nextEventTimeDefined,`nextEventTimeDefined == fmi3True`>>, the next time event is known and <<nextEventTime>> has a valid value.
+* When <<nextEventTimeDefined,`nextEventTimeDefined = fmi3True`>>, the next time event is known and <<nextEventTime>> has a valid value.
 
 [[nextEventTime,`nextEventTime`]]
-* The return argument <<nextEventTime>> contains the absolute time of the next time event latexmath:[\mathbf{T}_\mathit{next}] if <<nextEventTimeDefined,`nextEventTimeDefined == fmi3True`>>.
-The importer must compute up to <<nextEventTime>> (or if needed slightly further) and then enter <<EventMode>> using <<fmi3EnterEventMode>> with argument <<timeEvent,`timeEvent == fmi3True`>>.
-The FMU must handle this time event at the first call to <<fmi3EnterEventMode>> with <<timeEvent,`timeEvent == fmi3True`>> at or after <<nextEventTime>>. +
+* The return argument <<nextEventTime>> contains the absolute time of the next time event latexmath:[\mathbf{T}_\mathit{next}] if <<nextEventTimeDefined,`nextEventTimeDefined = fmi3True`>>.
+The importer must compute up to <<nextEventTime>> (or if needed slightly further) and then enter <<EventMode>> using <<fmi3EnterEventMode>> with argument <<timeEvent,`timeEvent = fmi3True`>>.
+The FMU must handle this time event at the first call to <<fmi3EnterEventMode>> with <<timeEvent,`timeEvent = fmi3True`>> at or after <<nextEventTime>>. +
 _[This might be needed if, for example, the time resolution of the importer does not allow hitting the precise <<nextEventTime>>._
 _If the time offset proves to be too large, the FMU could issue a log message and return fmi3Error._
 _The user can improve time settings of the importer to alleviate the issues.]_ +

--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -829,7 +829,7 @@ _If we allowed 0 dimension sizes for initial values, tools that do not even care
 
 _[Example:_
 _`V` is a floating point vector parameter._
-_The length of the vector depends on the <<structuralParameter,`structural parameter`>> `len`, connected via the `valueReference="100"`._
+_The length of the vector depends on the <<structuralParameter,`structural parameter`>> `len`, connected via the `valueReference = "100"`._
 _The default length of the vector is 7._
 _This length can be changed in <<ConfigurationMode>> because the <<variability>> of the <<structuralParameter,`structural parameter`>> `len` is <<fixed>>._
 _The values of `V` can be changed whenever <<tunable>> parameters can be changed._

--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -502,7 +502,7 @@ image::images/schema/DisplayUnit.png[width=70%, align="center"]
 A `<DisplayUnit>` is defined by `name`, `factor`, `offset`, and `inverse`.
 The attribute `name` must be unique with respect to all other names of the `<DisplayUnit>` definitions of the same `Unit`.
 _[Different `Unit` elements may have the same `<DisplayUnit>` names]._ +
-`inverse == true` is only allowed if `offset == 0`. +
+`inverse = true` is only allowed if `offset = 0`. +
 _[Reason: no use case is known for the combination of inverse and offset, which would also be more complicated.]_
 
 A value latexmath:[v_{unit}] in `Unit` is converted to a value latexmath:[v_{display}] in `DisplayUnit` by the equation:
@@ -511,8 +511,8 @@ A value latexmath:[v_{unit}] in `Unit` is converted to a value latexmath:[v_{dis
 ++++
 v_{display} =
 \left\{\begin{array}{ll}
-\texttt{factor} *          v_{unit}  + \texttt{offset} &\text{if} \; \texttt{inverse == false} \\
-\texttt{factor} * \frac{1}{v_{unit}}  &\text{if} \; \texttt{inverse == true}
+\texttt{factor} *          v_{unit}  + \texttt{offset} &\text{if} \; \texttt{inverse = false} \\
+\texttt{factor} * \frac{1}{v_{unit}}  &\text{if} \; \texttt{inverse = true}
 \end{array}\right.
 ++++
 
@@ -652,7 +652,7 @@ _This information can, for example, be used to increase numerical stability and 
 
 |`canBeDeactivated`
 |[[canBeDeactivated,`canBeDeactivated`]]
-<<Clock,`Clocks`>> with the attribute <<canBeDeactivated,`canBeDeactivated == true`>> may be actively deactivated using <<fmi3SetClockEM>>.
+<<Clock,`Clocks`>> with the attribute <<canBeDeactivated,`canBeDeactivated = true`>> may be actively deactivated using <<fmi3SetClockEM>>.
 
 |`priority`
 |[[priority,`priority`]]
@@ -701,7 +701,7 @@ latexmath:[\mathbf{T}_{interval} = ] `intervalCounter / resolution`.
 
 <<intervalCounter>> and <<resolution>> have no default value.
 This value must be greater than 0.
-This attribute is allowed if <<supportsFraction,`supportsFraction = true`>> and is required if <<intervalVariability,intervalVariability == `constant`>> or <<intervalVariability,intervalVariability == `fixed`>>.
+This attribute is allowed if <<supportsFraction,`supportsFraction = true`>> and is required if <<intervalVariability,`intervalVariability = constant`>> or <<intervalVariability,`intervalVariability = fixed`>>.
 This attribute must only be used for <<periodic-clock,periodic Clocks>>.
 
 |[[shiftCounter,`shiftCounter`]]`shiftCounter`
@@ -709,7 +709,7 @@ This attribute must only be used for <<periodic-clock,periodic Clocks>>.
 
 latexmath:[\mathbf{T}_{shift} = ] `shiftCounter / resolution`.
 
-This attribute is allowed if <<supportsFraction,`supportsFraction = true`>> and is required if <<intervalVariability,intervalVariability == `constant`>> or <<intervalVariability,intervalVariability == `fixed`>>.
+This attribute is allowed if <<supportsFraction,`supportsFraction = true`>> and is required if <<intervalVariability,`intervalVariability = constant`>> or <<intervalVariability,`intervalVariability = fixed`>>.
 This attribute must only be used for <<periodic-clock,periodic Clocks>>.
 
 |====
@@ -987,10 +987,10 @@ _[<<tunable>> <<input,inputs>> are not allowed, see <<table-allowed-variability-
 Model Exchange: The value of the variable is constant between external and internal events (= <<time event,time event>>, <<state event,state event>>, <<step event,step events>> defined implicitly in the FMU). +
 Co-Simulation: By convention, the variable is from a real sampled data system and its value is only changed at communication points (including event handling).
 During <<intermediateUpdate>>, <<discrete>> variables are not allowed to change.
-_[If the simulation algorithm notices a change in a discrete variable during <<intermediateUpdate>>, the simulation algorithm will delay the change, raise an event with <<earlyReturnRequested,`earlyReturnRequested == fmi3True`>> and during the communication point it can change the <<discrete>> variable, followed by event handling.]_
+_[If the simulation algorithm notices a change in a discrete variable during <<intermediateUpdate>>, the simulation algorithm will delay the change, raise an event with <<earlyReturnRequested,`earlyReturnRequested = fmi3True`>> and during the communication point it can change the <<discrete>> variable, followed by event handling.]_
 
 [[continuous,`continuous`]]
-`= continuous`: Only a variable of `type == fmi3GetFloat32` or `type == fmi3GetFloat64` can be <<continuous>>. +
+`= continuous`: Only a variable of `type = fmi3GetFloat32` or `type = fmi3GetFloat64` can be <<continuous>>. +
 Model Exchange: No restrictions on value changes (see <<smoothness>>).
 
 The default is <<continuous>> for variables of type `<Float32>` and `<Float64>`, and <<discrete>> for all other types.
@@ -1027,13 +1027,14 @@ If present, this variable is a <<ClockedState>> and this attribute is a value re
 The following constraints apply:
 
 * Only clocked variables (i.e. variables with the attribute <<clocks>>) may have the <<previous>> attribute.
-* Only variables with <<variability,`variability == discrete`>> may have the <<previous>> attribute.
+* Only variables with <<variability,`variability = discrete`>> may have the <<previous>> attribute.
 * Variables of type <<Clock>> must not have the <<previous>> attribute.
 * Two variables must not have the same <<previous>> attribute reference.
 * A variable must not refer to itself in the <<previous>> attribute.
-* The variable referenced by the <<previous>> attribute must have the same numeric type, <<variability,`variability == discrete`>>, and must not have <<causality,`causality == input`>>.
+* The variable referenced by the <<previous>> attribute must have the same numeric type, <<variability,`variability = discrete`>>, and must not have <<causality,`causality = input`>>.
 
-_[For example, if `previous == 3` for variable `8`, then variable `3` is the previous value of variable `8`. See also <<fmi3UpdateDiscreteStates>>._
+_[For example, if `previous = 3` for variable `8`, then variable `3` is the previous value of variable `8`._
+_See also <<fmi3UpdateDiscreteStates>>._
 _Note: This is reverse compared to the <<derivative>> attribute.]_
 
 |`clocks`
@@ -1041,7 +1042,7 @@ _Note: This is reverse compared to the <<derivative>> attribute.]_
 [[clocks,`clocks`]]
 If present, this variable is clocked.
 The value of <<clocks>> is a list of value references of <<Clock>> variables this variable depends on.
-Only variables with <<variability,`variability == discrete`>> or <<variability,`variability == tunable`>> can have this attribute.
+Only variables with <<variability,`variability = discrete`>> or <<variability,`variability = tunable`>> can have this attribute.
 _[Some importers might require a variable to be dependent on a single Clock for technical reasons._
 _They could reject FMUs violating this restriction._
 _Note: It is not further restricted, which variables can be clocked to not restrict currently unknown use cases._
@@ -1628,7 +1629,7 @@ latexmath:[{\dot{\mathbf{x}_c} := \mathbf{f}_{\mathit{der}}(\mathbf{x}_c, \mathb
 A <<ClockedState>> is part of the discrete state of a model partition and represented by a clocked variable.
 To which Clock or Clocks it belongs is described by the attribute <<clocks>>.
 Each <<ClockedState>> must have the attribute <<previous>> to represent the previous value of this <<ClockedState>>.
-All clocked states must have <<variability,`variability == discrete`>> and must not be of type <<fmi3Clock>>.
+All clocked states must have <<variability,`variability = discrete`>> and must not be of type <<fmi3Clock>>.
 
 |`InitialUnknown`
 |

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -94,7 +94,7 @@ This order is also used in the arguments of the following functions: <<fmi3GetNo
 +
 * Argument `nContinuousStates` is the size of the `continuousStates` vector.
 +
-_[<<fmi3Discard,`fmi3Status == fmi3Discard`>> should be returned if the FMU rejects any of the state values because they, for example, violate min/max value restrictions.]_
+_[<<fmi3Discard,`fmi3Status = fmi3Discard`>> should be returned if the FMU rejects any of the state values because they, for example, violate min/max value restrictions.]_
 
 Functions <<get-and-set-variable-values,`fmi3Get{VariableType}`>>::
 Getting variables might trigger <<selectiv-computation,computations>>.
@@ -116,7 +116,7 @@ Returns the first-order derivatives with respect to the independent variable (us
 
 * Argument `nContinuousStates` is the size of the `derivatives` vector.
 +
-_[<<fmi3Discard,`fmi3Status == fmi3Discard`>> should be returned if the FMU was not able to compute the derivatives according to_ latexmath:[\mathbf{f}_{\mathit{cont}}] _because, for example, a numerical issue, such as division by zero, occurred.]_
+_[<<fmi3Discard,`fmi3Status = fmi3Discard`>> should be returned if the FMU was not able to compute the derivatives according to_ latexmath:[\mathbf{f}_{\mathit{cont}}] _because, for example, a numerical issue, such as division by zero, occurred.]_
 
 [[fmi3GetEventIndicators,`fmi3GetEventIndicators`]]
 Function `fmi3GetEventIndicators`::
@@ -133,7 +133,7 @@ Returns the event indicators signaling <<state-event,state events>> by their sig
 * Argument `nEventIndicators` is the size of the `eventIndicators` vector.
 
 +
-_[<<fmi3Discard,`fmi3Status == fmi3Discard`>> should be returned if the FMU was not able to compute the event indicators according to_ latexmath:[\mathbf{f}_{\mathit{cont}}] _because, for example, a numerical issue, such as division by zero, occurred.]_
+_[<<fmi3Discard,`fmi3Status = fmi3Discard`>> should be returned if the FMU was not able to compute the event indicators according to_ latexmath:[\mathbf{f}_{\mathit{cont}}] _because, for example, a numerical issue, such as division by zero, occurred.]_
 
 [[fmi3CompletedIntegratorStep,`fmi3CompletedIntegratorStep`]]
 Function `fmi3CompletedIntegratorStep`::
@@ -143,13 +143,13 @@ Function `fmi3CompletedIntegratorStep`::
 include::../headers/fmi3FunctionTypes.h[tags=CompletedIntegratorStep]
 ----
 +
-This function is called after every completed step of the integrator provided the capability flag `needsCompletedIntegratorStep == true`.
+This function is called after every completed step of the integrator provided the capability flag `needsCompletedIntegratorStep = true`.
 The importer must have set valid values for <<time>>, <<continuous>> <<input,`inputs`>> and <<continuous>> <<state,states>> prior to calling this function to evaluate latexmath:[\mathbf{f}_{\mathit{comp}}] with valid right-hand side data.
 +
 --
-* Argument `noSetFMUStatePriorToCurrentPoint == fmi3True` if <<fmi3SetFMUState>> will no longer be called for time instants prior to current time in this simulation run.
+* Argument `noSetFMUStatePriorToCurrentPoint = fmi3True` if <<fmi3SetFMUState>> will no longer be called for time instants prior to current time in this simulation run.
 * [[enterEventMode,`enterEventMode`]] The return argument `enterEventMode` signals that the importer must call <<fmi3EnterEventMode>> to handle a <<step-event>>.
-* [[terminateSimulationCIS,`terminateSimulation`]] When <<terminateSimulationUDS,`terminateSimulation == fmi3True`>>, the FMU requests to stop the simulation and the importer must call <<fmi3Terminate>>.
+* [[terminateSimulationCIS,`terminateSimulation`]] When <<terminateSimulationUDS,`terminateSimulation = fmi3True`>>, the FMU requests to stop the simulation and the importer must call <<fmi3Terminate>>.
 --
 
 +
@@ -166,12 +166,12 @@ _[In this function the FMU might, for example:_
 * _Update delay buffers_
 * _Detect <<step-event,step events>> and request handling of <<step-event,step events>> for <<dynamic-state-selection,dynamic state selection>>:_ +
 _The FMU checks whether the dynamically selected states are still numerically appropriate._
-_If not, the function returns with `enterEventMode == fmi3True`, the importer will call <<fmi3EnterEventMode>> and in <<EventMode>> the new mapping is computed by the FMU._
-_This new mapping might require a reinitialization of continuous states, which must be signaled to the importer by returning from <<fmi3UpdateDiscreteStates>> with <<valuesOfContinuousStatesChanged,`valuesOfContinuousStatesChanged == fmi3True`>>._
+_If not, the function returns with `enterEventMode = fmi3True`, the importer will call <<fmi3EnterEventMode>> and in <<EventMode>> the new mapping is computed by the FMU._
+_This new mapping might require a reinitialization of continuous states, which must be signaled to the importer by returning from <<fmi3UpdateDiscreteStates>> with <<valuesOfContinuousStatesChanged,`valuesOfContinuousStatesChanged = fmi3True`>>._
 
 +
 _The function <<fmi3CompletedIntegratorStep>> is not used to detect <<time-event,time events>> or <<state-event,state events>>, for example, by comparing event indicators of the previous with the current call of <<fmi3CompletedIntegratorStep>>._
-_<<time-event,Time events>> and <<state-event,state events>> must be detected by the importer, which has to call <<fmi3EnterEventMode>> in these cases, even if the returning from <<fmi3CompletedIntegratorStep>> with `enterEventMode == fmi3False`.]_
+_<<time-event,Time events>> and <<state-event,state events>> must be detected by the importer, which has to call <<fmi3EnterEventMode>> in these cases, even if the returning from <<fmi3CompletedIntegratorStep>> with `enterEventMode = fmi3False`.]_
 
 [[fmi3EnterEventMode,`fmi3EnterEventMode`]]
 Function `fmi3EnterEventMode`::
@@ -183,23 +183,23 @@ include::../headers/fmi3FunctionTypes.h[tags=EnterEventMode]
 +
 This function changes the state to <<EventMode>>.
 
-* Model Exchange only: `stepEvent == fmi3True` signals that a <<step-event>> occurs.
+* Model Exchange only: `stepEvent = fmi3True` signals that a <<step-event>> occurs.
 
-* Model Exchange only: `stateEvent == fmi3True` signals that a <<state-event>> occurs.
+* Model Exchange only: `stateEvent = fmi3True` signals that a <<state-event>> occurs.
 
 * Model Exchange only: `rootsFound` is an array of length `nEventIndicators` that informs the FMU which event indicator has a root. +
 For `i = 0, ... nEventIndicators-1, rootsFound[i]` informs about event indicator latexmath:[{\mathbf{z}_{\mathit{i}}}]:
-** `rootsFound[i] == 0` no root,
-** `rootsFound[i] == +1` indicates the direction of the zero-crossing from negative to positive,
-** `rootsFound[i] == -1` indicates the direction of the zero-crossing from positive to negative.
+** `rootsFound[i] = 0` no root,
+** `rootsFound[i] = +1` indicates the direction of the zero-crossing from negative to positive,
+** `rootsFound[i] = -1` indicates the direction of the zero-crossing from positive to negative.
 
 +
-If `nEventIndicators == 0` the value of `rootsFound` is not defined.
+If `nEventIndicators = 0` the value of `rootsFound` is not defined.
 The order in the `rootsFound` array is the same as in <<eventIndicators>> of <<fmi3GetEventIndicators>>.
 
 * Model Exchange only: `nEventIndicators` contains the number of event indicators as deduced from the list <<EventIndicator>> or `0` if the importer cannot provide this information.
 
-* [[timeEvent,`timeEvent`]]`timeEvent == fmi3True` signals that this event is a <<time-event>> triggered by <<nextEventTime>> of <<fmi3UpdateDiscreteStates>>.
+* [[timeEvent,`timeEvent`]]`timeEvent = fmi3True` signals that this event is a <<time-event>> triggered by <<nextEventTime>> of <<fmi3UpdateDiscreteStates>>.
 
 +
 _[An <<input-event>> can be detected by the FMU by keeping track of the calls of <<get-and-set-variable-values,`fmi3Set{VariableType}`>> in <<EventMode>>.]_

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -39,7 +39,7 @@ a|
 a|
 * Evaluate model equations with valid values for the right-hand side: +
 latexmath:[(\mathbf{y}_{c}, \mathbf{\dot{x}}_c, \mathbf{z}, \mathbf{w}_{c}, \mathbf{b},]<<enterEventMode>>latexmath:[) := \mathbf{f}_{\mathit{comp}}(\mathbf{x}_{c}, {}^\bullet\mathbf{x}_{d}, \mathbf{u}_{c}, {}^\bullet\mathbf{u}_{d}, \mathbf{p}, {}^\bullet\mathbf{r}, {}^\bullet\mathbf{b}, \mathbf{t})]
-* Update previous values of <<buffers>>: latexmath:[{}^\bullet\mathbf{b}:=\mathbf{b}]
+* Update previous values of <<buffers>>: latexmath:[{}^\bullet\mathbf{b} := \mathbf{b}]
 
 |<<fmi3CompletedIntegratorStep>>
 
@@ -47,7 +47,7 @@ a|
 * Evaluate latexmath:[\mathbf{f}_{\mathit{cont}}], if no `fmi3GetXXX` function was called
 * Deactivate continuous-time equations latexmath:[\mathbf{f}_{\mathit{cont}}]
 * Activate event equations latexmath:[\mathbf{f}_{\mathit{event}}]
-* latexmath:[\mathbf{t}:=(\mathbf{t}_\mathit{R}, 0)]
+* latexmath:[\mathbf{t} := (\mathbf{t}_\mathit{R}, 0)]
 |<<fmi3EnterEventMode>>
 
 |====

--- a/docs/4_1_co-simulation_math.adoc
+++ b/docs/4_1_co-simulation_math.adoc
@@ -50,8 +50,8 @@ The inner level does not exist for scalar variables.
 --
 
 _[ Example:_ +
-_Assuming an FMU has outputs latexmath:[y_1][2*3] with value reference 1, latexmath:[y_2] with value reference 2, latexmath:[ y_3][2] value reference 3, latexmath:[y_4] with value reference 4 and `maxOutputDerivativeOrder`=2._ +
-_With `valueReferences`= [1, 1, 3, 3, 4, 4], and `orders`= [1, 2, 1, 2, 1, 2], <<fmi3GetOutputDerivatives>> will provide first and second time derivatives of the outputs y1, y3, y4, which in `values` are serialized in the following way:_
+_Assuming an FMU has outputs latexmath:[y_1][2*3] with value reference 1, latexmath:[y_2] with value reference 2, latexmath:[ y_3][2] value reference 3, latexmath:[y_4] with value reference 4 and `maxOutputDerivativeOrder = 2`._ +
+_With `valueReferences = [1, 1, 3, 3, 4, 4]`, and `orders = [1, 2, 1, 2, 1, 2]`, <<fmi3GetOutputDerivatives>> will provide first and second time derivatives of the outputs y1, y3, y4, which in `values` are serialized in the following way:_
 _((array serialization of latexmath:[\dot y_1]), (array serialization of latexmath:[\ddot y_1]), (array serialization of latexmath:[\dot y_3]), (array serialization of latexmath:[\ddot y_3]), latexmath:[\dot y_4], latexmath:[\ddot y_4]).]_
 
 ==== Early Return [[early-return]]

--- a/docs/4_2_co-simulation_api.adoc
+++ b/docs/4_2_co-simulation_api.adoc
@@ -20,7 +20,7 @@ During <<StepMode>>, <<clocked-variable,clocked variables>> can not be set or ge
 |<<each-state-description,Equations and Actions>>
 |Functions Influencing Equations
 
-|Set <<tunable>> <<parameter,`parameters`>> latexmath:[\mathbf{p}_{\mathit{variability == tunable}}] .
+|Set <<tunable>> <<parameter,`parameters`>> latexmath:[\mathbf{p}_{\mathit{variability = tunable}}] .
 |<<get-and-set-variable-values,`fmi3Set{VariableType}`>>
 
 |Set non-clocked, continuous-time and discrete-time <<input,`inputs`>> latexmath:[\mathbf{u}_{c+d-k}(\mathbf{t})].
@@ -98,27 +98,27 @@ _[Formally, argument <<currentCommunicationPoint>> is not needed._
 _It is present in order to handle a potential mismatch between the importer's and the FMU's time representations and/or computations._
 _Both arguments <<currentCommunicationPoint>> and <<communicationStepSize>> allow computing of_ latexmath:[\mathbf{t}_\mathit{i+1}] _by one addition, avoiding accumulation of numerical errors.]_
 
-* [[noSetFMUStatePriorToCurrentPoint,`noSetFMUStatePriorToCurrentPoint`]] `noSetFMUStatePriorToCurrentPoint == fmi3True` if `fmi3SetFMUState` will no longer be called for time instants prior to <<currentCommunicationPoint>> in this simulation run.
+* [[noSetFMUStatePriorToCurrentPoint,`noSetFMUStatePriorToCurrentPoint`]] `noSetFMUStatePriorToCurrentPoint = fmi3True` if `fmi3SetFMUState` will no longer be called for time instants prior to <<currentCommunicationPoint>> in this simulation run.
 +
 _[The FMU can use this flag to flush a result buffer.]_
 
-* [[eventHandlingNeeded,`eventHandlingNeeded`]] <<eventHandlingNeeded,`eventHandlingNeeded == fmi3True`>> indicates that an event was encountered at <<lastSuccessfulTime>> and the importer has to enter <<EventMode>> by calling <<fmi3EnterEventModeCS>>.
-<<eventHandlingNeeded,`eventHandlingNeeded == fmi3True`>> must not be signaled, if the importer indicates to not support <<EventMode>> by <<eventModeUsed,`eventModeUsed == fmi3False`>>.
+* [[eventHandlingNeeded,`eventHandlingNeeded`]] <<eventHandlingNeeded,`eventHandlingNeeded = fmi3True`>> indicates that an event was encountered at <<lastSuccessfulTime>> and the importer has to enter <<EventMode>> by calling <<fmi3EnterEventModeCS>>.
+<<eventHandlingNeeded,`eventHandlingNeeded = fmi3True`>> must not be signaled, if the importer indicates to not support <<EventMode>> by <<eventModeUsed,`eventModeUsed = fmi3False`>>.
 _[This is different from <<earlyReturn>> which only indicates that the <<fmi3DoStep>> did not complete the intended step up until <<currentCommunicationPoint>> + <<communicationStepSize>> and does not require event handling in itself.]_
 
-* [[terminateSimulationDS,`terminateSimulation`]] When <<terminateSimulationDS,`terminateSimulation == fmi3True`>>, the FMU requests to stop the simulation and the importer must call <<fmi3Terminate>>.
+* [[terminateSimulationDS,`terminateSimulation`]] When <<terminateSimulationDS,`terminateSimulation = fmi3True`>>, the FMU requests to stop the simulation and the importer must call <<fmi3Terminate>>.
 
 * [[earlyReturn,`earlyReturn`]] `earlyReturn` signals to the importer that the FMU returns at latexmath:[\mathbf{t}_\mathit{i+1} < \mathbf{t}_i +]<<communicationStepSize>> from the <<fmi3DoStep>>.
-<<earlyReturn, `earlyReturn == fmi3True`>> is only allowed if <<earlyReturnAllowed,`earlyReturnAllowed == fmi3True`>> in <<fmi3InstantiateCoSimulation>>.
+<<earlyReturn, `earlyReturn = fmi3True`>> is only allowed if <<earlyReturnAllowed,`earlyReturnAllowed = fmi3True`>> in <<fmi3InstantiateCoSimulation>>.
 The time reached is specified in <<lastSuccessfulTime>>.
-Reasons for <<earlyReturn, `earlyReturn == fmi3True`>> are
+Reasons for <<earlyReturn, `earlyReturn = fmi3True`>> are
 ** expressed by the return arguments <<eventHandlingNeeded>> or <<terminateSimulationDS>> of <<fmi3DoStep>>, or
-** the FMU's reaction to the importers request for <<earlyReturn>> by the return argument <<earlyReturnRequested, `earlyReturnRequested == fmi3True`>> of <<fmi3IntermediateUpdateCallback>>, or
+** the FMU's reaction to the importers request for <<earlyReturn>> by the return argument <<earlyReturnRequested, `earlyReturnRequested = fmi3True`>> of <<fmi3IntermediateUpdateCallback>>, or
 ** the FMU's request for a communication point at <<lastSuccessfulTime>> for any other reason.
 
 * [[lastSuccessfulTime,`lastSuccessfulTime`]] `lastSuccessfulTime` represents the internal time latexmath:[\mathbf{t}_\mathit{i+1}] of the FMU when <<fmi3DoStep>> returns, for any value of <<earlyReturn>>.
-It is possible that the <<lastSuccessfulTime>> is equal to <<currentCommunicationPoint>> when <<earlyReturn,`earlyReturn == fmi3True`>> to indicate, for example, the detection of an event at <<currentCommunicationPoint>>.
-Even if the FMU returns from <<fmi3DoStep>> with <<fmi3OK>> and <<earlyReturn, `earlyReturn == fmi3False`>>, it is allowed that <<lastSuccessfulTime>> deviates from the expected <<currentCommunicationPoint>> `+` <<communicationStepSize>>.
+It is possible that the <<lastSuccessfulTime>> is equal to <<currentCommunicationPoint>> when <<earlyReturn,`earlyReturn = fmi3True`>> to indicate, for example, the detection of an event at <<currentCommunicationPoint>>.
+Even if the FMU returns from <<fmi3DoStep>> with <<fmi3OK>> and <<earlyReturn, `earlyReturn = fmi3False`>>, it is allowed that <<lastSuccessfulTime>> deviates from the expected <<currentCommunicationPoint>> `+` <<communicationStepSize>>.
 _[Examples:_
 ** _A fixed-step integrator inside the FMU cannot reach the requested time exactly._
 _<<fixedInternalStepSize>> was introduced to reduce these effects._
@@ -130,7 +130,7 @@ Function <<fmi3IntermediateUpdateCallback>>::
 [[fmi3EnterEventModeCS,`fmi3EnterEventMode`]]
 Function <<fmi3EnterEventMode>>::
 Changes state to <<EventMode>>.
-This function must not be called, if <<fmi3InstantiateCoSimulation>> signaled <<eventModeUsed,`eventModeUsed == fmi3False`>>, which can be forced by the FMU with <<hasEventMode,`hasEventMode == false`>>. +
+This function must not be called, if <<fmi3InstantiateCoSimulation>> signaled <<eventModeUsed,`eventModeUsed = fmi3False`>>, which can be forced by the FMU with <<hasEventMode,`hasEventMode = false`>>. +
 
 Function <<fmi3EnterConfigurationMode>>::
 <<fmi3EnterConfigurationMode>> changes state to <<ReconfigurationMode>>.
@@ -187,29 +187,29 @@ include::../headers/fmi3FunctionTypes.h[tag=CallbackIntermediateUpdate]
 If an event happens or an <<outputClock>> ticks, <<intermediateUpdateTime>> is the time of event or <<outputClock>> tick.
 In Co-Simulation, <<intermediateUpdateTime>> is restricted by the arguments to <<fmi3DoStep>> as follows: +
 <<currentCommunicationPoint>> latexmath:[\leq] <<intermediateUpdateTime>> latexmath:[\leq] (<<currentCommunicationPoint>> + <<communicationStepSize>>). +
-The FMU must not call the callback function <<fmi3IntermediateUpdateCallback>> with an <<intermediateUpdateTime>> that is smaller than the <<intermediateUpdateTime>> given in a previous call of <<fmi3IntermediateUpdateCallback>> with `intermediateStepFinished == fmi3True`. +
+The FMU must not call the callback function <<fmi3IntermediateUpdateCallback>> with an <<intermediateUpdateTime>> that is smaller than the <<intermediateUpdateTime>> given in a previous call of <<fmi3IntermediateUpdateCallback>> with `intermediateStepFinished = fmi3True`. +
 
 [[intermediateVariableSetRequested,`intermediateVariableSetRequested`]]
-* If <<intermediateVariableSetRequested,`intermediateVariableSetRequested == fmi3True`>>, the co-simulation algorithm may provide intermediate values for continuous <<input>> variables with <<intermediateUpdate,`intermediateUpdate = true`>> by calling <<get-and-set-variable-values,`fmi3Set{VariableType}`>>.
+* If <<intermediateVariableSetRequested,`intermediateVariableSetRequested = fmi3True`>>, the co-simulation algorithm may provide intermediate values for continuous <<input>> variables with <<intermediateUpdate,`intermediateUpdate = true`>> by calling <<get-and-set-variable-values,`fmi3Set{VariableType}`>>.
 The set of variables for which the co-simulation algorithm will provide intermediate values is declared through the <<requiredIntermediateVariables>> argument to <<fmi3Instantiate>>.
 If a co-simulation algorithm does not provide a new value for any of the variables contained in the set it registered, the last value set remains.
 
 [[intermediateVariableGetAllowed,`intermediateVariableGetAllowed`]]
-* If <<intermediateVariableGetAllowed,`intermediateVariableGetAllowed == fmi3True`>>, the co-simulation algorithm may collect intermediate output variables by calling <<get-and-set-variable-values,`fmi3Get{VariableType}`>> for variables with <<intermediateUpdate,`intermediateUpdate = true`>>.
+* If <<intermediateVariableGetAllowed,`intermediateVariableGetAllowed = fmi3True`>>, the co-simulation algorithm may collect intermediate output variables by calling <<get-and-set-variable-values,`fmi3Get{VariableType}`>> for variables with <<intermediateUpdate,`intermediateUpdate = true`>>.
 The set of variables for which the co-simulation algorithm can get values is supplied through the <<requiredIntermediateVariables>> argument to <<fmi3Instantiate>>.
 
 [[intermediateStepFinished,`intermediateStepFinished`]]
-* If <<intermediateStepFinished, `intermediateStepFinished == fmi3False`>>, the intermediate outputs of the FMU that the co-simulation algorithm inquires with <<get-and-set-variable-values,`fmi3Get{VariableType}`>> resulting from tentative internal solver states and may still change for the same <<intermediateUpdateTime>> _[e.g., if the solver deems the tentative state to cause a too high approximation error, it may go back in time and try to re-estimate the state using smaller internal time steps]_. +
-If <<intermediateStepFinished, `intermediateStepFinished == fmi3True`>>, intermediate outputs inquired by the co-simulation algorithm with <<get-and-set-variable-values,`fmi3Get{VariableType}`>> correspond to accepted internal solver step.
+* If <<intermediateStepFinished, `intermediateStepFinished = fmi3False`>>, the intermediate outputs of the FMU that the co-simulation algorithm inquires with <<get-and-set-variable-values,`fmi3Get{VariableType}`>> resulting from tentative internal solver states and may still change for the same <<intermediateUpdateTime>> _[e.g., if the solver deems the tentative state to cause a too high approximation error, it may go back in time and try to re-estimate the state using smaller internal time steps]_. +
+If <<intermediateStepFinished, `intermediateStepFinished = fmi3True`>>, intermediate outputs inquired by the co-simulation algorithm with <<get-and-set-variable-values,`fmi3Get{VariableType}`>> correspond to accepted internal solver step.
 
 [[canReturnEarly,`canReturnEarly`]]
-* When <<canReturnEarly,`canReturnEarly == fmi3True`>> the FMU signals to the co-simulation algorithm its ability to return early from the current <<fmi3DoStep>>.
+* When <<canReturnEarly,`canReturnEarly = fmi3True`>> the FMU signals to the co-simulation algorithm its ability to return early from the current <<fmi3DoStep>>.
 
 [[earlyReturnRequested,`earlyReturnRequested`]]
-* `earlyReturnRequested`: If and only if <<canReturnEarly,`canReturnEarly == fmi3True`>>, the co-simulation algorithm may request the FMU to return early from <<fmi3DoStep>> by setting `earlyReturnRequested == fmi3True`.
+* `earlyReturnRequested`: If and only if <<canReturnEarly,`canReturnEarly = fmi3True`>>, the co-simulation algorithm may request the FMU to return early from <<fmi3DoStep>> by setting `earlyReturnRequested = fmi3True`.
 
 [[earlyReturnTime,`earlyReturnTime`]]
-* `earlyReturnTime` is used to signal the FMU at which time to return early from the current <<fmi3DoStep>>, if the return value of <<earlyReturnRequested, `earlyReturnRequested == fmi3True`>>.
+* `earlyReturnTime` is used to signal the FMU at which time to return early from the current <<fmi3DoStep>>, if the return value of <<earlyReturnRequested, `earlyReturnRequested = fmi3True`>>.
 If the <<earlyReturnTime>> is greater than the last signaled <<intermediateUpdateTime>>, the FMU may integrate up to the time instant <<earlyReturnTime>>.
 
 .Mathematical description of <<IntermediateUpdateMode>>.
@@ -235,14 +235,14 @@ Set continuous intermediate input variables latexmath:[\mathbf{u}_{\mathit{c,u}}
 Allowed Function Calls::
 
 Function <<get-and-set-variable-values,`fmi3Get{VariableType}`>>::
-This function can be called for intermediate variables, if <<intermediateVariableGetAllowed,`intermediateVariableGetAllowed == fmi3True`>>.
+This function can be called for intermediate variables, if <<intermediateVariableGetAllowed,`intermediateVariableGetAllowed = fmi3True`>>.
 Intermediate variables are variables that are marked with attribute <<intermediateUpdate,`intermediateUpdate = true`>> in the <<modelDescription.xml>> and have been included in the <<requiredIntermediateVariables>> argument to <<fmi3Instantiate>>.
 
 +
 For details on <<fmi3GetOutputDerivatives>> see <<getting-output-derivatives>>.
 
 Function <<get-and-set-variable-values,`fmi3Set{VariableType}`>>::
-This function can be called for intermediate input variables, if <<intermediateVariableSetRequested,`intermediateVariableSetRequested == fmi3True`>>.
+This function can be called for intermediate input variables, if <<intermediateVariableSetRequested,`intermediateVariableSetRequested = fmi3True`>>.
 Intermediate input variables are input variables that are marked with attribute <<intermediateUpdate,`intermediateUpdate = true`>> in the <<modelDescription.xml>> and have been included in the <<requiredIntermediateVariables>> argument of <<fmi3Instantiate>>.
 In Co-Simulation, <<discrete>> <<input,`inputs`>> must not be set.
 

--- a/docs/4_2_co-simulation_api.adoc
+++ b/docs/4_2_co-simulation_api.adoc
@@ -34,9 +34,9 @@ During <<StepMode>>, <<clocked-variable,clocked variables>> can not be set or ge
 
 a|
 * latexmath:[(\mathbf{y}_{c+d-k}, \mathbf{y}_c^{(j)}, \mathbf{x}_{d-k}, \mathbf{w}_{c+d-k}, \mathbf{b}, \mathbf{t}_\mathit{i+1}) := \mathbf{f}_{\mathit{doStep}}({}^{\bullet}\mathbf{x}_d, \mathbf{u}_{c+d}, {}^{\bullet}\mathbf{u}_{c,u}, \mathbf{p}, {}^{\bullet}\mathbf{b}, \mathbf{t}_i, \mathbf{h}_i)] +
-* Update previous values of non-clocked, discrete states: latexmath:[{}^\bullet\mathbf{x}_{d-k}:=\mathbf{x}_{d-k}].
-* Update previous values of buffers: latexmath:[{}^\bullet\mathbf{b}:=\mathbf{b}].
-* latexmath:[\mathbf{t}:=(\mathbf{t}_\mathit{i+1}, 0)]
+* Update previous values of non-clocked, discrete states: latexmath:[{}^\bullet\mathbf{x}_{d-k} := \mathbf{x}_{d-k}].
+* Update previous values of buffers: latexmath:[{}^\bullet\mathbf{b} := \mathbf{b}].
+* latexmath:[\mathbf{t} := (\mathbf{t}_\mathit{i+1}, 0)]
 |<<fmi3DoStep>>
 
 |latexmath:[(\mathbf{v}_{u-k}, \mathbf{t}_u) := \mathbf{f}_{\mathit{inter}}({}^{\bullet}\mathbf{x}_d, \mathbf{u}_{c+d}, {}^{\bullet}\mathbf{u}_{c,u}, \mathbf{p}, {}^{\bullet}\mathbf{b}, \mathbf{t}_i, \mathbf{h}_i)]

--- a/docs/4_4_co-simulation_schema.adoc
+++ b/docs/4_4_co-simulation_schema.adoc
@@ -43,15 +43,15 @@ latexmath:[k=0] means continuous (see <<smoothness>>). +
 If this flag is `false` (the default), the importer can assume that the FMU computes the <<fmi3DoStep>> as instructed up until <<currentCommunicationPoint>> + <<communicationStepSize>>.
 
 |[[canReturnEarlyAfterIntermediateUpdate,`canReturnEarlyAfterIntermediateUpdate`]] `canReturnEarlyAfterIntermediateUpdate`
-|If `true`, the FMU is able to return early from <<fmi3DoStep>> if the co-simulation algorithm returns <<earlyReturnRequested,`earlyReturnRequested == fmi3True`>> from the callback <<intermediateUpdate>> and <<canReturnEarly,`canReturnEarly == fmi3True`>>.
+|If `true`, the FMU is able to return early from <<fmi3DoStep>> if the co-simulation algorithm returns <<earlyReturnRequested,`earlyReturnRequested = fmi3True`>> from the callback <<intermediateUpdate>> and <<canReturnEarly,`canReturnEarly = fmi3True`>>.
 The default value of this capability flag is `false`.
 
 |[[hasEventMode,`hasEventMode`]]`hasEventMode`
 |If `true` the FMU supports <<EventMode>>.
-Even if this flag is `true`, the co-simulation algorithm can chose to delegate event handling to the FMU by calling <<fmi3InstantiateCoSimulation>> with <<eventModeUsed,`eventModeUsed == fmi3False`>>.
-If `eventModeUsed == fmi3True`, the co-simulation algorithm will have to actively trigger event handling in the FMU using <<fmi3EnterEventModeCS>>.
-<<fmi3InstantiateCoSimulation>> must only be called with `eventModeUsed == fmi3True` if <<hasEventMode,`hasEventMode == true`>>.
-If the FMU has clocks, then  <<modelDescription.xml>> must set <<hasEventMode,`hasEventMode == true`>> and the importer must call <<fmi3InstantiateCoSimulation>> with <<eventModeUsed,`eventModeUsed == fmi3True`>>.
+Even if this flag is `true`, the co-simulation algorithm can chose to delegate event handling to the FMU by calling <<fmi3InstantiateCoSimulation>> with <<eventModeUsed,`eventModeUsed = fmi3False`>>.
+If `eventModeUsed = fmi3True`, the co-simulation algorithm will have to actively trigger event handling in the FMU using <<fmi3EnterEventModeCS>>.
+<<fmi3InstantiateCoSimulation>> must only be called with `eventModeUsed = fmi3True` if <<hasEventMode,`hasEventMode = true`>>.
+If the FMU has clocks, then  <<modelDescription.xml>> must set <<hasEventMode,`hasEventMode = true`>> and the importer must call <<fmi3InstantiateCoSimulation>> with <<eventModeUsed,`eventModeUsed = fmi3True`>>.
 
 |====
 

--- a/docs/4_4_co-simulation_schema.adoc
+++ b/docs/4_4_co-simulation_schema.adoc
@@ -33,7 +33,7 @@ Calling of `fmi3GetOutputDerivatives` is allowed up to the order defined by `max
 
 |[[recommendedIntermediateInputSmoothness,`recommendedIntermediateInputSmoothness`]] `recommendedIntermediateInputSmoothness`
 |A value of latexmath:[k] with latexmath:[k>0] signals to the co-simulation algorithm, that it is beneficial for the solver to receive intermediate inputs that are k-time continuously differentiable (latexmath:[C^k]) on the current communication interval.
-latexmath:[k=0] means continuous (see <<smoothness>>). +
+latexmath:[k = 0] means continuous (see <<smoothness>>). +
 
 |[[providesIntermediateUpdate,`providesIntermediateUpdate`]] `providesIntermediateUpdate`
 |The FMU supports <<IntermediateUpdateMode>> and will call <<fmi3IntermediateUpdateCallback>>, if provided.

--- a/docs/5_1_scheduled_execution_math.adoc
+++ b/docs/5_1_scheduled_execution_math.adoc
@@ -13,7 +13,7 @@ The FMU may request to schedule another model partition even while currently a m
 A new interval for a <<countdown-aperiodic-clock,`countdown`>> Clock can be provided at any time during the execution of any model partition.
 The FMU signals that a <<countdown-aperiodic-clock,`countdown`>> Clock is about to tick by calling <<fmi3ClockUpdateCallback>>.
 The importer calls <<fmi3GetInterval>> for all <<countdown-aperiodic-clock,`countdown`>> Clocks.
-If a new interval latexmath:[\mathbf{T}_{interval, i}] is provided, i.e. return argument <<qualifiers>> == <<fmi3IntervalChanged>>, the importer initiates the scheduling of the associated model partitions regarding the delay of the returned interval.
+If a new interval latexmath:[\mathbf{T}_{interval, i}] is provided, i.e. return argument <<qualifiers>> = <<fmi3IntervalChanged>>, the importer initiates the scheduling of the associated model partitions regarding the delay of the returned interval.
 
 In case more than one Clock ticks at the same time instant, the scheduler needs a priority to define the activation sequence of the associated model partitions.
 This ordering is defined by the <<priority>> attributes of the Clock.

--- a/docs/5_2_scheduled_execution_api.adoc
+++ b/docs/5_2_scheduled_execution_api.adoc
@@ -61,7 +61,7 @@ I.e. the importer may activate potential sinks (e.g. a model partition of anothe
 a|When an input Clock latexmath:[\mathbf{k}_i] ticks, activate the corresponding model partition:
 
 * latexmath:[(\mathbf{y}_\mathit{d,k_i}, \mathbf{x}_\mathit{d,k_i}, \mathbf{w}_\mathit{d,k_i}) := \mathbf{f}_{\mathit{activate}}({}^{\bullet}\mathbf{x}_\mathit{d}, \mathbf{w}_d, \mathbf{u}_\mathit{d}, \mathbf{p}, \mathbf{k_i})] +
-* Update previous values of discrete states of the corresponding model partition: latexmath:[{}^\bullet\mathbf{x}_\mathit{d,k_i}:=\mathbf{x}_\mathit{d,k_i}].
+* Update previous values of discrete states of the corresponding model partition: latexmath:[{}^\bullet\mathbf{x}_\mathit{d,k_i} := \mathbf{x}_\mathit{d,k_i}].
 |<<fmi3ActivateModelPartition>>
 
 |====

--- a/docs/5_2_scheduled_execution_api.adoc
+++ b/docs/5_2_scheduled_execution_api.adoc
@@ -49,7 +49,7 @@ I.e. the importer may activate potential sinks (e.g. a model partition of anothe
 |<<each-state-description,Equations and Actions>>
 |Functions Influencing Equations
 
-|Set <<tunable>> <<parameter,`parameters`>> latexmath:[\mathbf{p}_{\mathit{variability == tunable}}] .
+|Set <<tunable>> <<parameter,`parameters`>> latexmath:[\mathbf{p}_{\mathit{variability = tunable}}] .
 |<<get-and-set-variable-values,`fmi3Set{VariableType}`>>
 
 |Set discrete-time <<input,`inputs`>> latexmath:[\mathbf{u}_{d}(\mathbf{t})].


### PR DESCRIPTION
This now makes the use of `=` consistent.
Note: an argument for the single `=` is that it in all circumstances this now reads the same for importer and FMU.
When using `==`, it is really only right for the side to check the conditions, the other side needs to meet that condition and why would you write it as `==`?
So after reading through the changes, I am more convinced than before that single `=` is the better solution.