### PR TITLE
Modify sentence of when time event should be handled

### DIFF
--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -652,7 +652,7 @@ This argument is only valid in Model Exchange.
 [[nextEventTime,`nextEventTime`]]
 * The return argument <<nextEventTime>> contains the absolute time of the next time event latexmath:[T_{\mathit{next}}] if <<nextEventTimeDefined,`nextEventTimeDefined = fmi3True`>>.
 The importer must compute up to <<nextEventTime>> (or if needed slightly further) and then enter <<EventMode>> using <<fmi3EnterEventMode>>.
-The FMU must handle this time event during the event mode that is entered in by first call to <<fmi3EnterEventMode>>, at or after <<nextEventTime>>. +
+The FMU must handle this time event during the event mode that is entered in by the first call to <<fmi3EnterEventMode>>, at or after <<nextEventTime>>. +
 _[This might be needed if, for example, the time resolution of the importer does not allow hitting the precise <<nextEventTime>>._
 _If the time offset proves to be too large, the FMU could issue a log message and return fmi3Error._
 _The user can improve time settings of the importer to alleviate the issues.]_ +

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -652,7 +652,7 @@ This argument is only valid in Model Exchange.
 [[nextEventTime,`nextEventTime`]]
 * The return argument <<nextEventTime>> contains the absolute time of the next time event latexmath:[T_{\mathit{next}}] if <<nextEventTimeDefined,`nextEventTimeDefined = fmi3True`>>.
 The importer must compute up to <<nextEventTime>> (or if needed slightly further) and then enter <<EventMode>> using <<fmi3EnterEventMode>>.
-The FMU must handle this time event during the event mode that is entered in by the first call to <<fmi3EnterEventMode>>, at or after <<nextEventTime>>. +
+The FMU must handle this time event during the event mode that is entered by the first call to <<fmi3EnterEventMode>>, at or after <<nextEventTime>>. +
 _[This might be needed if, for example, the time resolution of the importer does not allow hitting the precise <<nextEventTime>>._
 _If the time offset proves to be too large, the FMU could issue a log message and return fmi3Error._
 _The user can improve time settings of the importer to alleviate the issues.]_ +

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -652,7 +652,7 @@ This argument is only valid in Model Exchange.
 [[nextEventTime,`nextEventTime`]]
 * The return argument <<nextEventTime>> contains the absolute time of the next time event latexmath:[T_{\mathit{next}}] if <<nextEventTimeDefined,`nextEventTimeDefined = fmi3True`>>.
 The importer must compute up to <<nextEventTime>> (or if needed slightly further) and then enter <<EventMode>> using <<fmi3EnterEventMode>>.
-The FMU must handle this time event at the first call to <<fmi3EnterEventMode>> at or after <<nextEventTime>>. +
+The FMU must handle this time event during the event mode that is entered in by first call to <<fmi3EnterEventMode>>, at or after <<nextEventTime>>. +
 _[This might be needed if, for example, the time resolution of the importer does not allow hitting the precise <<nextEventTime>>._
 _If the time offset proves to be too large, the FMU could issue a log message and return fmi3Error._
 _The user can improve time settings of the importer to alleviate the issues.]_ +

--- a/docs/2_3_common_states.adoc
+++ b/docs/2_3_common_states.adoc
@@ -652,9 +652,9 @@ This argument is only valid in Model Exchange.
 [[nextEventTime,`nextEventTime`]]
 * The return argument <<nextEventTime>> contains the absolute time of the next time event latexmath:[T_{\mathit{next}}] if <<nextEventTimeDefined,`nextEventTimeDefined = fmi3True`>>.
 The importer must compute up to <<nextEventTime>> (or if needed slightly further) and then enter <<EventMode>> using <<fmi3EnterEventMode>>.
-The FMU must handle this time event during the event mode that is entered by the first call to <<fmi3EnterEventMode>>, at or after <<nextEventTime>>. +
+The FMU must handle this time event during the <<EventMode>> that is entered by the first call to <<fmi3EnterEventMode>>, at or after <<nextEventTime>>. +
 _[This might be needed if, for example, the time resolution of the importer does not allow hitting the precise <<nextEventTime>>._
-_If the time offset proves to be too large, the FMU could issue a log message and return fmi3Error._
+_If the time offset proves to be too large, the FMU could issue a log message and return <<fmi3Error>>._
 _The user can improve time settings of the importer to alleviate the issues.]_ +
 If another (e.g. <<state event>>) event happens before that <<nextEventTime>>, the previous definition of <<nextEventTime>> becomes obsolete.
 


### PR DESCRIPTION
Stated at function enterEventMode, should be event that is entered in call to enterEventMode

see
https://github.com/modelica/fmi-standard/pull/1744#discussion_r856142585