### PR TITLE
Fix missing content in XML schema for enums

### DIFF
--- a/schema/fmi3Variable.xsd
+++ b/schema/fmi3Variable.xsd
@@ -74,17 +74,20 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             </xs:simpleType>
         </xs:attribute>
     </xs:complexType>
+    <xs:group name="fmi3Dimensions">
+        <xs:sequence>
+            <xs:element name="Dimension" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="start" type="xs:unsignedLong"/>
+                    <xs:attribute name="valueReference" type="xs:unsignedInt"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:group>
     <xs:complexType name="fmi3ArrayableVariable" abstract="true">
         <xs:complexContent>
             <xs:extension base="fmi3AbstractVariable">
-                <xs:sequence>
-                    <xs:element name="Dimension" minOccurs="0" maxOccurs="unbounded">
-                        <xs:complexType>
-                            <xs:attribute name="start" type="xs:unsignedLong"/>
-                            <xs:attribute name="valueReference" type="xs:unsignedInt"/>
-                        </xs:complexType>
-                    </xs:element>
-                </xs:sequence>
+                <xs:group ref="fmi3Dimensions"/>
                 <xs:attribute name="intermediateUpdate" type="xs:boolean"/>
                 <xs:attribute name="previous" type="xs:unsignedInt"/>
             </xs:extension>
@@ -107,6 +110,10 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <xs:complexType name="fmi3MandatorilyTypedArrayableVariable" abstract="true">
         <xs:complexContent>
             <xs:restriction base="fmi3TypedArrayableVariable">
+                <xs:sequence>
+                    <xs:element ref="Annotations" minOccurs="0"/>
+                    <xs:group ref="fmi3Dimensions"/>
+                </xs:sequence>
                 <xs:attribute name="declaredType" type="xs:normalizedString" use="required"/>
             </xs:restriction>
         </xs:complexContent>


### PR DESCRIPTION
Fixes #1837, where enumerations had no allowed Annotations and Dimension elements due to the content not being repeated in the restriction for mandatorily typed variables, i.e. enumerations.
