### PR TITLE
Update Julia Computing/JuliaSim to JuliaHub/Dyad

### DIFF
--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -203,7 +203,7 @@ Special thanks to
 ** dSPACE GmbH with TargetLink, SystemDesk, ConfigurationDesk, and VEOS
 ** ESI Group with SimulationX
 ** ETAS GmbH with COSYM
-** Julia Computing with JuliaSim
+** JuliaHub with Dyad
 ** Maplesoft with MapleSIM
 ** OSMC
 ** PMSF IT Consulting with FMI Bench


### PR DESCRIPTION
## Summary

- Updates the tool vendor listing in the appendix: "Julia Computing with JuliaSim" → "JuliaHub with Dyad"
- Julia Computing has rebranded to JuliaHub, and JuliaSim has been renamed to Dyad

## Changes

- `docs/7___appendix.adoc` line 206: Updated company and product name

🤖 Generated with [Claude Code](https://claude.com/claude-code)