### PR TITLE
Remove redundant "shifts" and "intervals" prefixes

### DIFF
--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -818,7 +818,7 @@ For restrictions on when to call which of the following functions for <<table-ov
 
 [[fmi3SetInterval,`fmi3SetInterval`]]
 For <<table-overview-clocks,some Clock types>>, the interval must be set by the environment for the current time instant by the function <<fmi3SetIntervalDecimal>> or <<fmi3SetIntervalFraction>>.
-The values of the arguments `intervals`, `shifts`, and `counters` / `resolutions` refer to the unit of the <<independent>> variable.
+The values of the arguments <<intervals>>, <<shifts>>, and <<counters>> / <<resolutions>> refer to the unit of the <<independent>> variable.
 
 The attribute <<supportsFraction>> of a Clock declares if the <<fmi3SetIntervalFraction>> and/or `fmi3GetXXXFraction` functions may be called.
 
@@ -831,7 +831,7 @@ include::../headers/fmi3FunctionTypes.h[tag=SetIntervalDecimal]
 * `valueReferences` is an array of size `nValueReferences` holding the value references of the Clock variables.
 
 [[intervals,`intervals`]]
-* `intervals` is an array of size `nValueReferences` holding the Clock intervals to be set.
+* <<intervals>> is an array of size `nValueReferences` holding the Clock intervals to be set.
 
 [[fmi3SetIntervalFraction,`fmi3SetIntervalFraction`]]
 [source, C]
@@ -842,10 +842,10 @@ include::../headers/fmi3FunctionTypes.h[tag=SetIntervalFraction]
 * `valueReferences` is an array of size `nValueReferences` holding the value references of the Clock variables.
 
 [[counters,`counters`]]
-* `counters` and
+* <<counters>> and
 
 [[resolutions,`resolutions`]]
-* `resolutions` are arrays of size `nValueReferences` holding the Clock `counters` and `resolutions` to be set.
+* <<resolutions>> are arrays of size `nValueReferences` holding the Clock <<counters>> and <<resolutions>> to be set.
 
 [[fmi3GetInterval,`fmi3GetInterval`]]
 For <<table-overview-clocks,other Clock types>>, the importer must call <<fmi3GetIntervalDecimal>> or <<fmi3GetIntervalFraction>> to query the next Clock interval:
@@ -858,11 +858,11 @@ include::../headers/fmi3FunctionTypes.h[tag=GetIntervalDecimal]
 
 * `valueReferences` is an array of size `nValueReferences` holding the value references of the Clock variables.
 
-* `intervals` is an array of size `nValueReferences` to retrieve the Clock intervals.
+* <<intervals>> is an array of size `nValueReferences` to retrieve the Clock intervals.
 
 [[qualifiers,`qualifiers`]]
-* `qualifiers` is an array of size `nValueReferences` to retrieve the Clocks `qualifiers`.
-`qualifiers` describes how to treat the <<intervals>> and <<counters>> arguments and is defined as:
+* <<qualifiers>> is an array of size `nValueReferences` to retrieve the Clocks <<qualifiers>>.
+<<qualifiers>> describes how to treat the <<intervals>> and <<counters>> arguments and is defined as:
 
 [source, C]
 ----
@@ -893,11 +893,11 @@ include::../headers/fmi3FunctionTypes.h[tag=GetIntervalFraction]
 
 * `valueReferences` is an array of size `nValueReferences` holding the value references of the `Clock` variables.
 
-* `counters` and `resolutions` are arrays of size `nValueReferences` to retrieve the Clock intervals as a fraction `counters / resolutions`.
+* <<counters>> and <<resolutions>> are arrays of size `nValueReferences` to retrieve the Clock intervals as a fraction `counters / resolutions`.
 
-* `qualifiers` is an array of size `nValueReferences` to retrieve the Clock <<qualifiers>>.
+* <<qualifiers>> is an array of size `nValueReferences` to retrieve the Clock <<qualifiers>>.
 
