### PR TITLE
put serialization info at one place

### DIFF
--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -289,7 +289,7 @@ The attribute <<causality>> defines the direction of the information flow with r
 Variables, except Clocks, may be scalar or multi-dimensional arrays.
 Clocks must always be scalar.
 
-===== Serialization of Array Variables [[serialization-of_variables]]
+===== Serialization of Array Variables [[serialization-of-variables]]
 
 Array variables in C-API and <<modelDescription.xml>> (i.e. <<start>> attribute) are serialized as row major.
 The order of dimensions is defined as follows:
@@ -355,7 +355,7 @@ include::../headers/fmi3FunctionTypes.h[tags=GetClock]
 
 * `valueReferences` is a vector of `nValueReferences` handles that reference the variables that shall be inquired.
 
-* `values` is a vector consisting of the <<serialization-of_variables,serialized>> values of these variables.
+* `values` is a vector consisting of the <<serialization-of-variables,serialized>> values of these variables.
 
 * `valueSizes` is a vector with the actual sizes of the values for binary variables.
 
@@ -377,7 +377,7 @@ include::../headers/fmi3FunctionTypes.h[tags=SetClock]
 
 * `valueReferences` is a vector of `nValueReferences` handles that reference the variables that shall be set.
 
-* `values` is a vector consisting of the <<serialization-of_variables,serialized>> values of these variables.
+* `values` is a vector consisting of the <<serialization-of-variables,serialized>> values of these variables.
 
 * `valueSizes` is a vector with the actual sizes of the values of binary variables.
 
@@ -1000,7 +1000,7 @@ This function returns the dependency information for a single variable.
 * `elementIndicesOfDependent` must point to a buffer of `size_t` values of size `nDependencies` allocated by the calling environment.
 It is filled in by this function with the element index of the dependent variable that dependency information is provided for.
 The element indices start with 1. Using the element index 0 means all elements of the variable.
-(Note: If an array has more than one dimension the indices are serialized in the same order as defined for values in <<serialization-of_variables>>.)
+(Note: If an array has more than one dimension the indices are serialized in the same order as defined for values in <<serialization-of-variables>>.)
 
 * `independents` must point to a buffer of <<fmi3ValueReference>> values of size `nDependencies` allocated by the calling environment.
 It is filled in by this function with the value reference of the <<independent>> variable that this dependency entry is dependent upon.
@@ -1009,7 +1009,7 @@ It is filled in by this function with the value reference of the <<independent>>
 It is filled in by this function with the element index of the <<independent>> variable that this dependency entry is dependent upon.
 The element indices start with 1.
 Using the element index 0 means all elements of the variable.
-(Note: If an array has more than one dimension the indices are serialized in the same order as defined for values in <<serialization-of_variables>>.)
+(Note: If an array has more than one dimension the indices are serialized in the same order as defined for values in <<serialization-of-variables>>.)
 
 * `dependencyKinds` must point to a buffer of <<dependenciesKind>> values of size `nDependencies` allocated by the calling environment.
 It is filled in by this function with the enumeration value describing the dependency of this dependency entry.
@@ -1167,9 +1167,9 @@ Both functions have the same arguments:
 * `nUnknowns` contains the length of argument `unknowns`.
 * `knowns` contains value references of the knowns.
 * `nKnowns` contains the length of argument `knowns`.
-* `seed` contains the <<serialization-of_variables,serialized>> components of the seed vector.  
+* `seed` contains the <<serialization-of-variables,serialized>> components of the seed vector.  
 * `nSeed` contains the length of `seed`.
-* `sensitivity` contains the <<serialization-of_variables,serialized>> components of the sensitivity vector.
+* `sensitivity` contains the <<serialization-of-variables,serialized>> components of the sensitivity vector.
 * `nSensitivity` contains the length of `sensitivity`.
 
 _[Note that array variables will be serialized, so `nSeed` is only equal to `nKnowns` in the case of directional derivatives (resp., equal to `nUnknowns` in the case of adjoint derivatives) if all value references of `knowns` (resp., `unknowns`) point to scalar variables._

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -333,6 +333,8 @@ _]_
 For this serialization of array variables the sparsity pattern of the array is not taken into account.
 All elements of the array, including structural zeros, are serialized.
 
