### PR TITLE
Explain matching of terminals with structured naming convention arrays in 2.0.4

### DIFF
--- a/docs/2_3_fmu_distribution.adoc
+++ b/docs/2_3_fmu_distribution.adoc
@@ -208,3 +208,6 @@ _[New in FMI 2.0.4:]_
 ==== Terminals and Icons
 
 The optional directory `terminalsAndIcons` contains the definition of the Ports and Icons of the FMU as defined in the FMI 3.0 Specification, 2.4.9. Terminals and Icons.
+
+Please note that "matching" terminal variables includes matching of scalarized variables "based on structured naming convention" of with FMI 3.0 array variables.
+This will be explained in more detail in maintenance releases of FMI 3.0 and the FMI 3.0 implementer's guide (https://modelica.github.io/fmi-guides/main/fmi-guide/)

--- a/docs/2_3_fmu_distribution.adoc
+++ b/docs/2_3_fmu_distribution.adoc
@@ -209,5 +209,5 @@ _[New in FMI 2.0.4:]_
 
 The optional directory `terminalsAndIcons` contains the definition of the Ports and Icons of the FMU as defined in the FMI 3.0 Specification, 2.4.9. Terminals and Icons.
 
-Please note that "matching" terminal variables includes matching of scalarized variables "based on structured naming convention" of with FMI 3.0 array variables.
+Please note that "matching" terminal variables includes matching of scalarized variables "based on structured naming convention" with FMI 3.0 array variables.
 This will be explained in more detail in maintenance releases of FMI 3.0 and the FMI 3.0 implementer's guide (https://modelica.github.io/fmi-guides/main/fmi-guide/)


### PR DESCRIPTION
As it is proposed to explain the matching in more detail in FMI 3.0 (https://github.com/modelica/fmi-standard/pull/1808) and the IG, this consist mainly of a reference to these two places to avoid redundancies.
Please comment or create an alternative PR if you have a better suggestion.