### PR TITLE
Spell out that it's the FMU that should add a hysteresis

### DIFF
--- a/docs/3_1_model_exchange_math.adoc
+++ b/docs/3_1_model_exchange_math.adoc
@@ -56,4 +56,4 @@ y = (r1 || r2) ? +1 : -1;
 ----
 
 _Therefore, the original if-clause is evaluated in this form only during <<InitializationMode>> and <<EventMode>>._
-_A hysteresis should be added for the event indicators to stabilize the event localization.]_
+_A hysteresis should be added, in the FMU, for the event indicators to stabilize the event localization.]_


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Checklist

* [ x] Used a [personal fork](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo) of the repository to propose changes.
* [ ] [Built the specification](https://github.com/modelica/fmi-standard/blob/master/CONTRIBUTING.adoc#building-the-specification-document).
* [ x] [Linted the documents](https://github.com/modelica/fmi-standard/blob/master/CONTRIBUTING.adoc#building-the-specification-document).

As I mentioned in #1739 I think we should really make it clear that it's the FMU that should add the hysteresis and not the importing tool.
