### PR TITLE
Fix notation of time domain

### DIFF
--- a/docs/2_1_common_math.adoc
+++ b/docs/2_1_common_math.adoc
@@ -15,7 +15,7 @@ The real part latexmath:[t_R] of this tuple is the <<independent>> variable of t
 During continuous-time integration the integer part of time latexmath:[t_I = 0].
 latexmath:[t_I] is a counter to enumerate (and therefore distinguish) the events at the same continuous-time instant latexmath:[t_R].
 This time definition is also called "super-dense time" in literature, see, for example, <<LZ07>>.
-An ordering is defined on latexmath:[\mathbb{\textsf{T}}] that leads to the notation in <<table-model-exchange-math-notation>>.
+An ordering is defined on latexmath:[\mathbb{T}] that leads to the notation in <<table-model-exchange-math-notation>>.
 
 .Conventions and notation used for time.
 [#table-model-exchange-math-notation]


### PR DESCRIPTION
The latex formula was changed in the theme update. The notation is now inconsistent.

<img width="737" height="109" alt="image" src="https://github.com/user-attachments/assets/9c73a089-ee2a-41cc-9637-47aaacf1a5ac" />