+In case of API-functions takeing multiple value references, the serialization of the corresponding values consists of the concatenation of the serialized array varibles.
+
 ===== Getting and Setting Variable Values [[get-and-set-variable-values]]
 
 Restrictions for setting and getting of variables with certain types, causalities and variabilities are defined in the state machine and state descriptions (see <<common-state-machine>> for common states, <<state-machine-model-exchange>> for Model Exchange, <<state-machine-co-simulation>> for Co-Simulation, and <<state-machine-scheduled-execution>> for Scheduled Execution).
@@ -354,7 +356,7 @@ include::../headers/fmi3FunctionTypes.h[tags=GetClock]
 
 * `valueReferences` is a vector of `nValueReferences` handles that reference the variables that shall be inquired.
 
-* `values` is a vector consisting of the concatenation of the (serialized in the case of arrays) values of these variables.
+* `values` is a vector consisting of the <<serialization-of_variables,serialized>> values of these variables.
 
 * `valueSizes` is a vector with the actual sizes of the values for binary variables.
 
@@ -376,7 +378,7 @@ include::../headers/fmi3FunctionTypes.h[tags=SetClock]
 
 * `valueReferences` is a vector of `nValueReferences` handles that reference the variables that shall be set.
 
-* `values` is a vector consisting of the concatenation of the (serialized in the case of arrays) values of these variables.
+* `values` is a vector consisting of the <<serialization-of_variables,serialized>> values of these variables.
 
 * `valueSizes` is a vector with the actual sizes of the values of binary variables.
 
@@ -1166,9 +1168,9 @@ Both functions have the same arguments:
 * `nUnknowns` contains the length of argument `unknowns`.
 * `knowns` contains value references of the knowns.
 * `nKnowns` contains the length of argument `knowns`.
-* `seed` contains the components of the seed vector.
+* `seed` contains the <<serialization-of_variables,serialized>> components of the seed vector.  
 * `nSeed` contains the length of `seed`.
-* `sensitivity` contains the components of the sensitivity vector.
+* `sensitivity` contains the <<serialization-of_variables,serialized>> components of the sensitivity vector.
 * `nSensitivity` contains the length of `sensitivity`.
 
 _[Note that array variables will be serialized, so `nSeed` is only equal to `nKnowns` in the case of directional derivatives (resp., equal to `nUnknowns` in the case of adjoint derivatives) if all value references of `knowns` (resp., `unknowns`) point to scalar variables._

--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -332,8 +332,7 @@ _]_
 
 For this serialization of array variables the sparsity pattern of the array is not taken into account.
 All elements of the array, including structural zeros, are serialized.
-
-In case of API-functions taking multiple value references, the serialization of the corresponding values consists of the concatenation of the serialized array variables.
+If an API function takes multiple value references, the serialized variables are concatenated.
 
 ===== Getting and Setting Variable Values [[get-and-set-variable-values]]
 

--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -1362,7 +1362,7 @@ _It is not allowed to change the start values in the <<modelDescription.xml>> fi
 _This could lead to unpredictable behavior of the FMU in different importers, as it is not mandatory to call <<get-and-set-variable-values,`fmi3Set{VariableType}`>> to set <<start>> values during initialization.]_
 
 The <<start>> attribute is either a single value or a list of values.
-The serialization of a multi-dimensional array variable is described in <<serialization-of_variables>>.
+The serialization of a multi-dimensional array variable is described in <<serialization-of-variables>>.
 If only a single value is given for a multi-dimensional array, all values of the multi-dimensional array are equal to this value.
 
 For variables of type `<String>` and `<Binary>`, the start values are not given as a list in the `start` attribute but as a sequence of `<Start>` elements with a `value` attribute.

--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -93,7 +93,7 @@ Set new continuous state values.
 +
 * Argument `continuousStates` contains the new values for each <<state,continuous state>>.
 The order of the `continuousStates` vector must be the same as the ordered list of elements <<ContinuousStateDerivative>> in <<ModelStructure>>.
