### PR TITLE
Add full description for CS version of fmi3EnterEventMode

### DIFF
--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -162,7 +162,7 @@ If this function is never called, logging for all log categories is allowed.
 If <<loggingOn,`loggingOn = fmi3False`>>, debug logging is disabled for the log categories specified in `categories`.
 
 ** `nCategories` defines the length of the array of argument `categories`.
-If `nCategories = 0`, <<loggingOn>> applies to all log categories and the value of `categories` is undefined.
+If `nCategories = 0`, <<loggingOn>> applies to all log categories and the value of `categories` must be NULL.
 
 ** `categories` is an array of `nCategories` elements.
 The importer must only use values specified in the <<modelDescription.xml>> via element <<definition-of-log-categories,`<LogCategories>`>> as elements of argument `categories`.

--- a/docs/3_1_model_exchange_math.adoc
+++ b/docs/3_1_model_exchange_math.adoc
@@ -12,9 +12,9 @@ For <<state-event,state events>> event indicators are used.
 * handle such events in <<EventMode>>.
 * restart the integration algorithm when leaving <<EventMode>>.
 
-[[state-event,state event]]An <<fmi3GetEventIndicators,event indicator>>, and only an event indicator, signals a <<state-event>> with the change from latexmath:[\mathbf{z}_j > 0] to latexmath:[\mathbf{z}_j \leq 0] or vice versa. +
+[[state-event,state event]]An <<fmi3GetEventIndicators,event indicator>>, and only an event indicator, signals a <<state-event>> with the domain change from latexmath:[\mathbf{z}_j > 0] to latexmath:[\mathbf{z}_j \leq 0] or from latexmath:[\mathbf{z}_j \leq 0] to latexmath:[\mathbf{z}_j > 0]. +
 _[This definition is slightly different from the usual standard definition of state events:_ latexmath:[\mathbf{z}(t) \cdot \mathbf{z}(t_{i-1}) \leq 0] _which has the severe drawback that the value of the event indicator at the previous event instant,_ latexmath:[\mathbf{z}(t_{i-1}) \neq 0], _must be non-zero and this condition cannot be guaranteed._
-_The often used term "zero-crossing function" for latexmath:[\mathbf{z}] is misleading (and is therefore not used in this document), since a state event is defined by a change of a domain and not by a zero-crossing of a variable.]_
+_The often used term "zero-crossing function" for latexmath:[\mathbf{z}] is misleading (and is therefore not used in this document), since a state event is defined by a domain change and not by a zero-crossing of a variable.]_
 
 The FMU must guarantee that after leaving <<EventMode>> latexmath:[\mathbf{z}_j \neq 0], for example, by shifting latexmath:[\mathbf{z}_j] with a small value. +
 _[All event indicators should be continuous between events._

--- a/docs/3_1_model_exchange_math.adoc
+++ b/docs/3_1_model_exchange_math.adoc
@@ -12,7 +12,7 @@ For <<state-event,state events>> event indicators are used.
 * handle such events in <<EventMode>>.
 * restart the integration algorithm when leaving <<EventMode>>.
 
-[[state-event,state event]]An <<fmi3GetEventIndicators,event indicator>> signals a <<state-event>> with the change from latexmath:[\mathbf{z}_j > 0] to latexmath:[\mathbf{z}_j \leq 0] or vice versa. +
+[[state-event,state event]]An <<fmi3GetEventIndicators,event indicator>>, and only an event indicator, signals a <<state-event>> with the change from latexmath:[\mathbf{z}_j > 0] to latexmath:[\mathbf{z}_j \leq 0] or vice versa. +
 _[This definition is slightly different from the usual standard definition of state events:_ latexmath:[\mathbf{z}(t) \cdot \mathbf{z}(t_{i-1}) \leq 0] _which has the severe drawback that the value of the event indicator at the previous event instant,_ latexmath:[\mathbf{z}(t_{i-1}) \neq 0], _must be non-zero and this condition cannot be guaranteed._
 _The often used term "zero-crossing function" for latexmath:[\mathbf{z}] is misleading (and is therefore not used in this document), since a state event is defined by a change of a domain and not by a zero-crossing of a variable.]_
 

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -190,8 +190,7 @@ include::../headers/fmi3FunctionTypes.h[tags=EnterEventMode]
 +
 This function changes the state to <<EventMode>>.
 +
-The arguments `stepEvent`, `stateEvent`, and `timeEvent` enable efficient and robust event handling.
-They are of enumeration type `fmi3EventQualifier`:
+[[fmi3EventQualitfier,`fmi3EventQualifier`]]The arguments `stepEvent`, `stateEvent`, and `timeEvent` are of the enumeration type `fmi3EventQualifier`:
 +
 [source, C]
 ----
@@ -211,15 +210,15 @@ with the following meanings:
  In this case, the FMU must determine itself if this event type happens.
 --
 +
-The arguments of the function have the following meaning:
+For Model Exchange, the arguments of the function have the following meaning _[For Co-Simulation, the semantics of the arguments are <<fmi3EnterEventModeCS,different>>.]_:
 +
 --
-* Model Exchange only: `stepEvent` signals a <<step-event>>.
+* `stepEvent` signals a <<step-event>>.
 `stepEvent` must be `fmi3EventTrue` if <<fmi3CompletedIntegratorStep>> returned with `enterEventMode = fmi3True`.
 
-* `stateEvent` signals a <<state-event>>, triggered by a zero-crossing of an event indicator in Model Exchange.
+* `stateEvent` signals a <<state-event>>, `stateEvent` is triggered by a zero-crossing of an event indicator.
 
-* Model Exchange only: `rootsFound` is an array of length `nEventIndicators` that informs the FMU which event indicator has a root. +
+* `rootsFound` is an array of length `nEventIndicators` that informs the FMU which event indicator has a root. +
 For `i = 0, ... nEventIndicators-1, rootsFound[i]` informs about event indicator latexmath:[{\mathbf{z}_{\mathit{i}}}]:
 +
 ** `rootsFound[i] = 0` no root,
@@ -230,7 +229,7 @@ For `i = 0, ... nEventIndicators-1, rootsFound[i]` informs about event indicator
 If `nEventIndicators = 0` the value of `rootsFound` is not defined.
 The order in the `rootsFound` array is the same as in <<eventIndicators>> of <<fmi3GetEventIndicators>>.
 
-* Model Exchange only: `nEventIndicators` contains the current number of event indicators (see <<fmi3GetNumberOfEventIndicators>>) or `0`.
+* `nEventIndicators` contains the current number of event indicators (see <<fmi3GetNumberOfEventIndicators>>) or `0`.
 If `nEventIndicators = 0` and `stateEvent != fmi3EventFalse` the importer is unable to provide this information and the FMU must determine itself which event indicator has a zero-crossing.
 
 * [[timeEvent,`timeEvent`]]`timeEvent` signals a <<time-event>> triggered by <<nextEventTime>> of <<fmi3UpdateDiscreteStates>>.

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -218,7 +218,8 @@ For Model Exchange, the arguments of the function have the following meaning _[F
 
 * `stateEvent` signals a <<state-event>>, `stateEvent` is triggered by a domain change of an event indicator.
 
-* `eventIndicatorDomainChanges` is an array of length `nEventIndicators` that informs the FMU which event indicator has a root. +
+* `eventIndicatorDomainChanges` is an array of length `nEventIndicators` that informs the FMU which event indicator has a domain change.
+It is given in the order defined by the ordered list of XML elements <<EventIndicator>>, which is the same as in the argument <<eventIndicators>> of <<fmi3GetEventIndicators>>.
 `eventIndicatorDomainChanges` may be NULL, even if `stateEvent` equals <<fmi3EventTrue>>.
 `eventIndicatorDomainChanges` must be NULL if `stateEvent` equals either <<fmi3EventFalse>> or <<fmi3EventUnknown>>. +
 For `i = 0, ... nEventIndicators-1, eventIndicatorDomainChanges[i]` informs about event indicator latexmath:[{\mathbf{z}_{\mathit{i}}}]:
@@ -231,7 +232,6 @@ For `i = 0, ... nEventIndicators-1, eventIndicatorDomainChanges[i]` informs abou
 The importer must call <<fmi3EnterEventMode>> at a time when the signs of the event indicators signal an event according to <<localizationStateEvents>>.
 If given, the importer must ensure that `eventIndicatorDomainChanges` is consistent with the values of the event indicators. +
 If `nEventIndicators = 0` the value of `eventIndicatorDomainChanges` must be NULL.
-The order in the `eventIndicatorDomainChanges` array is the same as in <<eventIndicators>> of <<fmi3GetEventIndicators>>.
 
 * `nEventIndicators` contains the current number of event indicators (see <<fmi3GetNumberOfEventIndicators>>) or `0`.
 If `nEventIndicators = 0` and `stateEvent != fmi3EventFalse` the importer is unable to provide this information and the FMU must determine itself which event indicator has a domain change.

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -218,20 +218,20 @@ For Model Exchange, the arguments of the function have the following meaning _[F
 
 * `stateEvent` signals a <<state-event>>, `stateEvent` is triggered by a domain change of an event indicator.
 
-* `rootsFound` is an array of length `nEventIndicators` that informs the FMU which event indicator has a root. +
-`rootsFound` may be NULL, even if `stateEvent` equals <<fmi3EventTrue>>.
-`rootsFound` must be NULL if `stateEvent` equals either <<fmi3EventFalse>> or <<fmi3EventUnknown>>. +
-For `i = 0, ... nEventIndicators-1, rootsFound[i]` informs about event indicator latexmath:[{\mathbf{z}_{\mathit{i}}}]:
+* `eventIndicatorDomainChanges` is an array of length `nEventIndicators` that informs the FMU which event indicator has a root. +
+`eventIndicatorDomainChanges` may be NULL, even if `stateEvent` equals <<fmi3EventTrue>>.
+`eventIndicatorDomainChanges` must be NULL if `stateEvent` equals either <<fmi3EventFalse>> or <<fmi3EventUnknown>>. +
+For `i = 0, ... nEventIndicators-1, eventIndicatorDomainChanges[i]` informs about event indicator latexmath:[{\mathbf{z}_{\mathit{i}}}]:
 +
-** `rootsFound[i] = 0` no root,
-** `rootsFound[i] = +1` indicates the direction of the domain change from negative to positive,
-** `rootsFound[i] = -1` indicates the direction of the domain change from positive to negative.
+** `eventIndicatorDomainChanges[i] = 0` no root,
+** `eventIndicatorDomainChanges[i] = +1` indicates the direction of the domain change from negative to positive,
+** `eventIndicatorDomainChanges[i] = -1` indicates the direction of the domain change from positive to negative.
 
 +
 The importer must call <<fmi3EnterEventMode>> at a time when the signs of the event indicators signal an event according to <<localizationStateEvents>>.
-If given, the importer must ensure that `rootsFound` is consistent with the values of the event indicators. +
-If `nEventIndicators = 0` the value of `rootsFound` must be NULL.
-The order in the `rootsFound` array is the same as in <<eventIndicators>> of <<fmi3GetEventIndicators>>.
+If given, the importer must ensure that `eventIndicatorDomainChanges` is consistent with the values of the event indicators. +
+If `nEventIndicators = 0` the value of `eventIndicatorDomainChanges` must be NULL.
+The order in the `eventIndicatorDomainChanges` array is the same as in <<eventIndicators>> of <<fmi3GetEventIndicators>>.
 
 * `nEventIndicators` contains the current number of event indicators (see <<fmi3GetNumberOfEventIndicators>>) or `0`.
 If `nEventIndicators = 0` and `stateEvent != fmi3EventFalse` the importer is unable to provide this information and the FMU must determine itself which event indicator has a domain change.

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -217,7 +217,7 @@ The arguments of the function have the following meaning:
 * Model Exchange only: `stepEvent` signals a <<step-event>>.
 `stepEvent` must be `fmi3EventTrue` if <<fmi3CompletedIntegratorStep>> returned with `enterEventMode = fmi3True`.
 
-* Model Exchange only: `stateEvent` signals a <<state-event>>, triggered by a zero-crossing of an event indicator.
+* `stateEvent` signals a <<state-event>>, triggered by a zero-crossing of an event indicator in Model Exchange.
 
 * Model Exchange only: `rootsFound` is an array of length `nEventIndicators` that informs the FMU which event indicator has a root. +
 For `i = 0, ... nEventIndicators-1, rootsFound[i]` informs about event indicator latexmath:[{\mathbf{z}_{\mathit{i}}}]:

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -216,12 +216,17 @@ For Model Exchange, the arguments of the function have the following meaning _[F
 * `stepEvent` signals a <<step-event>>.
 `stepEvent` must be `fmi3EventTrue` if <<fmi3CompletedIntegratorStep>> returned with `enterEventMode = fmi3True`.
 
+* [[timeEvent,`timeEvent`]]`timeEvent` signals a <<time-event>> triggered by <<nextEventTime>> of <<fmi3UpdateDiscreteStates>>.
+
 * `stateEvent` signals a <<state-event>>, `stateEvent` is triggered by a domain change of an event indicator.
 
-* `eventIndicatorDomainChanges` is an array of length `nEventIndicators` that informs the FMU which event indicator has a domain change.
-It is given in the order defined by the ordered list of XML elements <<EventIndicator>>, which is the same as in the argument <<eventIndicators>> of <<fmi3GetEventIndicators>>.
-`eventIndicatorDomainChanges` may be NULL, even if `stateEvent` equals <<fmi3EventTrue>>.
-`eventIndicatorDomainChanges` must be NULL if `stateEvent` equals either <<fmi3EventFalse>> or <<fmi3EventUnknown>>. +
+* `nEventIndicators` is only defined if `stateEvent == fmi3EventTrue`.
+It contains the current number of event indicators (see <<fmi3GetNumberOfEventIndicators>>) or `0`.
+If `nEventIndicators = 0` the importer is unable to provide this information and the FMU must determine itself which event indicator has a domain change.
+
+* `eventIndicatorDomainChanges` is defined only if `stateEvent == fmi3EventTrue` and `nEventIndicators > 0`.
+`eventIndicatorDomainChanges` is an array of length `nEventIndicators` that informs the FMU which event indicator has a domain change.
+It is given in the order defined by the ordered list of XML elements <<EventIndicator>>, which is the same as in the argument <<eventIndicators>> of <<fmi3GetEventIndicators>>. +
 For `i = 0, ... nEventIndicators-1, eventIndicatorDomainChanges[i]` informs about event indicator latexmath:[{\mathbf{z}_{\mathit{i}}}]:
 +
 ** `eventIndicatorDomainChanges[i] = 0` no root,
@@ -233,10 +238,6 @@ The importer must call <<fmi3EnterEventMode>> at a time when the signs of the ev
 If given, the importer must ensure that `eventIndicatorDomainChanges` is consistent with the values of the event indicators. +
 If `nEventIndicators = 0` the value of `eventIndicatorDomainChanges` must be NULL.
 
-* `nEventIndicators` contains the current number of event indicators (see <<fmi3GetNumberOfEventIndicators>>) or `0`.
-If `nEventIndicators = 0` and `stateEvent != fmi3EventFalse` the importer is unable to provide this information and the FMU must determine itself which event indicator has a domain change.
-
-* [[timeEvent,`timeEvent`]]`timeEvent` signals a <<time-event>> triggered by <<nextEventTime>> of <<fmi3UpdateDiscreteStates>>.
 --
 +
 _[An <<input-event>> can be detected by the FMU by keeping track of the calls of <<get-and-set-variable-values,`fmi3Set{VariableType}`>> in <<EventMode>>._ +

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -216,21 +216,25 @@ For Model Exchange, the arguments of the function have the following meaning _[F
 * `stepEvent` signals a <<step-event>>.
 `stepEvent` must be `fmi3EventTrue` if <<fmi3CompletedIntegratorStep>> returned with `enterEventMode = fmi3True`.
 
-* `stateEvent` signals a <<state-event>>, `stateEvent` is triggered by a zero-crossing of an event indicator.
+* `stateEvent` signals a <<state-event>>, `stateEvent` is triggered by a domain change of an event indicator.
 
 * `rootsFound` is an array of length `nEventIndicators` that informs the FMU which event indicator has a root. +
+`rootsFound` may be NULL, even if `stateEvent` equals <<fmi3EventTrue>>.
+`rootsFound` must be NULL if `stateEvent` equals either <<fmi3EventFalse>> or <<fmi3EventUnknown>>. +
 For `i = 0, ... nEventIndicators-1, rootsFound[i]` informs about event indicator latexmath:[{\mathbf{z}_{\mathit{i}}}]:
 +
 ** `rootsFound[i] = 0` no root,
-** `rootsFound[i] = +1` indicates the direction of the zero-crossing from negative to positive,
-** `rootsFound[i] = -1` indicates the direction of the zero-crossing from positive to negative.
+** `rootsFound[i] = +1` indicates the direction of the domain change from negative to positive,
+** `rootsFound[i] = -1` indicates the direction of the domain change from positive to negative.
 
 +
-If `nEventIndicators = 0` the value of `rootsFound` is not defined.
+The importer must call <<fmi3EnterEventMode>> at a time when the signs of the event indicators signal an event according to <<localizationStateEvents>>.
+If given, the importer must ensure that `rootsFound` is consistent with the values of the event indicators. +
+If `nEventIndicators = 0` the value of `rootsFound` must be NULL.
 The order in the `rootsFound` array is the same as in <<eventIndicators>> of <<fmi3GetEventIndicators>>.
 
 * `nEventIndicators` contains the current number of event indicators (see <<fmi3GetNumberOfEventIndicators>>) or `0`.
-If `nEventIndicators = 0` and `stateEvent != fmi3EventFalse` the importer is unable to provide this information and the FMU must determine itself which event indicator has a zero-crossing.
+If `nEventIndicators = 0` and `stateEvent != fmi3EventFalse` the importer is unable to provide this information and the FMU must determine itself which event indicator has a domain change.
 
 * [[timeEvent,`timeEvent`]]`timeEvent` signals a <<time-event>> triggered by <<nextEventTime>> of <<fmi3UpdateDiscreteStates>>.
 --

--- a/docs/4_2_co-simulation_api.adoc
+++ b/docs/4_2_co-simulation_api.adoc
@@ -136,45 +136,20 @@ include::../headers/fmi3FunctionTypes.h[tags=EnterEventMode]
 ----
 +
 This function changes the state to <<EventMode>>.
++
 This function must not be called, if <<fmi3InstantiateCoSimulation>> signaled <<eventModeUsed,`eventModeUsed = fmi3False`>>, which can be forced by the FMU with <<hasEventMode,`hasEventMode = false`>>. +
 +
-The arguments `stepEvent`, `stateEvent`, and `timeEvent` enable efficient and robust event handling.
-They are of enumeration type `fmi3EventQualifier`:
+For Co-Simulation, the argument `stepEvent` is not used and must have the value <<fmi3EventUnknown>>; `nEventIndicators` must always be 0 and the value of `rootsFound` must be NULL.
 +
-[source, C]
-----
-include::../headers/fmi3FunctionTypes.h[tags=EventQualifier]
-----
-with the following meanings:
+For Co-Simulation, the other arguments of the function have the following meaning:
 +
---
- * `fmi3EventTrue` indicates that the given event type happens.
-
- * `fmi3EventFalse` indicates that the given event type does not happen.
-
- * `fmi3EventUnknown` indicates that the importer is unable to provide this information about this event type.
- In this case, the FMU must determine itself if this event type happens.
---
-+
-The arguments of the function have the following meaning for Co-Simulation:
-+
---
-* Model Exchange only: `stepEvent` signals a <<step-event>>.
-For Co-Simulation, this argument must be `fmi3EventUnknown`.
-
 * `stateEvent` signals a <<state-event>>, triggered in Co-Simulation by <<fmi3DoStep>> returning  with <<eventHandlingNeeded,`eventHandlingNeeded = fmi3True`>>.
 
-* Model Exchange only: `rootsFound` is an array of length `nEventIndicators` that informs the FMU which event indicator has a root.
-+
-If `nEventIndicators = 0`, as required for Co-Simulation, the value of `rootsFound` is not defined.
-
-* Model Exchange only: `nEventIndicators` contains the current number of event indicators (see <<fmi3GetNumberOfEventIndicators>>) or `0`.
-For Co-Simulation the value must be `0`.
-
 * `timeEvent` signals a <<time-event>> triggered by <<nextEventTime>> of <<fmi3UpdateDiscreteStates>>.
---
+
 +
-_[An <<input-event>> can be detected by the FMU by keeping track of the calls of <<get-and-set-variable-values,`fmi3Set{VariableType}`>> in <<EventMode>>.]_
+_[An <<input-event>> can be detected by the FMU by keeping track of the calls of <<get-and-set-variable-values,`fmi3Set{VariableType}`>> in <<EventMode>>.]_ +
+_[For Model Exchange, the semantics of the arguments are <<fmi3EnterEventMode,different>>.]_
 
 Function <<fmi3EnterConfigurationMode>>::
 <<fmi3EnterConfigurationMode>> changes state to <<ReconfigurationMode>>.

--- a/docs/4_2_co-simulation_api.adoc
+++ b/docs/4_2_co-simulation_api.adoc
@@ -139,17 +139,22 @@ This function changes the state to <<EventMode>>.
 +
 This function must not be called, if <<fmi3InstantiateCoSimulation>> signaled <<eventModeUsed,`eventModeUsed = fmi3False`>>, which can be forced by the FMU with <<hasEventMode,`hasEventMode = false`>>. +
 +
-For Co-Simulation, the argument `stepEvent` is not used and must have the value <<fmi3EventUnknown>>; `nEventIndicators` must always be 0 and the value of `eventIndicatorDomainChanges` must be NULL.
+The arguments `stepEvent`, `stateEvent`, and `timeEvent` are of the enumeration type <<fmi3EventQualitfier>>.
 +
-For Co-Simulation, the other arguments of the function have the following meaning:
-+
-* `stateEvent` signals a <<state-event>>, triggered in Co-Simulation by <<fmi3DoStep>> returning  with <<eventHandlingNeeded,`eventHandlingNeeded = fmi3True`>>.
+For Co-Simulation, the arguments of the function have the following meaning _[For Model Exchange, the semantics of the arguments are <<fmi3EnterEventMode,different>>.]_:
+
+* The value of argument `stepEvent` must be <<fmi3EventFalse>>.
 
 * `timeEvent` signals a <<time-event>> triggered by <<nextEventTime>> of <<fmi3UpdateDiscreteStates>>.
 
+* `stateEvent` signals a <<state-event>>, triggered in Co-Simulation by <<fmi3DoStep>> returning  with <<eventHandlingNeeded,`eventHandlingNeeded = fmi3True`>>.
+
+* The value of `nEventIndicators` must always be 0.
+
+* The value of `eventIndicatorDomainChanges` must be NULL.
+
 +
-_[An <<input-event>> can be detected by the FMU by keeping track of the calls of <<get-and-set-variable-values,`fmi3Set{VariableType}`>> in <<EventMode>>.]_ +
-_[For Model Exchange, the semantics of the arguments are <<fmi3EnterEventMode,different>>.]_
+_[An <<input-event>> can be detected by the FMU by keeping track of the calls of <<get-and-set-variable-values,`fmi3Set{VariableType}`>> in <<EventMode>>.]_
 
 Function <<fmi3EnterConfigurationMode>>::
 <<fmi3EnterConfigurationMode>> changes state to <<ReconfigurationMode>>.

--- a/docs/4_2_co-simulation_api.adoc
+++ b/docs/4_2_co-simulation_api.adoc
@@ -129,8 +129,52 @@ Function <<fmi3IntermediateUpdateCallback>>::
 
 [[fmi3EnterEventModeCS,`fmi3EnterEventMode`]]
 Function <<fmi3EnterEventMode>>::
-Changes state to <<EventMode>>.
++
+[source, C]
+----
+include::../headers/fmi3FunctionTypes.h[tags=EnterEventMode]
+----
++
+This function changes the state to <<EventMode>>.
 This function must not be called, if <<fmi3InstantiateCoSimulation>> signaled <<eventModeUsed,`eventModeUsed = fmi3False`>>, which can be forced by the FMU with <<hasEventMode,`hasEventMode = false`>>. +
++
+The arguments `stepEvent`, `stateEvent`, and `timeEvent` enable efficient and robust event handling.
+They are of enumeration type `fmi3EventQualifier`:
++
+[source, C]
+----
+include::../headers/fmi3FunctionTypes.h[tags=EventQualifier]
+----
+with the following meanings:
++
+--
+ * `fmi3EventTrue` indicates that the given event type happens.
+
+ * `fmi3EventFalse` indicates that the given event type does not happen.
+
+ * `fmi3EventUnknown` indicates that the importer is unable to provide this information about this event type.
+ In this case, the FMU must determine itself if this event type happens.
+--
++
+The arguments of the function have the following meaning for Co-Simulation:
++
+--
+* Model Exchange only: `stepEvent` signals a <<step-event>>.
+For Co-Simulation, this argument must be `fmi3EventUnknown`.
+
+* `stateEvent` signals a <<state-event>>, triggered in Co-Simulation by <<fmi3DoStep>> returning  with <<eventHandlingNeeded,`eventHandlingNeeded = fmi3True`>>.
+
+* Model Exchange only: `rootsFound` is an array of length `nEventIndicators` that informs the FMU which event indicator has a root.
++
+If `nEventIndicators = 0`, as required for Co-Simulation, the value of `rootsFound` is not defined.
+
+* Model Exchange only: `nEventIndicators` contains the current number of event indicators (see <<fmi3GetNumberOfEventIndicators>>) or `0`.
+For Co-Simulation the value must be `0`.
+
+* `timeEvent` signals a <<time-event>> triggered by <<nextEventTime>> of <<fmi3UpdateDiscreteStates>>.
+--
++
+_[An <<input-event>> can be detected by the FMU by keeping track of the calls of <<get-and-set-variable-values,`fmi3Set{VariableType}`>> in <<EventMode>>.]_
 
 Function <<fmi3EnterConfigurationMode>>::
 <<fmi3EnterConfigurationMode>> changes state to <<ReconfigurationMode>>.

--- a/docs/4_2_co-simulation_api.adoc
+++ b/docs/4_2_co-simulation_api.adoc
@@ -139,7 +139,7 @@ This function changes the state to <<EventMode>>.
 +
 This function must not be called, if <<fmi3InstantiateCoSimulation>> signaled <<eventModeUsed,`eventModeUsed = fmi3False`>>, which can be forced by the FMU with <<hasEventMode,`hasEventMode = false`>>. +
 +
-For Co-Simulation, the argument `stepEvent` is not used and must have the value <<fmi3EventUnknown>>; `nEventIndicators` must always be 0 and the value of `rootsFound` must be NULL.
+For Co-Simulation, the argument `stepEvent` is not used and must have the value <<fmi3EventUnknown>>; `nEventIndicators` must always be 0 and the value of `eventIndicatorDomainChanges` must be NULL.
 +
 For Co-Simulation, the other arguments of the function have the following meaning:
 +

--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -40,6 +40,11 @@ Synonyms: dynamic mutual-exchange, simulator coupling, and coupled simulation.
 |_direct feedthrough_
 |Direct feedthrough describes that values of output variables depend directly on values of input variables.
 
+|_domain change_
+|Used instead of zero-crossing.
+Indicates the change of an event indicator from the domain latexmath:[\mathbf{z}_j > 0] to the domain latexmath:[\mathbf{z}_j \leq 0] or from latexmath:[\mathbf{z}_j \leq 0] to latexmath:[\mathbf{z}_j > 0].
+See <<localizationStateEvents>>.
+
 |[[dynamic-state-selection,dynamic state selection]]_dynamic state selection_
 |Dynamic State Selection is a method to solve differential algebraic equations (DAEs).
 The FMU checks whether the dynamically selected states are still numerically appropriate.

--- a/headers/fmi3FunctionTypes.h
+++ b/headers/fmi3FunctionTypes.h
@@ -193,7 +193,7 @@ typedef fmi3Status fmi3ExitInitializationModeTYPE(fmi3Instance instance);
 typedef fmi3Status fmi3EnterEventModeTYPE(fmi3Instance instance,
                                           fmi3EventQualifier stepEvent,
                                           fmi3EventQualifier stateEvent,
-                                          const fmi3Int32 rootsFound[],
+                                          const fmi3Int32 eventIndicatorDomainChanges[],
                                           size_t nEventIndicators,
                                           fmi3EventQualifier timeEvent);
 /* end::EnterEventMode[] */


### PR DESCRIPTION
This should clarify and correct the presentation of fmi3EnterEventMode for CS.

It narrows down the allowable values for unused arguments, and corrects errors in both descriptions with regards to CS use.