### PR TITLE
Removed trailing comma in fmi3FunctionTypes.h

### DIFF
--- a/headers/fmi3FunctionTypes.h
+++ b/headers/fmi3FunctionTypes.h
@@ -55,7 +55,7 @@ typedef enum {
     fmi3Warning,
     fmi3Discard,
     fmi3Error,
-    fmi3Fatal,
+    fmi3Fatal
 } fmi3Status;
 /* end::Status[] */
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Checklist

* [X] Used a [personal fork](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo) of the repository to propose changes.
* [X] [Built the specification](https://github.com/modelica/fmi-standard/blob/master/CONTRIBUTING.adoc#building-the-specification-document).
* [X] [Re-generated schema figures](https://github.com/modelica/fmi-standard/blob/master/CONTRIBUTING.adoc#changing-the-xsd-schemas).
* [X] [Linted the documents](https://github.com/modelica/fmi-standard/blob/master/CONTRIBUTING.adoc#building-the-specification-document).

Hi!
By removing the trailing comma as highlighted in the changeset, then, the headers compile also as C89.
I am aware that the standard mentions that the headers are C99, however, I noticed that the other enum definitions below in the same file are written without trailing commas and therefore hopefully removing this one wouldn't be an issue.