### PR TITLE
Add missing architecture to ZIP file image

### DIFF
--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -49,6 +49,8 @@ terminalsAndIcons                   // FMU and terminal icons (optional)
 sources                             // directory containing the C sources (optional)
    buildDescription.xml
 binaries                            // directory containing the binaries (optional)
+   x86-windows                      // binaries for Windows on Intel 32-bit
+      <modelIdentifier>.so          // shared library of the FMI implementation
    x86_64-windows                   // binaries for Windows on Intel 64-bit
       <modelIdentifier>.dll         // shared library of the FMI implementation
       <other files>                 // other platform dependend files 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Checklist

* [x] Used a [personal fork](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo) of the repository to propose changes.
* [x] [Built the specification](https://github.com/modelica/fmi-standard/blob/master/CONTRIBUTING.adoc#building-the-specification-document).
* [ ] ~~[Re-generated schema figures](https://github.com/modelica/fmi-standard/blob/master/CONTRIBUTING.adoc#changing-the-xsd-schemas).~~ unnecessary
* [ ] [Linted the documents](https://github.com/modelica/fmi-standard/blob/master/CONTRIBUTING.adoc#building-the-specification-document). -> this seems to be a leftover check or the Contributing doc needs updating. I can't seem to find how to do this but I strongly doubt this will fail linting.

The current `Structure of the ZIP file` image is missing the alternative `x86-windows`.