-[[shifts, `shifts`]]
+[[shifts,`shifts`]]
 For <<table-overview-clocks,some Clock types>>, the importer must query the delay to the first Clock tick from the FMU using the following functions[[fmi3GetShift,`fmi3GetShift`]]:
 
 [[fmi3GetShiftDecimal,`fmi3GetShiftDecimal`]]
@@ -914,7 +914,7 @@ include::../headers/fmi3FunctionTypes.h[tag=GetShiftFraction]
 
 * `valueReferences` is an array of size `nValueReferences` holding the value references of the Clock variables.
 
-* `shifts` and `counters` are arrays of length `nValueReferences` that define the time of the first Clock tick (see <<shiftCounter>>).
+* <<shifts>> and <<counters>> are arrays of length `nValueReferences` that define the time of the first Clock tick (see <<shiftCounter>>).
 
 For <<table-overview-clocks,other Clock types>>, the importer may set the delay to the first Clock tick from the FMU using the following functions[[fmi3SetShift,`fmi3SetShift`]]:
 [[fmi3SetShiftDecimal,`fmi3SetShiftDecimal`]]
@@ -931,7 +931,7 @@ include::../headers/fmi3FunctionTypes.h[tag=SetShiftFraction]
 
 * `valueReferences` is an array of size `nValueReferences` holding the value references of the Clock variables.
 
-* `shifts` and `counters` is an array of length `nValueReferences` that defines the time of the first Clock tick (see <<shiftCounter>>).
+* <<shifts>> and <<counters>> is an array of length `nValueReferences` that defines the time of the first Clock tick (see <<shiftCounter>>).
 
 ==== Dependencies of Variables [[model-dependencies]]
 

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -842,7 +842,7 @@ include::../headers/fmi3FunctionTypes.h[tag=SetIntervalFraction]
 * `valueReferences` is an array of size `nValueReferences` holding the value references of the Clock variables.
 
 [[counters,`counters`]]
-* <<counters>> and
+* <<counters>> _[Note: This variable may increment by values other than 1.]_ and
 
 [[resolutions,`resolutions`]]
 * <<resolutions>> are arrays of size `nValueReferences` holding the Clock <<counters>> and <<resolutions>> to be set.

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -842,8 +842,10 @@ include::../headers/fmi3FunctionTypes.h[tag=SetIntervalFraction]
 * `valueReferences` is an array of size `nValueReferences` holding the value references of the Clock variables.
 
 [[counters,`counters`]]
+* `counters` and
+
 [[resolutions,`resolutions`]]
-* `counters` and `resolutions` are arrays of size `nValueReferences` holding the Clock `counters` and `resolutions` to be set.
+* `resolutions` are arrays of size `nValueReferences` holding the Clock `counters` and `resolutions` to be set.
 
 [[fmi3GetInterval,`fmi3GetInterval`]]
 For <<table-overview-clocks,other Clock types>>, the importer must call <<fmi3GetIntervalDecimal>> or <<fmi3GetIntervalFraction>> to query the next Clock interval:

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -632,11 +632,11 @@ The mathematical descriptions of time-based Clocks uses the following notations:
 |The previous time instant, when the Clock ticked.
 
 |latexmath:[\mathbf{T}_{\mathit{shift}}]
-|The delay for the first Clock tick relative to latexmath:[\mathbf{t}_{\mathit{start}}]. latexmath:[\mathbf{T}_{\mathit{shift}}] is defined differently for the different Clock types, and can be set with <<fmi3SetShiftDecimal>> or retrieved from the FMU with <<fmi3GetShiftDecimal>> as floating point value, or as rational number using <<fmi3SetShiftFraction>> or <<fmi3GetShiftFraction>> with <<shiftCounters>> / <<resolutions>>.
+|The delay for the first Clock tick relative to latexmath:[\mathbf{t}_{\mathit{start}}]. latexmath:[\mathbf{T}_{\mathit{shift}}] is defined differently for the different Clock types, and can be set with <<fmi3SetShiftDecimal>> or retrieved from the FMU with <<fmi3GetShiftDecimal>> as floating point value, or as rational number using <<fmi3SetShiftFraction>> or <<fmi3GetShiftFraction>>.
 
 |latexmath:[\mathbf{T}_{interval, i}]
 |The time interval until the next Clock tick, defined differently for the different Clock types.
