### PR TITLE
Add "universal2" to architectures

### DIFF
--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -119,8 +119,8 @@ Architecture `<arch>`::
 |x86_64
 |Intel/AMD x86 64-bit
 
-|universal
-|Binaries for multiple architectures
+|universal2
+|Universal 2 binaries that run on both 64-bit Intel (x86_64) and Apple Silicon (aarch64) Macs
 |====
 
 Operating system `<sys>`::

--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -118,6 +118,9 @@ Architecture `<arch>`::
 
 |x86_64
 |Intel/AMD x86 64-bit
+
+|universal
+|Binaries for multiple architectures
 |====
 
 Operating system `<sys>`::


### PR DESCRIPTION
to support universal binaries on macOS