### PR TITLE
Initial proposal for FMI layered standard manifest

### DIFF
--- a/docs/2_6_versioning_layered_standards.adoc
+++ b/docs/2_6_versioning_layered_standards.adoc
@@ -25,3 +25,44 @@ Layered standards can fall into one of three categories:
 * defined/adopted and published by the <<MAP>> FMI project itself, making them FMI project layered standards.
 
 Layered standards that have achieved enough adoption or importance to be included into the base standard could be incorporated into a new minor or major release version of the base standard, making support for this layered standard optional or required for conformance with the newly published release of the FMI standard.
+
+To enable implementations to uniformly detect the presence of a layered standard in an FMU, even if they are not aware of the particular layered standard, adherence by layered standards to the following conventions is recommended:
+
+A layered standard should recommend the presence of an XML file named `fmi-ls-manifest.xml` in the sub-directory of `extra` mandated by the layered standard.
+The root element of this XML file shall have the following attributes in the XML namespace `http://fmi-standard.org/fmi-ls-manifest`:
+
+.`fmi-ls-manifest.xml` root attribute details.
+[[table-schema-fmi-ls-manifest-root-attributes]]
+[cols="1,3",options="header"]
+|====
+|Attribute
+|Description
+
+|`fmi-ls-name`
+|Name, in reverse domain name notation, of the layered standard.
+
+|`fmi-ls-version`
+|Version of the layered standard.
+The use of semantic versioning is highly recommended.
+In case of semantic versioning it is up to the layered standard to define whether only major and minor version are included in the version attribute, or the full version is to be included.
+
+|`fmi-ls-description`
+|String with a brief description of the layered standard that is suitable for display to users.
+|====
+
+Otherwise the content of this XML file can be arbitrary, i.e. the layered standard is free to mandate any root element and other content, as well as any XML namespaces.
+This allows the use of the file for layered standard content, if the layered standard so wishes.
+
+A simple example of a manifest file is shown below:
+
+[source, xml]
+----
+include::examples/fmi_ls_manifest_example.xml[]
+----
+
+A minimal example of a manifest file, for layered standards that have no need for additional content in that file is:
+
+[source, xml]
+----
+include::examples/fmi_ls_manifest_minimal_example.xml[]
+----

--- a/docs/2_6_versioning_layered_standards.adoc
+++ b/docs/2_6_versioning_layered_standards.adoc
@@ -28,7 +28,7 @@ Layered standards that have achieved enough adoption or importance to be include
 
 To enable implementations to uniformly detect the presence of a layered standard in an FMU, even if they are not aware of the particular layered standard, adherence by layered standards to the following conventions is recommended:
 
-A layered standard should recommend the presence of an XML file named `fmi-ls-manifest.xml` in the sub-directory of `extra` mandated by the layered standard.
+A layered standard should require the presence of an XML file named `fmi-ls-manifest.xml` in the sub-directory of `extra` mandated by the layered standard.
 The root element of this XML file shall have the following attributes in the XML namespace `http://fmi-standard.org/fmi-ls-manifest`:
 
 .`fmi-ls-manifest.xml` root attribute details.

--- a/docs/examples/fmi_ls_manifest_example.xml
+++ b/docs/examples/fmi_ls_manifest_example.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MyRootElement 
+  xmlns:fmi-ls="http://fmi-standard.org/fmi-ls-manifest"
+  fmi-ls:fmi-ls-name="org.fmi-standard.demo-ls-name"
+  fmi-ls:fmi-ls-version="1.0"
+  fmi-ls:fmi-ls-description="Demonstration FMI Layered Standard"
+  normal-attribute="foo">
+
+  <DemoElement modelIdentifier="PIDContoller">
+    <InfoSet>
+      <InfoFile name="PIDContoller.inf"/>
+    </InfoSet>
+  </DemoElement>
+
+</MyRootElement>

--- a/docs/examples/fmi_ls_manifest_minimal_example.xml
+++ b/docs/examples/fmi_ls_manifest_minimal_example.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FMILSManifest 
+  xmlns:fmi-ls="http://fmi-standard.org/fmi-ls-manifest"
+  fmi-ls:fmi-ls-name="org.fmi-standard.demo-ls-name"
+  fmi-ls:fmi-ls-version="1.0"
+  fmi-ls:fmi-ls-description="Demonstration FMI Layered Standard">
+</FMILSManifest>


### PR DESCRIPTION
This provides the initial proposal for the FMI layered standard manifest information that is suggested for layered standards to support.

Modifications might be needed to make the whole added part non-normative, and we might want to also provide a schema that allows checking of those attributes.

This is against the 3.0.x branch to ease discussion/merger, backmerge to main can be performed afterwards.