-latexmath:[\mathbf{T}_{interval, i}] can be set with <<fmi3SetIntervalDecimal>> or retrieved with <<fmi3GetIntervalDecimal>> as floating point value, or as rational number using <<fmi3SetIntervalFraction>> or <<fmi3GetIntervalFraction>> with <<intervalCounters>> / <<resolutions>>.
+latexmath:[\mathbf{T}_{interval, i}] can be set with <<fmi3SetIntervalDecimal>> or retrieved with <<fmi3GetIntervalDecimal>> as floating point value, or as rational number using <<fmi3SetIntervalFraction>> or <<fmi3GetIntervalFraction>>.
 
 |latexmath:[\mathbf{t}_\mathit{event}]
 |The current event time in <<EventMode>>, or the current time in Scheduled Execution.
@@ -818,7 +818,7 @@ For restrictions on when to call which of the following functions for <<table-ov
 
 [[fmi3SetInterval,`fmi3SetInterval`]]
 For <<table-overview-clocks,some Clock types>>, the interval must be set by the environment for the current time instant by the function <<fmi3SetIntervalDecimal>> or <<fmi3SetIntervalFraction>>.
-The values of the arguments <<intervals>>, <<intervalCounters>>, <<resolutions>>, <<shifts>> and <<shiftCounters>> refer to the unit of the <<independent>> variable.
+The values of the arguments `intervals`, `shifts`, and `counters` / `resolutions` refer to the unit of the <<independent>> variable.
 
 The attribute <<supportsFraction>> of a Clock declares if the <<fmi3SetIntervalFraction>> and/or `fmi3GetXXXFraction` functions may be called.
 
@@ -841,9 +841,9 @@ include::../headers/fmi3FunctionTypes.h[tag=SetIntervalFraction]
 
 * `valueReferences` is an array of size `nValueReferences` holding the value references of the Clock variables.
 
-[[intervalCounters,`intervalCounters`]]
+[[counters,`counters`]]
 [[resolutions,`resolutions`]]
-* `intervalCounters` and `resolutions` are arrays of size `nValueReferences` holding the Clock `intervalCounters` and `resolutions` to be set.
+* `counters` and `resolutions` are arrays of size `nValueReferences` holding the Clock `counters` and `resolutions` to be set.
 
 [[fmi3GetInterval,`fmi3GetInterval`]]
 For <<table-overview-clocks,other Clock types>>, the importer must call <<fmi3GetIntervalDecimal>> or <<fmi3GetIntervalFraction>> to query the next Clock interval:
@@ -860,7 +860,7 @@ include::../headers/fmi3FunctionTypes.h[tag=GetIntervalDecimal]
 
 [[qualifiers,`qualifiers`]]
 * `qualifiers` is an array of size `nValueReferences` to retrieve the Clocks `qualifiers`.
-`qualifiers` describes how to treat the <<intervals>> and <<intervalCounters>> arguments and is defined as:
+`qualifiers` describes how to treat the <<intervals>> and <<counters>> arguments and is defined as:
 
 [source, C]
 ----
@@ -891,8 +891,7 @@ include::../headers/fmi3FunctionTypes.h[tag=GetIntervalFraction]
 
 * `valueReferences` is an array of size `nValueReferences` holding the value references of the `Clock` variables.
 
-[[intervalCounters,`intervalCounters`]]
-* `intervalCounters` and <<resolutions>> are arrays of size `nValueReferences` to retrieve the Clock <<intervalCounters>> and <<resolutions>>.
+* `counters` and `resolutions` are arrays of size `nValueReferences` to retrieve the Clock intervals as a fraction `counters / resolutions`.
 
 * `qualifiers` is an array of size `nValueReferences` to retrieve the Clock <<qualifiers>>.
 
