### PR TITLE
Fix typo in clocks definition section

### DIFF
--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -617,7 +617,7 @@ Clock variables synchronize events between importer and across FMUs, by
 * communicating exactly which specific event happens (using <<fmi3SetClock>> in <<EventMode>> in ME and CS or <<fmi3ActivateModelPartition>> in SE) and
 * exactly at which time instant, independent from continuous time specified by the arguments of <<fmi3SetTime>> or <<fmi3DoStep>>.
 
-Clocks define <<clocked-variable,model partitions>> effecting only <<clocked-variable,clocked variables>>.
+Clocks define <<clocked-variable,model partitions>> affecting only <<clocked-variable,clocked variables>>.
 
 ===== Clock Types [[fmi3Clock,`fmi3Clock`]]
 


### PR DESCRIPTION
I think it should be "affecting" and not "effecting"
