### PR TITLE
Bugfix: dissalow output derivatives in SE

### DIFF
--- a/docs/2_1_common_math.adoc
+++ b/docs/2_1_common_math.adoc
@@ -161,7 +161,7 @@ latexmath:[\mathbf{y}^{(j)}]
 |Output variables.
 The values of these variables are computed in the FMU and they are designed to be used outside the FMU.
 Variables of this type are defined with attribute <<causality>> = <<output>>.
-For CS and SE: Also j-th derivatives latexmath:[\mathbf{y}^{(j)}(t_{i+1})] can be provided if supported by the FMU.
+For CS: Also j-th derivatives latexmath:[\mathbf{y}^{(j)}(t_{i+1})] can be provided if supported by the FMU.
 A subset of outputs is selected via a <<table-subscripts,subscript>>.
 
 |latexmath:[\mathbf{w}]


### PR DESCRIPTION
resolves #1830 

as it was intentinally disallowed in FMI 3.0 to get output derivatives in SE, see e.g. https://github.com/modelica/fmi-standard/issues/1587