### PR TITLE
Remove clickable link to fmi-ls-manifest

### DIFF
--- a/docs/2_6_versioning_layered_standards.adoc
+++ b/docs/2_6_versioning_layered_standards.adoc
@@ -29,7 +29,7 @@ Layered standards that have achieved enough adoption or importance to be include
 To enable implementations to uniformly detect the presence of a layered standard in an FMU, even if they are not aware of the particular layered standard, adherence by layered standards to the following conventions is recommended:
 
 A layered standard should require the presence of an XML file named `fmi-ls-manifest.xml` in the sub-directory of `extra` mandated by the layered standard.
-The root element of this XML file shall have the following attributes in the XML namespace `http://fmi-standard.org/fmi-ls-manifest`:
+The root element of this XML file shall have the following attributes in the XML namespace pass:[http://fmi-standard.org/fmi-ls-manifest]:
 
 .`fmi-ls-manifest.xml` root attribute details.
 [[table-schema-fmi-ls-manifest-root-attributes]]


### PR DESCRIPTION
http://fmi-standard.org/fmi-ls-manifest is clickable. Clicking it results in 404 not found.
I guess it should not be clickable.