### PR TITLE
Enhance ls manifest description with schema

### DIFF
--- a/docs/2_6_versioning_layered_standards.adoc
+++ b/docs/2_6_versioning_layered_standards.adoc
@@ -67,7 +67,7 @@ A minimal example of a manifest file, for layered standards that have no need fo
 include::examples/fmi_ls_manifest_minimal_example.xml[]
 ----
 
-The standard includes a schema for the attribute definitions and the minimal example element as `fmi3LSManifest.xsd`.
+The standard includes a schema for the attribute definitions and the minimal example element `fmiLayeredStandardManifest` shown above as `fmi3LayeredStandardManifest.xsd`.
 An example schema that describes the simple example of a manifest above is shown below:
 
 [source, xsd]

--- a/docs/2_6_versioning_layered_standards.adoc
+++ b/docs/2_6_versioning_layered_standards.adoc
@@ -66,3 +66,12 @@ A minimal example of a manifest file, for layered standards that have no need fo
 ----
 include::examples/fmi_ls_manifest_minimal_example.xml[]
 ----
+
+The standard includes a schema for the attribute definitions and the minimal example element as `fmi3LSManifest.xsd`.
+An example schema that describes the simple example of a manifest above is shown below:
+
+[source, xsd]
+----
+include::examples/fmi_ls_manifest_example_schema.xsd[]
+----
+

--- a/docs/examples/fmi_ls_manifest_example.xml
+++ b/docs/examples/fmi_ls_manifest_example.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<MyRootElement 
+<MyRootElement
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="fmi_ls_manifest_example_schema.xsd"
   xmlns:fmi-ls="http://fmi-standard.org/fmi-ls-manifest"
   fmi-ls:fmi-ls-name="org.fmi-standard.demo-ls-name"
   fmi-ls:fmi-ls-version="1.0"

--- a/docs/examples/fmi_ls_manifest_example_schema.xsd
+++ b/docs/examples/fmi_ls_manifest_example_schema.xsd
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" elementFormDefault="qualified"
+    vc:minVersion="1.1"
+    xmlns:fmi-ls="http://fmi-standard.org/fmi-ls-manifest">
+
+    <xs:import namespace="http://fmi-standard.org/fmi-ls-manifest" schemaLocation="../../schema/fmi3LSManifest.xsd"/>
+
+    <xs:element name="MyRootElement">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="DemoElement">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="InfoSet">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="InfoFile" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                                <xs:attribute name="name" type="xs:normalizedString"/>
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="modelIdentifier" type="xs:NMTOKEN"/>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+            <xs:attribute ref="fmi-ls:fmi-ls-name" use="required" fixed="org.fmi-standard.demo-ls-name"/>
+            <xs:attribute ref="fmi-ls:fmi-ls-version" use="required" fixed="1.0"/>
+            <xs:attribute ref="fmi-ls:fmi-ls-description" use="required" fixed="Demonstration FMI Layered Standard"/>
+            <xs:attribute name="normal-attribute" type="xs:normalizedString"/>
+        </xs:complexType>
+    </xs:element>    
+</xs:schema>
+

--- a/docs/examples/fmi_ls_manifest_example_schema.xsd
+++ b/docs/examples/fmi_ls_manifest_example_schema.xsd
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" elementFormDefault="qualified"
-    vc:minVersion="1.1"
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
     xmlns:fmi-ls="http://fmi-standard.org/fmi-ls-manifest">
 
-    <xs:import namespace="http://fmi-standard.org/fmi-ls-manifest" schemaLocation="../../schema/fmi3LSManifest.xsd"/>
+    <xs:import namespace="http://fmi-standard.org/fmi-ls-manifest" schemaLocation="../../schema/fmi3LayeredStandardManifest.xsd"/>
 
     <xs:element name="MyRootElement">
         <xs:complexType>

--- a/docs/examples/fmi_ls_manifest_minimal_example.xml
+++ b/docs/examples/fmi_ls_manifest_minimal_example.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FMILSManifest 
+<FMILSManifest
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://fmi-standard.org/fmi-ls-manifest ../../schema/fmi3LSManifest.xsd"
+  xmlns="http://fmi-standard.org/fmi-ls-manifest"
   xmlns:fmi-ls="http://fmi-standard.org/fmi-ls-manifest"
   fmi-ls:fmi-ls-name="org.fmi-standard.demo-ls-name"
   fmi-ls:fmi-ls-version="1.0"
