### PR TITLE
Avoid deprecation warnings on cmake min version

### DIFF
--- a/docs/examples/CMakeLists.txt
+++ b/docs/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 # configuration to build the code examples
 
-cmake_minimum_required (VERSION 3.7)
+cmake_minimum_required (VERSION 3.10)
 
 project (snippets)
 


### PR DESCRIPTION
Avoid deprecation warnings on newer cmake versions by requiring at least 3.10 which is the defacto base for modern cmake semantics going forward.