### PR TITLE
Add Code Example for Event Mode with Clocks

### DIFF
--- a/docs/4_3_co-simulation_example.adoc
+++ b/docs/4_3_co-simulation_example.adoc
@@ -40,7 +40,7 @@ image::images/cs_event_mode.svg[width=1000]
 
 ==== Event Mode with Clocks
 
-In the following example, the usage of the fmi3XXX functions is sketched for a co-simulation FMU that supports <<EventMode>> (but neither <<early-return,Early Return>> nor <<IntermediateUpdateMode,Intermediate Update>>) and has <<Clock,Clocks>> and <<clocked-variable,clocked variables>> with <<variability>> = <<discrete>>.
+In the following example, the usage of the fmi3XXX functions is sketched for a co-simulation FMU with <<EventMode>> support. It does not include <<early-return,Early Return>> or <<IntermediateUpdateMode,Intermediate Update>> capabilities and considers only <<discrete>> <<clocked-variable,clocked variables>> and their associated <<triggered,triggered Clocks>>.
 
 [source, C]
 ----


### PR DESCRIPTION
Noting that the concept of _Clocks_ is often difficult for newcomers to the FMI standard, and following the discussion in Issue #2079, I believe it is highly valuable to include a clarifying code example. The existing Co‑Simulation examples do not sufficiently cover Clocks, which can make the Event Mode specification hard to fully understand.

This PR introduces:

- A short note pointing out that the current Event Mode example does not consider Clocks.
- A complete Event Mode code example **including Clocks and Clocked Variables**.
To keep the example as accessible as possible, it intentionally does not cover early return or intermediate updates.
- For ease of discussion within this PR, the full example is currently included inline. This can be refactored or moved as needed once we agree on the final content.

Feedback is very welcome.