### PR TITLE
Add icon theming support

### DIFF
--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -1863,6 +1863,22 @@ This enables high quality rendering and printing in importers.
 The point (`x1`, `y1`) maps to the left lower corner of the PNG image or SVG viewport.
 The point (`x2`, `y2`) maps to the right upper corner of the PNG image or SVG viewport.
 
+====== Icon Theming
+
+To support different user interface themes (e.g., light and dark mode), additional themed icon files may be provided alongside the default icon files.
+Importers should select the appropriate icon file based on their current theme.
+
+The naming convention for themed icon files is:
+
+* `terminalsAndIcons/icon.png` and optionally `terminalsAndIcons/icon.svg` - Default icon (light theme)
+* `terminalsAndIcons/icon-dark.png` and optionally `terminalsAndIcons/icon-dark.svg` - Dark theme variant
+* `terminalsAndIcons/icon-{theme}.png` and optionally `terminalsAndIcons/icon-{theme}.svg` - Custom theme variants
+
+All themed icon variants should use the same coordinate positioning as defined in the `<Icon>` element, as changing layout when switching themes would be undesirable.
+
+_[Importers should check for themed icon files matching their current theme before falling back to the default icon._
+_The default icon file (`icon.png`) should always be provided to ensure backward compatibility with importers that do not support theming.]_
+
 ====== Placement, Extent, and Painting Order of Graphical Items
 
 image::images/GraphicalRepresentation.svg[width=70%, pdfwidth=70%, align="center"]
@@ -2104,6 +2120,19 @@ The PNG file with the extension '.png' has to be provided.
 An additional SVG file with extension '.svg' is optional.
 
 _[Note that this specification is functionally equivalent to looking up image sources from the `terminalsAndIcons` folder of the FMU ZIP archive after dot removal from the path as per section 5.2.4 of RFC 3986.]_
+
+Similar to FMU icons, terminal icons may be provided in multiple theme variants to support different user interface themes.
+The naming convention for themed terminal icon files follows the FMU icon pattern:
+
+* `terminalsAndIcons/{iconBaseName}.png` and optionally `{iconBaseName}.svg` - Default terminal icon (light theme)
+* `terminalsAndIcons/{iconBaseName}-dark.png` and optionally `{iconBaseName}-dark.svg` - Dark theme variant
+* `terminalsAndIcons/{iconBaseName}-{theme}.png` and optionally `{iconBaseName}-{theme}.svg` - Custom theme variants
+
+All themed terminal icon variants should use the same coordinate positioning as defined in the `<TerminalGraphicalRepresentation>` element.
+
+_[Importers should check for themed terminal icon files matching their current theme before falling back to the default icon._
+_The default icon file (with no theme suffix) should always be provided to ensure backward compatibility._
+_Note that theme-specific connection colors cannot be specified in the XML, so the `defaultConnectionColor` applies to all themes.]_
 
 The `defaultConnectionStrokeSize` and `defaultConnectionColor` can be provided to define the intended connection line layout in the importer.
 The stroke size is given relative to the coordinate system extent.

--- a/docs/2_5_fmu_distribution.adoc
+++ b/docs/2_5_fmu_distribution.adoc
@@ -44,6 +44,10 @@ terminalsAndIcons                   // FMU and terminal icons (optional)
    terminalsAndIcons.xml            // description of terminals and icons (optional)
    icon.png                         // image file of icon without terminals (optional)
    icon.svg                         // if existing the icon.png is required (optional)
+   icon-dark.png                    // image file for dark theme (optional)
+   icon-dark.svg                    // if existing the icon-dark.png is required (optional)
+   icon-{theme}.png                 // image file for custom theme icons (optional)
+   icon-{theme}.svg                 // SVG file for custom theme icons (optional)
                                     // all terminal and fmu icons referenced in the
                                     // graphical representation
 sources                             // directory containing the C sources (optional)
@@ -78,6 +82,23 @@ _This will help the users to comply with license conditions when passing source 
 ===== Directory `terminalsAndIcons` [[terminalsAndIcons-directory]]
 
 See <<fmiTerminalsAndIcons>> for a definition of the directory `terminalsAndIcons`.
+
+The `terminalsAndIcons` directory contains the graphical representation metadata and icon image files.
+Icon files may be provided in multiple theme variants to support different user interface themes (e.g., light and dark mode).
+
+The following files may be present:
+
+* `terminalsAndIcons.xml` - XML file defining terminals and graphical representations
+* `icon.png` - FMU icon (required if any icons are provided)
+* `icon.svg` - Optional SVG version of the FMU icon
+* `icon-dark.png` - Optional dark theme variant of the FMU icon
+* `icon-dark.svg` - Optional SVG version of the dark theme icon
+* `icon-{theme}.png` - Optional custom theme variants of the FMU icon
+* `icon-{theme}.svg` - Optional SVG versions of custom theme icons
+* Terminal icon files following the naming convention: `{iconBaseName}.png`, `{iconBaseName}-dark.png`, `{iconBaseName}-{theme}.png`, and their optional `.svg` counterparts, as specified by `iconBaseName` attributes in `terminalsAndIcons.xml`
+
+_[When providing themed icon variants, the default icon file (without theme suffix) must always be provided to ensure backward compatibility with importers that do not support theming._
+_All themed variants should have the same dimensions and positioning as defined in the `terminalsAndIcons.xml` file.]_
 
 ===== Directory `sources` [[sources-directory]]
 


### PR DESCRIPTION
Closes #2061

I added the possibility to add icons and terminal icons in any color themes.

The default icon is assumed to be used on a light theme.
The only other standardized theme is "dark".

This change should be backwards compatible, since the default icon naming has not changed.
Also this should be future proof, since any further theme can be added.

