### PR TITLE
Fix the fmi3GetOutputDerivatives description

### DIFF
--- a/docs/4_1_co-simulation_math.adoc
+++ b/docs/4_1_co-simulation_math.adoc
@@ -40,7 +40,7 @@ If multiple derivatives of a variable shall be retrieved, list the value referen
 * `orders` contains the orders of the respective <<derivative>> (1 means the first <<derivative>>, 2 means the second <<derivative>>, ..., 0 is not allowed).
 If multiple derivatives of a variable shall be retrieved, its value reference must occur multiple times in `valueReferences` aligned with the corresponding `orders` array.
 
-* `values` is a vector consisting of the <<serialization-of-variables,serialized>> values of these <<derivative,`derivatives`>:
+* `values` is a vector consisting of the <<serialization-of-variables,serialized>> values of these <<derivative,`derivatives`>>:
 The order of the `values` elements is derived from a twofold serialization: the outer level corresponds to the combination of a value reference (e.g., `valueReferences[k]`) and order (e.g., `orders[k]`), and the inner level to the serialization of variables as defined in <<serialization-of-variables>>.
 The inner level does not exist for scalar variables.
 


### PR DESCRIPTION
The section "4.1.2. Getting Derivatives of Continuous Outputs" describing the fmi3GetOutputDerivatives function is broken due to a missing >. This PR fixes it.