### PR TITLE
Add override functionality for FMI3_FUNCTION_PREFIX

### DIFF
--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -115,7 +115,7 @@ In case of a static link library, the name of the library must be `MyModel.lib` 
 - If the FMU is shipped with DLL/SharedObject: +
 The constructed function name is `fmi3GetFloat64`, in other words, it is not changed.
 _[This can be realized in the case of a source code FMU with a target-specific version of `fmi3Functions.h` that does not use FMI3_FUNCTION_PREFIX to construct the function names._
-_Using the standard-supplied version of `fmi3Functions.h`, the same effect can be achieved by defining the `FMI3_OVERRIDE_FUNCTION_PREFIX` precompiler macro prior to the includion of the `fmi3Functions.h` header, for example using precompiler command-line flags.]_
+_Using the standard-supplied version of `fmi3Functions.h`, the same effect can be achieved by defining the `FMI3_OVERRIDE_FUNCTION_PREFIX` precompiler macro prior to the inclusion of the `fmi3Functions.h` header, for example using precompiler command-line flags.]_
 A simulation environment dynamically loads this library and explicitly imports the function pointers by providing the FMI function names as strings.
 The name of the library must be `MyModel.dll` on Windows or `MyModel.so` on Linux; in other words the <<modelIdentifier>> attribute is used as library name.
 

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -114,7 +114,8 @@ In case of a static link library, the name of the library must be `MyModel.lib` 
 
 - If the FMU is shipped with DLL/SharedObject: +
 The constructed function name is `fmi3GetFloat64`, in other words, it is not changed.
-_[This can be realized in the case of a source code FMU with a target-specific version of `fmi3Functions.h` that does not use FMI3_FUNCTION_PREFIX to construct the function names.]_
+_[This can be realized in the case of a source code FMU with a target-specific version of `fmi3Functions.h` that does not use FMI3_FUNCTION_PREFIX to construct the function names._
+_Using the standard-supplied version of `fmi3Functions.h`, the same effect can be achieved by defining the `FMI3_OVERRIDE_FUNCTION_PREFIX` precompiler macro prior to the includion of the `fmi3Functions.h` header, for example using precompiler command-line flags.]_
 A simulation environment dynamically loads this library and explicitly imports the function pointers by providing the FMI function names as strings.
 The name of the library must be `MyModel.dll` on Windows or `MyModel.so` on Linux; in other words the <<modelIdentifier>> attribute is used as library name.
 

--- a/headers/fmi3Functions.h
+++ b/headers/fmi3Functions.h
@@ -61,13 +61,23 @@ extern "C" {
 #include <stdlib.h>
 
 /*
+Allow override of FMI3_FUNCTION_PREFIX: If FMI3_OVERRIDE_FUNCTION_PREFIX
+is defined, then FMI3_ACTUAL_FUNCTION_PREFIX will be used, if defined,
+or no prefix if undefined. Otherwise FMI3_FUNCTION_PREFIX will be used,
+if defined.
+*/
+#if !defined(FMI3_OVERRIDE_FUNCTION_PREFIX) && defined(FMI3_FUNCTION_PREFIX)
+  #define FMI3_ACTUAL_FUNCTION_PREFIX FMI3_FUNCTION_PREFIX
+#endif
+
+/*
 Export FMI3 API functions on Windows and under GCC.
 If custom linking is desired then the FMI3_Export must be
 defined before including this file. For instance,
 it may be set to __declspec(dllimport).
 */
 #if !defined(FMI3_Export)
-  #if !defined(FMI3_FUNCTION_PREFIX)
+  #if !defined(FMI3_ACTUAL_FUNCTION_PREFIX)
     #if defined _WIN32 || defined __CYGWIN__
      /* Note: both gcc & MSVC on Windows support this syntax. */
         #define FMI3_Export __declspec(dllexport)
@@ -84,10 +94,10 @@ it may be set to __declspec(dllimport).
 #endif
 
 /* Macros to construct the real function name (prepend function name by FMI3_FUNCTION_PREFIX) */
-#if defined(FMI3_FUNCTION_PREFIX)
+#if defined(FMI3_ACTUAL_FUNCTION_PREFIX)
   #define fmi3Paste(a,b)     a ## b
   #define fmi3PasteB(a,b)    fmi3Paste(a,b)
-  #define fmi3FullName(name) fmi3PasteB(FMI3_FUNCTION_PREFIX, name)
+  #define fmi3FullName(name) fmi3PasteB(FMI3_ACTUAL_FUNCTION_PREFIX, name)
 #else
   #define fmi3FullName(name) name
 #endif


### PR DESCRIPTION
As discussed in the last fmi design meeting, this adds functionality to the standard fmi3Functions.h header to override the FMI3_FUNCTION_PREFIX easily from the outside by defining the `FMI3_OVERRIDE_FUNCTION_PREFIX` preprocessor macro.