### PR TITLE
Define default variability

### DIFF
--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -999,6 +999,7 @@ During <<IntermediateUpdateMode>>, <<discrete>> variables are not allowed to cha
 
 The <<variability>> of <<Clock,Clocks>> must be <<discrete>>.
 The <<variability>> of <<clocked-variable,`clocked variables`>> must be <<discrete>> or <<tunable>>.
+The default for variables of type other than `<Float32>` or `<Float64>` is <<discrete>>.
 
 [[continuous,`continuous`]]
 `= continuous`: Only variables of type `<Float32>` or `<Float64>` may be <<continuous>>.

--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -983,6 +983,7 @@ Values of this enumeration are:
 
 [[fixed,`fixed`]]
 `= fixed`: The value of the variable is fixed in super state <<Initialized>>, in other words, after <<fmi3ExitInitializationMode>> was called the variable value does not change anymore.
+The default for variables of causality `parameter`, `structural parameter` or `calculated parameter` is `fixed`.
 
 [[tunable,`tunable`]]
 `= tunable`: The value of the variable is constant between events (ME and CS if <<EventMode>> is supported) and between communication points (CS and SE).
@@ -999,11 +1000,11 @@ During <<IntermediateUpdateMode>>, <<discrete>> variables are not allowed to cha
 
 The <<variability>> of <<Clock,Clocks>> must be <<discrete>>.
 The <<variability>> of <<clocked-variable,`clocked variables`>> must be <<discrete>> or <<tunable>>.
-The default for variables of type other than `<Float32>` or `<Float64>` is <<discrete>>.
+The default for variables of causility `input`, `output` or `local` of type other than `<Float32>` or `<Float64>` is <<discrete>>.
 
 [[continuous,`continuous`]]
 `= continuous`: Only variables of type `<Float32>` or `<Float64>` may be <<continuous>>.
-The default for variables of type `<Float32>` and `<Float64>` is <<continuous>>.
+The default for variables of type `<Float32>` and `<Float64>` and causality other than `parameter`, `structural parameter` or `calculated parameter` is <<continuous>>.
 Variables with <<variability>> `continuous` may change in <<InitializationMode>> and in super state <<Initialized>>.
 
 For more explanations on value changes see <<smoothness>>.


### PR DESCRIPTION
resolves #1835

by deifing default variabiliy as "discrete" for varaibles of type other than float32 or float64