@@ -913,10 +912,7 @@ include::../headers/fmi3FunctionTypes.h[tag=GetShiftFraction]
 
 * `valueReferences` is an array of size `nValueReferences` holding the value references of the Clock variables.
 
-* <<shifts>> and
-
-* <<shiftCounters>> are arrays of length `nValueReferences` that define the time of the first Clock tick (see <<shiftCounter>>).
-
+* `shifts` and `counters` are arrays of length `nValueReferences` that define the time of the first Clock tick (see <<shiftCounter>>).
 
 For <<table-overview-clocks,other Clock types>>, the importer may set the delay to the first Clock tick from the FMU using the following functions[[fmi3SetShift,`fmi3SetShift`]]:
 [[fmi3SetShiftDecimal,`fmi3SetShiftDecimal`]]
@@ -933,10 +929,7 @@ include::../headers/fmi3FunctionTypes.h[tag=SetShiftFraction]
 
 * `valueReferences` is an array of size `nValueReferences` holding the value references of the Clock variables.
 
-* <<shifts>> and
-
-[[shiftCounters,`shiftCounters`]]
-* <<shiftCounters>> are arrays of length `nValueReferences` that define the time of the first Clock tick (see <<shiftCounter>>).
+* `shifts` and `counters` is an array of length `nValueReferences` that defines the time of the first Clock tick (see <<shiftCounter>>).
 
 ==== Dependencies of Variables [[model-dependencies]]
 

--- a/headers/fmi3FunctionTypes.h
+++ b/headers/fmi3FunctionTypes.h
@@ -479,7 +479,7 @@ typedef fmi3Status fmi3GetIntervalDecimalTYPE(fmi3Instance instance,
 typedef fmi3Status fmi3GetIntervalFractionTYPE(fmi3Instance instance,
                                                const fmi3ValueReference valueReferences[],
                                                size_t nValueReferences,
-                                               fmi3UInt64 intervalCounters[],
+                                               fmi3UInt64 counters[],
                                                fmi3UInt64 resolutions[],
                                                fmi3IntervalQualifier qualifiers[]);
 /* end::GetIntervalFraction[] */
@@ -495,7 +495,7 @@ typedef fmi3Status fmi3GetShiftDecimalTYPE(fmi3Instance instance,
 typedef fmi3Status fmi3GetShiftFractionTYPE(fmi3Instance instance,
                                             const fmi3ValueReference valueReferences[],
                                             size_t nValueReferences,
-                                            fmi3UInt64 shiftCounters[],
+                                            fmi3UInt64 counters[],
                                             fmi3UInt64 resolutions[]);
 /* end::GetShiftFraction[] */
 
@@ -510,7 +510,7 @@ typedef fmi3Status fmi3SetIntervalDecimalTYPE(fmi3Instance instance,
 typedef fmi3Status fmi3SetIntervalFractionTYPE(fmi3Instance instance,
                                                const fmi3ValueReference valueReferences[],
                                                size_t nValueReferences,
-                                               const fmi3UInt64 intervalCounters[],
+                                               const fmi3UInt64 counters[],
                                                const fmi3UInt64 resolutions[]);
 /* end::SetIntervalFraction[] */
 
@@ -525,7 +525,7 @@ typedef fmi3Status fmi3SetShiftDecimalTYPE(fmi3Instance instance,
 typedef fmi3Status fmi3SetShiftFractionTYPE(fmi3Instance instance,
                                             const fmi3ValueReference valueReferences[],
                                             size_t nValueReferences,
-                                            const fmi3UInt64 shiftCounters[],
+                                            const fmi3UInt64 counters[],
                                             const fmi3UInt64 resolutions[]);
 /* end::SetShiftFraction[] */
 


### PR DESCRIPTION
from parameter names