### PR TITLE
Fix formatting of table "Predefined kinds of variables" minor

### DIFF
--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -1959,6 +1959,7 @@ The normalized string `variableKind` is used to provide general information abou
 This information defines how the connection of this variable has to be implemented (e.g. Kirchhoff's current law or common signal flow).
 
 The predefined `variableKind` are:
+
 .Predefined kinds of variables.
 [[table-variable-kinds]]
 [cols="1,3",options="header"]


### PR DESCRIPTION
This fixes the formatting of the table heading 

(Currently it is displayed as "The predefined variableKind are: .Predefined kinds of variables", without a table number)
