### PR TITLE
Fixing reference to incorrect table

### DIFF
--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -1589,7 +1589,7 @@ _[Dependencies of individual array elements can be retrieved during runtime usin
 [#figure-schema-ModelStructure]
 image::images/schema/ModelStructure.png[width=90%]
 
-Note that attribute <<dependenciesKind>> for element <<InitialUnknown>> has less enumeration values as <<dependenciesKind>> in the other lists, as detailed in <<table-model-structure-elements>>.
+Note that attribute <<dependenciesKind>> for element <<InitialUnknown>> has less enumeration values as <<dependenciesKind>> in the other lists, as detailed in <<table-output-der-initialUnknown-details>>.
 
 <<ModelStructure>> consists of the elements detailed in <<table-model-structure-elements>> (see also <<figure-schema-ModelStructure>>; the symbols of the mathematical equations describing the dependencies are defined in <<concepts-model-exchange>>):
 
@@ -1678,7 +1678,7 @@ _If an event indicator shall not be exposed, or if event indicators are not stat
 Elements <<Output>>, <<ContinuousStateDerivative>>, <<ClockedState>>, <<InitialUnknown>>, and <<EventIndicator>> have (partially) the following attributes:
 
 .<<Output>>, <<ContinuousStateDerivative>>, <<ClockedState>>, <<InitialUnknown>>, and <<EventIndicator>> attribute details.
-[[table-output-der-initialUknown-details]]
+[[table-output-der-initialUnknown-details]]
 [cols="1,5a", options="header"]
 |====
 |Attribute


### PR DESCRIPTION
The referenced content is found in the attribute details table.