### PR TITLE
Clarify the set of to be implemented functions

### DIFF
--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -4,7 +4,7 @@ An FMU consists of several files, that are stored in a ZIP file with a pre-defin
 The implementation of the FMI C-API may be distributed in source code and/or in binary format.
 The FMU must be distributed with at least one implementation, in other words, either sources or one of the binaries for a particular machine.
 It is also possible to provide the sources and binaries for different target machines together in one ZIP file.
-The FMU must implement the functions for at least one of the interface types.
+The FMU must implement all the functions for at least one of the interface types.
 Especially it is required that all functions that are part of the specified interface type are present, even if they are only needed for optional capabilities that the FMU does not support.
 The behavior of those functions is unspecified, so while calling environments can rely on the functions being present, they cannot rely on any particular behavior for functions only needed for capabilities the FMU does not support.
 Additional functions may be present in the FMU, as for example required by the OS ABI, for layered standards, or future FMI versions.

--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -4,7 +4,7 @@ An FMU consists of several files, that are stored in a ZIP file with a pre-defin
 The implementation of the FMI C-API may be distributed in source code and/or in binary format.
 The FMU must be distributed with at least one implementation, in other words, either sources or one of the binaries for a particular machine.
 It is also possible to provide the sources and binaries for different target machines together in one ZIP file.
-The FMU must implement all common API functions according to <<general-mechanisms>> and the functions for at least one of the interface types.
+The FMU must implement the functions for at least one of the interface types.
 Especially it is required that all functions that are part of the specified interface type are present, even if they are only needed for optional capabilities that the FMU does not support.
 The behavior of those functions is unspecified, so while calling environments can rely on the functions being present, they cannot rely on any particular behavior for functions only needed for capabilities the FMU does not support.
 Additional functions may be present in the FMU, as for example required by the OS ABI, for layered standards, or future FMI versions.


### PR DESCRIPTION
This removes the ambiguous reference to 2.2, which does not clearly define common API, nor is it necessary to state what is to be implemented for one interface type, since by definition this will include the common functionality as well.

Fixes #1866
