### PR TITLE
Fixed typo in 2.4

### DIFF
--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -1963,7 +1963,7 @@ Therefore, the `memberName` attribute is required for `plug` and `bus` and must 
 The `memberName` is not required for `matchingRule` `sequence`.
 
 The normalized string `variableKind` is used to provide general information about the variable.
-It is strongly recommended to use [[reverse-DNS, reverse domain name notation]] to define a `varianbleKind`.
+It is strongly recommended to use [[reverse-DNS, reverse domain name notation]] to define a `variableKind`.
 This information defines how the connection of this variable has to be implemented (e.g. Kirchhoff's current law or common signal flow).
 
 The predefined `variableKind` are:


### PR DESCRIPTION
Changed "varianbleKind" to "variableKind"