### PR TITLE
Add independent variable to example model descriptions

### DIFF
--- a/docs/examples/alias_example.xml
+++ b/docs/examples/alias_example.xml
@@ -13,6 +13,7 @@
   </UnitDefinitions>
 <ModelVariables>
    <!-- tag::VariableAliases[] -->
+ <Float64 name="time" valueReference="0" causality="independent" variability="continuous" description="Simulation time"/>
  <Float64 name="engine.torque" valueReference="1" unit="N.m">
    <Alias name="engine.torqueLbfFt" description="Engine torque in pound-foot"
      displayUnit="lbf.ft"/>

--- a/docs/examples/co_simulation.xml
+++ b/docs/examples/co_simulation.xml
@@ -33,6 +33,7 @@
   </TypeDefinitions>
   <DefaultExperiment startTime="0.0" stopTime="3.0" tolerance="0.0001"/>
   <ModelVariables>
+    <Float64 name="time" valueReference="0" causality="independent" variability="continuous" description="Simulation time"/>
     <Float64 name="inertia1.J" valueReference="1073741824"
       description="Moment of load inertia" causality="parameter" variability="fixed"
       declaredType="Modelica.Units.SI.Inertia" start="1"/>

--- a/docs/examples/co_simulation_early_return.xml
+++ b/docs/examples/co_simulation_early_return.xml
@@ -36,6 +36,7 @@
   </TypeDefinitions>
   <DefaultExperiment startTime="0.0" stopTime="3.0" tolerance="0.0001"/>
   <ModelVariables>
+    <Float64 name="time" valueReference="0" causality="independent" variability="continuous" description="Simulation time"/>
     <Float64 name="inertia1.J" valueReference="1073741824"
       description="Moment of load inertia" causality="parameter" variability="fixed"
       declaredType="Modelica.Units.SI.Inertia" start="1"/>

--- a/docs/examples/model_exchange.xml
+++ b/docs/examples/model_exchange.xml
@@ -31,6 +31,7 @@
   </TypeDefinitions>
   <DefaultExperiment startTime="0.0" stopTime="3.0" tolerance="0.0001"/>
   <ModelVariables>
+    <Float64 name="time" valueReference="4" causality="independent" variability="continuous" description="Simulation time"/>
     <Float64 name="inertia1.J" valueReference="1073741824"
       description="Moment of load inertia" causality="parameter" variability="fixed"
       declaredType="Modelica.Units.SI.Inertia" start="1"/>

--- a/docs/examples/scheduled_execution.xml
+++ b/docs/examples/scheduled_execution.xml
@@ -6,6 +6,7 @@
 	</LogCategories>
 	<DefaultExperiment startTime="0" stopTime="6" stepSize="0.001"/>
 	<ModelVariables>
+		<Float64 name="time" valueReference="9" causality="independent" variability="continuous" description="Simulation time"/>
 		<!-- Variables related to input clock 10msClock  -->
 		<Float64 name="AIn1" valueReference="0" causality="input" variability="discrete" clocks="5"
 		start="0"/>

--- a/docs/examples/string_vector_example.xml
+++ b/docs/examples/string_vector_example.xml
@@ -8,6 +8,7 @@
 <CoSimulation modelIdentifier="string_start_values"/>
 <ModelVariables>
 <!-- tag::string_start_values[] -->
+<Float64 name="time" valueReference="0" causality="independent" variability="continuous" description="Simulation time"/>
 <String name="strings" valueReference="1" causality="parameter" variability="tunable">
   <Dimension start="3"/>
   <Start value="First string" />

--- a/docs/examples/structural_parameter_example.xml
+++ b/docs/examples/structural_parameter_example.xml
@@ -8,6 +8,7 @@
 <CoSimulation modelIdentifier="structural_parameter_example"/>
 <ModelVariables>
 <!-- tag::structuralParameter[] -->
+<Float64 name="time" valueReference="0" causality="independent" variability="continuous" description="Simulation time"/>
 <UInt64 name="len" valueReference="100" causality="structuralParameter"
   variability="fixed" start="7"/>
 <Float32 name="V" valueReference="1" causality="parameter" variability="tunable"

--- a/docs/examples/unit_definition.xml
+++ b/docs/examples/unit_definition.xml
@@ -28,6 +28,7 @@
 </UnitDefinitions>
 <!-- end::UnitDefinitions[] -->
 <ModelVariables>
+  <Float64 name="time" valueReference="0" causality="independent" variability="continuous" description="Simulation time"/>
   <Float64 name="u" valueReference= "1"/>
 </ModelVariables>
 <ModelStructure/>

--- a/docs/examples/variable_types.xml
+++ b/docs/examples/variable_types.xml
@@ -4,6 +4,7 @@
   <CoSimulation modelIdentifier="VariableTypes"/>
 
   <ModelVariables>
+    <Float64 name="time" valueReference="0" causality="independent" variability="continuous" description="Simulation time"/>
     <Float32 name="Float32" valueReference="1" initial="exact" start="-INF -3.402823e+38 -1.175494e-38 NaN 1.175494e-38 3.402823e+38 INF">
       <Dimension start="7"/>
     </Float32>


### PR DESCRIPTION
The standard states in 2.4.7.4:

> Exactly one variable of an FMU must be defined as [independent](https://fmi-standard.org/docs/main/#independent).
