### PR TITLE
Fix typo in elementIndicesOfIndependents

### DIFF
--- a/docs/2_2_common_mechanisms.adoc
+++ b/docs/2_2_common_mechanisms.adoc
@@ -1289,7 +1289,7 @@ The element indices start with 1. Using the element index 0 means all elements o
 * `independents` must point to a buffer of <<fmi3ValueReference>> values of size `nDependencies` allocated by the calling environment.
 It is filled in by this function with the value reference of the <<independent>> variable that this dependency entry is dependent upon.
 
-* `elementIndicesIndependents` must point to a buffer of `size_t` values of size `nDependencies` allocated by the calling environment.
+* `elementIndicesOfIndependents` must point to a buffer of `size_t` values of size `nDependencies` allocated by the calling environment.
 It is filled in by this function with the element index of the <<independent>> variable that this dependency entry is dependent upon.
 The element indices start with 1.
 Using the element index 0 means all elements of the variable.


### PR DESCRIPTION
should be "elementIndicesOfIndependents" like in the header file.