### PR TITLE
Fix spelling of "adjoint" derivatives

### DIFF
--- a/docs/1___overview.adoc
+++ b/docs/1___overview.adoc
@@ -35,7 +35,7 @@ To allow implementation of more robust and efficient co-simulation algorithms, t
 
 * <<Clock,Clocks and clocked variables>>.
 
-Besides <<directionDerivatives,directional derivatives>>, now <<adjointDerivatives,adjoined derivatives>> of variables can be obtained.
+Besides <<directionDerivatives,directional derivatives>>, now <<adjointDerivatives,adjoint derivatives>> of variables can be obtained.
 
 The newly introduced <<BuildConfiguration>> simplifies the integration of source-code FMUs.
 

--- a/docs/2_4_common_schema.adoc
+++ b/docs/2_4_common_schema.adoc
@@ -1823,7 +1823,7 @@ NOTE: for example, <<parameter,`parameters`>> or initial <<state,states>>
 
 NOTE: The <<independent>> variable should be treated as any other variable when it comes to dependencies.
 As only explicit dependencies are listed it is required that unknowns that depend on the <<independent>> variable have a partial derivative w.r.t this variable that is different from identically zero.
-If the FMU supports <<directionDerivatives,directional derivatives>> or <<adjointDerivatives,adjoined derivatives>> the <<independent>> variable is a valid input to those functions if it is listed, just as any other listed variable.
+If the FMU supports <<directionDerivatives,directional derivatives>> or <<adjointDerivatives,adjoint derivatives>> the <<independent>> variable is a valid input to those functions if it is listed, just as any other listed variable.
 For example, for a mechanical system, if it has the <<independent>> variable listed among the dependencies it is called a rheonomous system, otherwise it is called a scleronomous system.
 
 |`dependenciesKind`


### PR DESCRIPTION
Change "adjoined" to "adjoint"