### PR TITLE
Use FMI 3.0 platform tuples

### DIFF
--- a/docs/2_3_fmu_distribution.adoc
+++ b/docs/2_3_fmu_distribution.adoc
@@ -59,6 +59,9 @@ binaries                     // Optional directory containing the binaries win32
      ...
   linux64    // Optional binaries for 64-bit Linux
      ...
+  aarch64-darwin  // Optional binaries for macOS on Apple Silicon
+     <modelIdentifier>.dylib
+     ...
   < If an FMU is run through one of its binaries all items in that binary folder is recommended to be unpacked at the same location as the binary < modelIdentifier >.* is unpacked.
    If not it's likely that, if the FMU has dependencies on those items, it will not be able to find them and run >
 resources    // Optional resources needed by the FMU
@@ -81,7 +84,8 @@ The FMU must be distributed with [underline]#at least# one implementation,
 in other words, either [underline]#sources# or one of the [underline]#binaries# for a particular machine.
 It is also possible to provide the sources and binaries for different target machines together in one ZIP file.
 The following names are standardized: for Windows: "win32",
-"win64"- for Linux: "linux32", "linux64", for Macintosh: "darwin32", "darwin64".
+"win64"- for Linux: "linux32", "linux64", for Macintosh: "darwin32", "darwin64" where "32" stands for "32-bit x86" and "64" for "64-bit x86" respectively.
+For any other platforms the "platform tuples" defined in the FMI 3.0 Specification, 2.5.1.4.1. Platform Tuple Definition, should be used.
 Furthermore, also the names "VisualStudioX" and "gccX" are standardized and define
 the compiler with which the binary has been generated _[, for example, VisualStudio8]_.
 Further names can be introduced by vendors.

--- a/docs/2_3_fmu_distribution.adoc
+++ b/docs/2_3_fmu_distribution.adoc
@@ -85,7 +85,7 @@ in other words, either [underline]#sources# or one of the [underline]#binaries# 
 It is also possible to provide the sources and binaries for different target machines together in one ZIP file.
 The following names are standardized: for Windows: "win32",
 "win64"- for Linux: "linux32", "linux64", for Macintosh: "darwin32", "darwin64" where "32" stands for "32-bit x86" and "64" for "64-bit x86" respectively.
-For any other platforms the "platform tuples" defined in the FMI 3.0 Specification, 2.5.1.4.1. Platform Tuple Definition, should be used.
+For any other platforms the "platform tuples" defined in the FMI 3.0 Specification, 2.5.1.4.1. Platform Tuple Definition, or any updated "platform tuples" published by MAP FMI on fmi-standard.org, should be used.
 Furthermore, also the names "VisualStudioX" and "gccX" are standardized and define
 the compiler with which the binary has been generated _[, for example, VisualStudio8]_.
 Further names can be introduced by vendors.


### PR DESCRIPTION
for platforms other than {darwin|linux|win}{32|64}

fixes #1764