### PR TITLE
Improved content description of binaries and resources dirs (#1822)

### DIFF
--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -90,7 +90,7 @@ The header files `fmi3PlatformTypes.h`, `fmi3FunctionTypes.h` and `fmi3Functions
 A binary FMU must contain, for each supported platform, the shared library `<modelIdentifier>.{dll|dylib|so}` and all files which are needed to load this shared library
 in the corresponding platform-specific binary folder.
 To use the binaries of a specific platform, all items in that platform-specific binary folder must be unpacked at the same location as the binary `<modelIdentifier>.{dll|dylib|so}`.
-The FMU importer must unpack these files prior loading the shared library `<modelIdentifier>.{dll|dylib|so}` and these files must stay there until unloading the shared library is finished.
+The FMU importer must unpack these files prior to loading the shared library `<modelIdentifier>.{dll|dylib|so}` and these files must stay there until unloading the shared library is finished.
 
 ====== Platform Tuple Definition [[platform-tupe-definition]]
 
@@ -196,7 +196,7 @@ The requirements and the expected processing must be documented in the `document
 In the optional directory `resources`, additional data can be provided in FMU specific formats, typically for tables and maps used in the FMU.
 More folders can be added under `resources` (tool/model specific).
 For the FMU to access these resource files, the resources directory shall be available in extracted form and the absolute path to this directory is provided via argument <<resourcePath>> of <<fmi3Instantiate>>.
-The `resources` directory must be available for the lifetime of the FMU instance, prior calling <<fmi3Instantiate>> and until <<fmi3FreeInstance>> has finished.
+The `resources` directory must be available for the lifetime of the FMU instance, from before calling <<fmi3Instantiate>> and until after <<fmi3FreeInstance>> has finished.
 The FMU instance must not write to or delete the directory or parts of it.
 
 ===== Directory `extra` [[extra-directory]]

--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -50,13 +50,16 @@ sources                             // directory containing the C sources (optio
 binaries                            // directory containing the binaries (optional)
    x86_64-windows                   // binaries for Windows on Intel 64-bit
       <modelIdentifier>.dll         // shared library of the FMI implementation
-      <other DLLs>                  // the DLL can include other DLLs
+      <other files>                 // the shared library may depend on other files
    x86-linux                        // binaries for Linux on Intel 32-bit
       <modelIdentifier>.so          // shared library of the FMI implementation
+      <other files>                 // the shared library may depend on other files
    aarch32-linux                    // binaries for Linux on ARM 32-bit
       <modelIdentifier>.so          // shared library of the FMI implementation
+      <other files>                 // the shared library may depend on other files
    x86_64-darwin                    // binaries for macOS
       <modelIdentifier>.dylib       // shared library of the FMI implementation
+      <other files>                 // the shared library may depend on other files
 resources                           // resources used by the FMU (optional)
 extra                               // Additional (meta-)data of the FMU (optional)
 ----
@@ -84,19 +87,20 @@ The header files `fmi3PlatformTypes.h`, `fmi3FunctionTypes.h` and `fmi3Functions
 
 ===== Directory `binaries` [[binaries-directory]]
 
-A binary FMU must contain the binary files for all supported platforms in this folder.
+A binary FMU must contain, for each supported platform, the shared library `<modelIdentifier>.{dll|dylib|so}` and all files which are needed to load this shared library
+in the corresponding platform-specific binary folder.
 To use the binaries of a specific platform, all items in that platform-specific binary folder must be unpacked at the same location as the binary `<modelIdentifier>.{dll|dylib|so}`.
+The FMU importer must unpack these files prior loading the shared library `<modelIdentifier>.{dll|dylib|so}` and these files must stay there until unloading the shared library is finished.
 
 ====== Platform Tuple Definition [[platform-tupe-definition]]
 
-The names of the binary directories are standardized by the "platform tuple".
+The names of the platform-specific binary directories are standardized by the "platform tuple".
 Further names can be introduced by vendors.
-FMUs should contain all resources that are required to load and execute a shared library, link against a static library, or compile from source.
 Shared libraries should be statically linked against their dependencies _[e.g. the Visual Studio C Runtime on Windows]_.
 `RPATH="$ORIGIN"` should be set when building ELF binaries to allow dynamic loading of dependencies on the target machine.
 All external dependencies must be documented (see <<documentation-directory>>).
 
-The binaries must be placed in the respective `<platformTuple>` directory with the general format `<arch>-<sys>`.
+The binaries must be placed in the respective `<platformTuple>` subdirectory of `binaries` with the general format `<arch>-<sys>`.
 
 Architecture `<arch>`::
 +
@@ -192,7 +196,7 @@ The requirements and the expected processing must be documented in the `document
 In the optional directory `resources`, additional data can be provided in FMU specific formats, typically for tables and maps used in the FMU.
 More folders can be added under `resources` (tool/model specific).
 For the FMU to access these resource files, the resources directory shall be available in extracted form and the absolute path to this directory is provided via argument <<resourcePath>> of <<fmi3Instantiate>>.
-The resources directory must be available for the lifetime of the FMU instance.
+The `resources` directory must be available for the lifetime of the FMU instance, prior calling <<fmi3Instantiate>> and until <<fmi3FreeInstance>> has finished.
 The FMU instance must not write to or delete the directory or parts of it.
 
 ===== Directory `extra` [[extra-directory]]

--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -103,7 +103,7 @@ in the corresponding platform-specific binary folder.
 These binary files may go into an ABI specific subdirectory, see <<platform-tupe-definition>> also for linking instructions.
 For static libraries the `binaries` directory can only contain files needed during link time since, in contrast to shared libraries, it is not possible to determine the file location
 of the static library at load time.
-Hence, the FMU importer is not needed to unpack these files during execution of the FMU.
+Hence, the FMU importer is not required to unpack these files during execution of the FMU.
 
 ====== Platform Tuple Definition [[platform-tupe-definition]]
 

--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -47,7 +47,8 @@ terminalsAndIcons                   // FMU and terminal icons (optional)
                                     // graphical representation
 sources                             // directory containing the C sources (optional)
    buildDescription.xml
-binaries                            // directory containing the binaries (optional)
+binaries                            // directory containing the binaries, shown for
+                                    // shared libraries here only (optional)
    x86_64-windows                   // binaries for Windows on Intel 64-bit
       <modelIdentifier>.dll         // shared library of the FMI implementation
       <other files>                 // the shared library may depend on other files
@@ -87,10 +88,22 @@ The header files `fmi3PlatformTypes.h`, `fmi3FunctionTypes.h` and `fmi3Functions
 
 ===== Directory `binaries` [[binaries-directory]]
 
-A binary FMU must contain, for each supported platform, the shared library `<modelIdentifier>.{dll|dylib|so}` and all files which are needed to load this shared library
+====== FMUs with shared libraries [[binaries-directory-shared]]
+
+A shared library binary FMU must contain, for each supported platform, the shared library `<modelIdentifier>.{dll|dylib|so}` and all files which are needed to load this shared library
 in the corresponding platform-specific binary folder.
 To use the binaries of a specific platform, all items in that platform-specific binary folder must be unpacked at the same location as the binary `<modelIdentifier>.{dll|dylib|so}`.
+This is needed since the shared library may search for other files, needed during library load time, relative to its own file location.
 The FMU importer must unpack these files prior to loading the shared library `<modelIdentifier>.{dll|dylib|so}` and these files must stay there until unloading the shared library is finished.
+
+====== FMUs with static libraries [[binaries-directory-static]]
+
+A static library binary FMU must contain, for each supported platform and ABI, the static library `<modelIdentifier>.{a|lib}` and all files which are needed to link with this static library
+in the corresponding platform-specific binary folder.
+These binary files may go into an ABI specific subdirectory, see <<platform-tupe-definition>> also for linking instructions.
+For static libraries the `binaries` directory can only contain files needed during link time since, in contrast to shared libraries, it is not possible to determine the file location
+of the static library at load time.
+Hence, the FMU importer is not needed to unpack these files during execution of the FMU.
 
 ====== Platform Tuple Definition [[platform-tupe-definition]]
 


### PR DESCRIPTION
Clearly define which files should go the binaries and resources dir of the FMU which when these dirs must be unpacked by the FMU importer.