### PR TITLE
Fix broken link to modelica association projects

### DIFF
--- a/docs/0___preamble.adoc
+++ b/docs/0___preamble.adoc
@@ -1,5 +1,5 @@
 The https://fmi-standard.org/[Functional Mock-up Interface (FMI)] is a free standard that defines a container and an interface to exchange dynamic models using a combination of XML files, binaries and C code, distributed as a ZIP file.
-[[MAP,MAP]]It is supported by https://fmi-standard.org/tools/[more than 200 tools] and maintained as a https://www.modelica.org/projects[Modelica Association Project] (MAP FMI).
+[[MAP,MAP]]It is supported by https://fmi-standard.org/tools/[more than 200 tools] and maintained as a https://www.modelica.org/association[Modelica Association Project] (MAP FMI).
 https://github.com/modelica/fmi-standard/releases[Releases] and https://github.com/modelica/fmi-standard/issues[issues] can be found on https://github.com/modelica/fmi-standard[github.com/modelica/fmi-standard].
 
 {empty} +


### PR DESCRIPTION
Modelica Association Projects are now listed here I guess:
https://modelica.org/association/