### PR TITLE
Add missing abbrivations

### DIFF
--- a/docs/7___appendix.adoc
+++ b/docs/7___appendix.adoc
@@ -8,8 +8,17 @@
 |Acronym
 |Meaning
 
+|ABI
+|Application Binary Interface
+
+|ANSI
+|American National Standards Institute
+
 |API
 |Application Programming Interface
+
+|ASCII
+|American Standard Code for Information Interchange
 
 |C-API
 |C-Language Application Programming Interface
@@ -44,17 +53,26 @@
 |FMU
 |Functional Mock-up Unit
 
+|HTML
+|HyperText Markup Language
+
 |IEEE
 |Institute of Electrical and Electronics Engineers
 
 |ISO
 |International Organization for Standardization
 
+|MAP
+|Modelica Association Project
+
 |ME
 |Model Exchange
 
 |ODE
 |Ordinary Differential Equation
+
+|OS
+|Operating System
 
 |SE
 |Scheduled Execution
@@ -65,8 +83,20 @@
 |TLM
 |Transmission Line Modeling
 
+|UML
+|Unified Modeling Language
+
+|UTF
+|Unicode Transformation Format
+
+|vECU
+|Virtual Electronic Control Unit
+
 |XML
 |eXtensible Markup Language
+
+|XSD
+|XML Schema Definition
 
 |ZIP
 |ZIP archive format


### PR DESCRIPTION
Since we changed the glossary, some links are broken. They should be fixed now or be removed.
Also I found some more abbreviations, not listed in the abbreviations table.
I linked all abbreviations in the documentation text (except the very common ones like "FMU" and "FMI").
I linked many references to the glossary (except the very common ones like "importer", etc.).