### PR TITLE
Remove duplicate API reference

### DIFF
--- a/docs/3_2_model_exchange_api.adoc
+++ b/docs/3_2_model_exchange_api.adoc
@@ -100,9 +100,6 @@ This order is also used in the arguments of the following functions: <<fmi3GetNo
 +
 _[<<fmi3Discard,`fmi3Status = fmi3Discard`>> should be returned if the FMU rejects any of the state values because they, for example, violate min/max value restrictions.]_
 
-Functions <<get-and-set-variable-values,`fmi3Get{VariableType}`>>::
-Getting variables might trigger <<selective-computation,computations>>.
-
 Function <<fmi3GetContinuousStates>>::
 Returns the current continuous state vector.
 


### PR DESCRIPTION
Checklist

* [x] Used a [personal fork](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo) of the repository to propose changes.

I have noticed a duplicate of an API reference in section 3.2.1 of the specification and thus removed it.
The remaining API reference is lines 81-82 of the changed file if you wish to make sure it was a duplicate.

I did not feel it was necessary to rebuild the specification document as this is a simple edit.