-Array variables are serialized as defined in <<serialization-of_variables>>.
+Array variables are serialized as defined in <<serialization-of-variables>>.
 This order is also used in the arguments of the following functions: <<fmi3GetNominalsOfContinuousStates>>, <<fmi3GetContinuousStates>>, and <<fmi3GetContinuousStateDerivatives>>.
 +
 * Argument `nContinuousStates` is the size of the `continuousStates` vector.

--- a/docs/4_1_co-simulation_math.adoc
+++ b/docs/4_1_co-simulation_math.adoc
@@ -40,8 +40,8 @@ If multiple derivatives of a variable shall be retrieved, list the value referen
 * `orders` contains the orders of the respective <<derivative>> (1 means the first <<derivative>>, 2 means the second <<derivative>>, ..., 0 is not allowed).
 If multiple derivatives of a variable shall be retrieved, its value reference must occur multiple times in `valueReferences` aligned with the corresponding `orders` array.
 
-* `values` is a vector consisting of the <<serialization-of_variables,serialized>> values of these <<derivative,`derivatives`>:
-The order of the `values` elements is derived from a twofold serialization: the outer level corresponds to the combination of a value reference (e.g., `valueReferences[k]`) and order (e.g., `orders[k]`), and the inner level to the serialization of variables as defined in <<serialization-of_variables>>.
+* `values` is a vector consisting of the <<serialization-of-variables,serialized>> values of these <<derivative,`derivatives`>:
+The order of the `values` elements is derived from a twofold serialization: the outer level corresponds to the combination of a value reference (e.g., `valueReferences[k]`) and order (e.g., `orders[k]`), and the inner level to the serialization of variables as defined in <<serialization-of-variables>>.
 The inner level does not exist for scalar variables.
 
 * `nValues` is the size of the argument `values`.

--- a/docs/4_1_co-simulation_math.adoc
+++ b/docs/4_1_co-simulation_math.adoc
@@ -40,9 +40,7 @@ If multiple derivatives of a variable shall be retrieved, list the value referen
 * `orders` contains the orders of the respective <<derivative>> (1 means the first <<derivative>>, 2 means the second <<derivative>>, ..., 0 is not allowed).
 If multiple derivatives of a variable shall be retrieved, its value reference must occur multiple times in `valueReferences` aligned with the corresponding `orders` array.
 
-* `values` is a vector with the values of the <<derivative,`derivatives`>>.
-The order of the `values` elements is derived from a twofold serialization: the outer level corresponds to the combination of a value reference (e.g., `valueReferences[k]`) and order (e.g., `orders[k]`), and the inner level to the serialization of variables as defined in <<serialization-of_variables>>.
-The inner level does not exist for scalar variables.
+* `values` is a vector consisting of the <<serialization-of_variables,serialized>> values of these <<derivative,`derivatives`>.
 
 * `nValues` is the size of the argument `values`.
 `nValues` only equals `nValueReferences` if all corresponding output variables are scalar variables.

--- a/docs/4_1_co-simulation_math.adoc
+++ b/docs/4_1_co-simulation_math.adoc
@@ -40,7 +40,9 @@ If multiple derivatives of a variable shall be retrieved, list the value referen
 * `orders` contains the orders of the respective <<derivative>> (1 means the first <<derivative>>, 2 means the second <<derivative>>, ..., 0 is not allowed).
 If multiple derivatives of a variable shall be retrieved, its value reference must occur multiple times in `valueReferences` aligned with the corresponding `orders` array.
 
-* `values` is a vector consisting of the <<serialization-of_variables,serialized>> values of these <<derivative,`derivatives`>.
+* `values` is a vector consisting of the <<serialization-of_variables,serialized>> values of these <<derivative,`derivatives`>:
+The order of the `values` elements is derived from a twofold serialization: the outer level corresponds to the combination of a value reference (e.g., `valueReferences[k]`) and order (e.g., `orders[k]`), and the inner level to the serialization of variables as defined in <<serialization-of_variables>>.
+The inner level does not exist for scalar variables.
 
 * `nValues` is the size of the argument `values`.
 `nValues` only equals `nValueReferences` if all corresponding output variables are scalar variables.


### PR DESCRIPTION
As in the comments on the merged PR #1882 there were some remarks on duplicatation of wording, this is an attempt to simplify it by providing all information in the serialization paragraph and referencing it.