### PR TITLE
Fix sorting and update former affiliation

### DIFF
--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -323,8 +323,8 @@ Additionally the following partners participated in FMI design meetings and cont
 
 - Nick Battle, United Kingdom
 - Martin Benedikt, Virtual Vehicle, Austria
-- Thomas Beutlich, TraceTronic GmbH, Germany
 - Jorge Bernal-Romero, ITK-Engineering, Germany
+- Thomas Beutlich, previously at ESI Group, Germany
 - Robert Braun, Link&#246;ping University, Sweden
 - Paul Filip, Synopsys, Romania
 - R&#252;diger Franke, ABB AG, Germany
@@ -337,7 +337,7 @@ Additionally the following partners participated in FMI design meetings and cont
 - Timo Penndorf, ETAS GmbH, Germany
 - Tim Schenk, Siemens AG, Germany
 - Patrick T&#228;uber, dSPACE GmbH, Germany
+- Jean-Philipp Tavella, EDF, France
 - Adrian Tirea, Synopsys, Romania
 - Otto Tronarp, Wolfram MathCore, Sweden
-- Jean-Philipp Tavella, EDF, France
 - Antoine Viel, Siemens PLM, France


### PR DESCRIPTION
I'd prefer to remove my former affiliation "TraceTronic GmbH" since neither TraceTronic as company nor myself was engaged at FMI design meetings when I was with TraceTronic. Better to have it as "previously at ESI Group", which holds for all (future) times.
See also https://doc.modelica.org/Modelica%204.0.0/Resources/helpDymola/Modelica_UsersGuide.html#Modelica.UsersGuide.Contact (for the (former) contributors of MSL).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Checklist

* [ ] Used a [personal fork](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo) of the repository to propose changes. Sorry, I did not when editing directly in GitHub.
* [ ] [Built the specification](https://github.com/modelica/fmi-standard/blob/master/CONTRIBUTING.adoc#building-the-specification-document).
* [ ] [Re-generated schema figures](https://github.com/modelica/fmi-standard/blob/master/CONTRIBUTING.adoc#changing-the-xsd-schemas).
* [ ] [Linted the documents](https://github.com/modelica/fmi-standard/blob/master/CONTRIBUTING.adoc#building-the-specification-document).

Fix for #1757.