-  fmi-ls:fmi-ls-description="Demonstration FMI Layered Standard">
-</FMILSManifest>
+  fmi-ls:fmi-ls-description="Demonstration FMI Layered Standard"></FMILSManifest>

--- a/docs/examples/fmi_ls_manifest_minimal_example.xml
+++ b/docs/examples/fmi_ls_manifest_minimal_example.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FMILSManifest
+<fmiLayeredStandardManifest
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://fmi-standard.org/fmi-ls-manifest ../../schema/fmi3LSManifest.xsd"
+  xsi:schemaLocation="http://fmi-standard.org/fmi-ls-manifest ../../schema/fmi3LayeredStandardManifest.xsd"
   xmlns="http://fmi-standard.org/fmi-ls-manifest"
   xmlns:fmi-ls="http://fmi-standard.org/fmi-ls-manifest"
   fmi-ls:fmi-ls-name="org.fmi-standard.demo-ls-name"
   fmi-ls:fmi-ls-version="1.0"
-  fmi-ls:fmi-ls-description="Demonstration FMI Layered Standard"></FMILSManifest>
+  fmi-ls:fmi-ls-description="Demonstration FMI Layered Standard"/>

--- a/schema/fmi3LSManifest.xsd
+++ b/schema/fmi3LSManifest.xsd
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified" attributeFormDefault="qualified"
+    xmlns:fmi-ls="http://fmi-standard.org/fmi-ls-manifest"
+    targetNamespace="http://fmi-standard.org/fmi-ls-manifest">
+    <xs:annotation>
+        <xs:documentation>
+Copyright(c) 2023 Modelica Association Project "FMI".
+             All rights reserved.
+
+This file is licensed by the copyright holders under the 2-Clause BSD License
+(https://opensource.org/licenses/BSD-2-Clause):
+
+----------------------------------------------------------------------------
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+----------------------------------------------------------------------------
+        </xs:documentation>
+    </xs:annotation>
+    
+    <xs:attribute name="fmi-ls-name" type="xs:normalizedString">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                This attribute gives the name, in reverse domain name notation,
+                of the layered standard.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="fmi-ls-version" type="xs:normalizedString">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                This attribute gives the version of the layered standard. The use
+                of semantic versioning is highly recommended. In case of semantic
+                versioning it is up to the layered standard to define whether only
+                major and minor version are included in the version attribute,
+                or the full version is to be included.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="fmi-ls-description" type="xs:normalizedString">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                This attribute gives a string with a brief description of the
+                layered standard that is suitable for display to users.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:attribute>
+    
+    <xs:attributeGroup name="AFMILSManifest">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                This attribute group specifies the required root element attributes
+                of the fmi-ls-manifest.xml file in the sub-directory of extra
+                mandated by a layered standard.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute ref="fmi-ls:fmi-ls-name" use="required"/>
+        <xs:attribute ref="fmi-ls:fmi-ls-version" use="required"/>
+        <xs:attribute ref="fmi-ls:fmi-ls-description" use="required"/>
+    </xs:attributeGroup>
+
+    <xs:element name="FMILSManifest">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                This is the default root element to use in a layered standard for the mandated
+                fmi-ls-manifest.xml file, if no other suitable root element definition is provided
+                in the layered standard.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:attributeGroup ref="fmi-ls:AFMILSManifest"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/schema/fmi3LayeredStandardManifest.xsd
+++ b/schema/fmi3LayeredStandardManifest.xsd
@@ -65,7 +65,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         </xs:annotation>
     </xs:attribute>
     
-    <xs:attributeGroup name="AFMILSManifest">
+    <xs:attributeGroup name="ALayeredStandardManifest">
         <xs:annotation>
             <xs:documentation xml:lang="en">
                 This attribute group specifies the required root element attributes
@@ -78,7 +78,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <xs:attribute ref="fmi-ls:fmi-ls-description" use="required"/>
     </xs:attributeGroup>
 
-    <xs:element name="FMILSManifest">
+    <xs:element name="fmiLayeredStandardManifest">
         <xs:annotation>
             <xs:documentation xml:lang="en">
                 This is the default root element to use in a layered standard for the mandated
@@ -87,7 +87,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             </xs:documentation>
         </xs:annotation>
         <xs:complexType>
-            <xs:attributeGroup ref="fmi-ls:AFMILSManifest"/>
+            <xs:attributeGroup ref="fmi-ls:ALayeredStandardManifest"/>
         </xs:complexType>
     </xs:element>
 </xs:schema>


### PR DESCRIPTION
This adds a schema for the manifest attributes and the default minimal manifest, and enhances the examples to showcase that to some extent.