### PR TITLE
Start of cleanup of wording in terminals section

### DIFF
--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -1743,9 +1743,9 @@ The following <<dependenciesKind>> is only allowed for floating point latexmath:
 
 ==== Terminals and Icons [[fmiTerminalsAndIcons]]
 
-Terminals define semantic groups of variables to ease connecting compatible signals on the system level.
+Terminals define semantic groups of variables to ease connecting compatible variables on the system level.
 This definition adds an additional layer to the interface description of the FMUs.
-It does not change the <<causality>> of the variables (i.e. inputs and outputs), but enables the definition of physical and bus-like  connectors that require special handling on the system level by the importer (e.g. flow variables and bus frames).
+It does not change the <<causality>> of the variables (e.g. inputs will remain inputs, and outputs will remain outputs), but enables the definition of physical and bus-like  connectors that require special handling on the system level by the importer (e.g. flow variables and bus frames).
 Icons define a graphical representation of an FMU and its terminals.
 
 Both features are optional and may be defined in the separate XML file `terminalsAndIcons/terminalsAndIcons.xml`. +
@@ -1862,11 +1862,11 @@ A terminal is:
 
 * a structured interface for connections to other models,
 * intended to be used for signal flow between models, parameter propagation, and compatibility checks of the model configuration, and
-* a sequence of references to variables with connection meta data.
+* a sequence of references to variables with connection and other meta data.
 
 Predefined rules for variable matching in a connection are given in <<table-predefined-matching-rules>>.
 Predefined variable kinds are used to describe how the terminal member variables have to be handled.
-Domain specific connection rules, terminals and their member variables can be provided by other standards.
+Domain specific connection rules, terminals and their member variables can be provided by other standards, including layered standards.
 
 _[Algebraic loops in systems of connected FMUs are not addressed or resolved by the terminals._
 _The FMU standard does not require that the <<causality>> of the terminal member variables in connected terminals match._


### PR DESCRIPTION
This starts the clarification of the terminals section in terms of unclear or misleading wording, especially unintentional narrowing on inputs and outputs as discussed in the design meeting on 2023-06-06