### PR TITLE
Fix contrib

### DIFF
--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -284,7 +284,7 @@ The FMI 3.0 standard text is based on FMI 2.0 and FMI 1.0 and we wish to acknowl
 Special thanks to
 
 * Andreas Junghanns (Synopsys) and Torsten Sommer (Dassault Syst&#232;mes) for the initial conversion of the FMI 2.0 Word document to AsciiDoc
-* Torsten Sommer (Dassault Syst&#232;mes) for the creation of the reference FMUs and the github CI tool chain
+* Torsten Sommer (Dassault Syst&#232;mes) for the creation of the Reference FMUs and the Continuous Integration pipeline
 * Cl&#225;udio Gomes (Aarhus University) for the creation of the tooling to create the graphical representation of the XML schemas
 * Andreas Junghanns (Synopsys) and Torsten Blochwitz (ESI Group) for restructuring and re-writing the whole FMI standard text
 * all companies and organizations that participated in the FMI 3.0 Plugfests:
@@ -292,8 +292,8 @@ Special thanks to
 ** Altair with Activate
 ** Augsburg University with FMI.jl
 ** AVL List GmbH with Model.CONNECT(TM)
-** Dassault Syst&#232;mes with Dymola, FMPy, FMI-Kit
-** dSPACE GmbH with TargetLink, SystemDesk, ConfigurationDesk and VEOS
+** Dassault Syst&#232;mes with Dymola, FMPy, and FMI Kit for Simulink
+** dSPACE GmbH with TargetLink, SystemDesk, ConfigurationDesk, and VEOS
 ** ESI Group with SimulationX
 ** ETAS GmbH with COSYM
 ** Julia Computing with JuliaSim
@@ -302,7 +302,6 @@ Special thanks to
 ** PMSF IT Consulting with FMI Bench
 ** Synopsys with Silver
 ** TLK-Thermo GmbH
-
 
 The essential parts of the design of this version were developed by (alphabetical list)
 
@@ -320,7 +319,7 @@ The essential parts of the design of this version were developed by (alphabetica
 - Karl Wernersson, Dassault Syst&#232;mes, Sweden
 - Irina Zacharias, dSPACE GmbH, Germany
 
-Additionally the following partners participated at FMI 3.0 design meetings and contributed to the discussion (alphabetical list)
+Additionally the following partners participated in FMI design meetings and contributed to the discussion (alphabetical list)
 
 - Nick Battle, United Kingdom
 - Martin Benedikt, Virtual Vehicle, Austria

--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -322,7 +322,7 @@ Additionally the following partners participated at FMI 3.0 design meetings and 
 - Kaska Kowalalska, Maplesoft, Canada
 - Gunter Lantzsch, ESI Group, Germany
 - Timo Penndorf, ETAS GmbH, Germany
-- Tim Schenk, Siemens AG, Germnay
+- Tim Schenk, Siemens AG, Germanmy
 - Patrick T&#228;uber, dSPACE GmbH, Germany
 - Adrian Tirea, Synopsys, Romania
 - Otto Tronarp, Wolfram MathCore, Sweden

--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -291,7 +291,7 @@ Special thanks to
 ** Aarhus University with VDMCheck
 ** Altair with Activate
 ** Augsburg University with FMI.jl
-** AVL List GmbH with ModelConnect
+** AVL List GmbH with Model.CONNECT(TM)
 ** Dassault Syst&#232;mes with Dymola, FMPy, FMI-Kit
 ** dSPACE GmbH with TargetLink, SystemDesk, ConfigurationDesk and VEOS
 ** ESI Group with SimulationX

--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -293,7 +293,7 @@ Special thanks to
 ** Augsburg University with FMI.jl
 ** AVL List GmbH with ModelConnect
 ** Dassault Syst&#232;mes with Dymola, FMPy, FMI-Kit
-** dSPACE GmbH with TargetLink, SystemDesk, Veos
+** dSPACE GmbH with TargetLink, SystemDesk, ConfigurationDesk and VEOS
 ** ESI Group with SimulationX
 ** ETAS GmbH with COSYM
 ** Julia Computing with JuliaSim

--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -300,7 +300,7 @@ Special thanks to
 ** Maplesoft with MapleSIM
 ** OSMC
 ** PMSF IT Consulting with FMI Bench
-** Synopsys with with Silver
+** Synopsys with Silver
 ** TLK-Thermo GmbH
 
 

--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -283,11 +283,25 @@ The FMI 3.0 standard text is based on FMI 2.0 and FMI 1.0 and we wish to acknowl
 
 Special thanks to
 
-- Andreas Junghanns (Synopsys) and Torsten Sommer (Dassault Syst&#232;mes) for the initial conversion of the FMI 2.0 Word document to AsciiDoc
-- Torsten Sommer (Dassault Syst&#232;mes) for the creation of the reference FMUs and the github CI tool chain
-- Cl&#225;udio Gomes (Aarhus University) for the creation of the tooling to create the graphical representation of the XML schemas
-- Andreas Junghanns (Synopsys) and Torsten Blochwitz (ESI Group) for restructuring and re-writing the whole FMI standard text
-- all companies and organizations that participated in the FMI 3.0 Plugfests: Aarhus University, Altair, Augsburg University, AVL List GmbH, Dassault Syst&#232;mes, dSPACE GmbH, ESI Group, ETAS GmbH, Julia Computing, Maplesoft, OSMC, PMSF IT Consulting, Synopsys, TLK-Thermo GmbH
+* Andreas Junghanns (Synopsys) and Torsten Sommer (Dassault Syst&#232;mes) for the initial conversion of the FMI 2.0 Word document to AsciiDoc
+* Torsten Sommer (Dassault Syst&#232;mes) for the creation of the reference FMUs and the github CI tool chain
+* Cl&#225;udio Gomes (Aarhus University) for the creation of the tooling to create the graphical representation of the XML schemas
+* Andreas Junghanns (Synopsys) and Torsten Blochwitz (ESI Group) for restructuring and re-writing the whole FMI standard text
+* all companies and organizations that participated in the FMI 3.0 Plugfests: 
+** Aarhus University
+** Altair with Acitvate
+** Augsburg University with FMI.jl
+** AVL List GmbH with ModelConnect
+** Dassault Syst&#232;mes with Dymola, FMPy, FMI-Kit
+** dSPACE GmbH with TargetLink, SystemDesk, Veos
+** ESI Group with SimulationX
+** ETAS GmbH with COSYM
+** Julia Computing with JuliaSim
+** Maplesoft with MapleSIM
+** OSMC 
+** PMSF IT Consulting with FMI Bench
+** Synopsys with with Silver
+** TLK-Thermo GmbH
 
 
 The essential parts of the design of this version were developed by (alphabetical list)

--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -287,7 +287,7 @@ Special thanks to
 * Torsten Sommer (Dassault Syst&#232;mes) for the creation of the reference FMUs and the github CI tool chain
 * Cl&#225;udio Gomes (Aarhus University) for the creation of the tooling to create the graphical representation of the XML schemas
 * Andreas Junghanns (Synopsys) and Torsten Blochwitz (ESI Group) for restructuring and re-writing the whole FMI standard text
-* all companies and organizations that participated in the FMI 3.0 Plugfests: 
+* all companies and organizations that participated in the FMI 3.0 Plugfests:
 ** Aarhus University
 ** Altair with Acitvate
 ** Augsburg University with FMI.jl
@@ -298,7 +298,7 @@ Special thanks to
 ** ETAS GmbH with COSYM
 ** Julia Computing with JuliaSim
 ** Maplesoft with MapleSIM
-** OSMC 
+** OSMC
 ** PMSF IT Consulting with FMI Bench
 ** Synopsys with with Silver
 ** TLK-Thermo GmbH

--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -287,7 +287,7 @@ Special thanks to
 - Torsten Sommer (Dassault Syst&#232;mes) for the creation of the reference FMUs and the github CI tool chain
 - Cl&#225;udio Gomes (Aarhus University) for the creation of the tooling to create the graphical representation of the XML schemas
 - Andreas Junghanns (Synopsys) and Torsten Blochwitz (ESI Group) for restructuring and re-writing the whole FMI standard text
-- all companies and organizations that participated in the FMI 3.0 Plugfests: Aarhus University, Altair, Augsburg University, AVL, Dassault Syst&#232;mes, dSPACE, ESI Group, ETAS, Julia Computing, Maplesoft, OSMC, PMSF IT Consulting, Synopsys, TLK
+- all companies and organizations that participated in the FMI 3.0 Plugfests: Aarhus University, Altair, Augsburg University, AVL List GmbH, Dassault Syst&#232;mes, dSPACE GmbH, ESI Group, ETAS GmbH, Julia Computing, Maplesoft, OSMC, PMSF IT Consulting, Synopsys, TLK-Thermo GmbH
 
 
 The essential parts of the design of this version were developed by (alphabetical list)

--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -288,7 +288,7 @@ Special thanks to
 * Cl&#225;udio Gomes (Aarhus University) for the creation of the tooling to create the graphical representation of the XML schemas
 * Andreas Junghanns (Synopsys) and Torsten Blochwitz (ESI Group) for restructuring and re-writing the whole FMI standard text
 * all companies and organizations that participated in the FMI 3.0 Plugfests:
-** Aarhus University
+** Aarhus University with VDMCheck
 ** Altair with Activate
 ** Augsburg University with FMI.jl
 ** AVL List GmbH with ModelConnect

--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -336,7 +336,7 @@ Additionally the following partners participated at FMI 3.0 design meetings and 
 - Kaska Kowalalska, Maplesoft, Canada
 - Gunter Lantzsch, ESI Group, Germany
 - Timo Penndorf, ETAS GmbH, Germany
-- Tim Schenk, Siemens AG, Germanmy
+- Tim Schenk, Siemens AG, Germany
 - Patrick T&#228;uber, dSPACE GmbH, Germany
 - Adrian Tirea, Synopsys, Romania
 - Otto Tronarp, Wolfram MathCore, Sweden

--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -289,7 +289,7 @@ Special thanks to
 * Andreas Junghanns (Synopsys) and Torsten Blochwitz (ESI Group) for restructuring and re-writing the whole FMI standard text
 * all companies and organizations that participated in the FMI 3.0 Plugfests:
 ** Aarhus University
-** Altair with Acitvate
+** Altair with Activate
 ** Augsburg University with FMI.jl
 ** AVL List GmbH with ModelConnect
 ** Dassault Syst&#232;mes with Dymola, FMPy, FMI-Kit


### PR DESCRIPTION
resolves #1758  (tools participating in XC): Please check

Fix Comments by @MBlesken  in https://github.com/modelica/fmi-standard/issues/1737#issuecomment-1108361917 .
@MBlesken : "Maybe separate country followed by next name by more than just a blank": I do not find this. Wasn't this fixed already? Or could you please create a PR?
Company names are still not uniform (with or w/o "GmbH")