### PR TITLE
Add local clocks to clocks table and definitions

### DIFF
--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -613,7 +613,7 @@ In Scheduled Execution the FMU must inform the importer by calling <<fmi3ClockUp
 
 |<<local>>
 |`triggered`
-|<<fmi3GetClock>> in both <<EventMode>> and <<ClockUpdateMode>>
+|<<fmi3GetClock>> in <<EventMode>>.
 |e.g. a clock inside a composed FMU that can be used only for debugging
 |====
 

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -599,7 +599,7 @@ a|[[tunable-clock]]<<fmi3SetClock>> in <<EventMode>>,
 In Scheduled Execution the FMU must inform the importer by calling <<fmi3ClockUpdateCallback>> that the Clock is about to tick
 |time-delayed actions after an event, for example, ignition signal some time after specific crank shaft angle
 
-2.2+|[[triggered,`triggered`]]<<triggered-clock,triggered>>
+2.3+|[[triggered,`triggered`]]<<triggered-clock,triggered>>
 |<<input>>
 |`triggered`
 |<<fmi3SetClock>> in <<EventMode>>,
@@ -610,6 +610,11 @@ In Scheduled Execution the FMU must inform the importer by calling <<fmi3ClockUp
 |`triggered`
 |<<fmi3GetClock>> in both <<EventMode>> and <<ClockUpdateMode>>
 |crankshaft angle sensor ticking several times per revolution
+
+|<<local>>
+|`triggered`
+|<<fmi3GetClock>> in both <<EventMode>> and <<ClockUpdateMode>>
+|e.g. a clock inside a composed FMU that can be used only for debugging
 |====
 
 [[time-based-clock,time-based Clock]]Time-based Clock::
@@ -758,6 +763,12 @@ is activated with <<fmi3SetClock>> by the importer in <<EventMode>>, or triggers
 
 Triggered output Clock::
 is activated within the FMU and the importer must call <<fmi3GetClock>> in <<EventMode>> or in <<ClockUpdateMode>>.
+
+Triggered local Clock::
+is activated within the FMU and the importer must call <<fmi3GetClock>> in <<EventMode>> or in <<ClockUpdateMode>>.
+Only local variables can be clocked variables of local Clocks.
+Like all local variables, local Clocks must not be used as inputs to other FMUs and must not be listed in the <<ModelStructure>>.
+This clock type is not allowed in Scheduled Execution.
 
 _[<<outputClock,Output Clocks>> enable an FMU to provide a trigger to the outside world, e.g. to a <<triggered,triggered input Clock>> of another FMU._ +
 _If an FMU wants to actively trigger a model partition (Clock) of itself, it should use a <<countdown-aperiodic-clock,countdown Clock>>._

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -765,7 +765,7 @@ Triggered output Clock::
 is activated within the FMU and the importer must call <<fmi3GetClock>> in <<EventMode>> or in <<ClockUpdateMode>>.
 
 Triggered local Clock::
-is activated within the FMU and the importer must call <<fmi3GetClock>> in <<EventMode>> or in <<ClockUpdateMode>>.
+is activated within the FMU and the importer must call <<fmi3GetClock>> in <<EventMode>>.
 Only local variables can be clocked variables of local Clocks.
 Like all local variables, local Clocks must not be used as inputs to other FMUs and must not be listed in the <<ModelStructure>>.
 This clock type is not allowed in Scheduled Execution.


### PR DESCRIPTION
As agreed during today´s FMI design meeting, I created this PR to explicitly define local clocks and their restrictions.